### PR TITLE
fix: resolve agentId from hook ctx for proper multi-agent scope isolation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -365,14 +365,14 @@ const memoryLanceDBProPlugin = {
 
     // Auto-recall: inject relevant memories before agent starts
     if (config.autoRecall !== false) {
-      api.on("before_agent_start", async (event) => {
+      api.on("before_agent_start", async (event, ctx) => {
         if (!event.prompt || shouldSkipRetrieval(event.prompt)) {
           return;
         }
 
         try {
           // Determine agent ID and accessible scopes
-          const agentId = event.agentId || "main";
+          const agentId = ctx?.agentId || "main";
           const accessibleScopes = scopeManager.getAccessibleScopes(agentId);
 
           const results = await retriever.retrieve({
@@ -409,14 +409,14 @@ const memoryLanceDBProPlugin = {
 
     // Auto-capture: analyze and store important information after agent ends
     if (config.autoCapture !== false) {
-      api.on("agent_end", async (event) => {
+      api.on("agent_end", async (event, ctx) => {
         if (!event.success || !event.messages || event.messages.length === 0) {
           return;
         }
 
         try {
           // Determine agent ID and default scope
-          const agentId = event.agentId || "main";
+          const agentId = ctx?.agentId || "main";
           const defaultScope = scopeManager.getDefaultScope(agentId);
 
           // Extract text content from messages


### PR DESCRIPTION
## Summary

Fix multi-agent scope isolation being completely bypassed due to `agentId` not being resolved from the hook context.

## Problem

The `before_agent_start` and `agent_end` hook handlers only accepted `(event)`, but OpenClaw passes `agentId` in the **second parameter** `ctx` (`PluginHookAgentContext`). Since `event.agentId` is always `undefined`, all agents fallback to `"main"`, making `scopes.agentAccess` configuration ineffective.

## Changes

- Accept `ctx` (2nd param) in `before_agent_start` and `agent_end` handlers
- Use `ctx?.agentId` instead of `event.agentId`

## Verification

Before fix (public agent session):
```
auto-recall agent=main (ctx.agentId=undefined), scopes=["global","agent:main"]
```

After fix:
```
auto-recall agent=public (ctx.agentId=public), scopes=["agent:public"]
```

Fixes #10