### PR TITLE
fix(#15): ghost memories stuck in autoRecall after deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.12
+
+- Fix: ghost memories stuck in autoRecall after deletion (#15). BM25-only results from stale FTS index are now validated via `store.hasId()` before inclusion in fused results. Removed the BM25-only floor score of 0.5 that allowed deleted entries to survive `hardMinScore` filtering.
+- Fix: HEARTBEAT pattern now matches anywhere in the prompt (not just at start), preventing autoRecall from triggering on prefixed HEARTBEAT messages.
+- Add: `autoRecallMinLength` config option to set a custom minimum prompt length for autoRecall (default: 15 chars English, 6 CJK). Prompts shorter than this threshold are skipped.
+- Add: `ping`, `pong`, `test`, `debug` added to skip patterns in adaptive retrieval.
+
 ## 1.0.11
 
 - Change: set `autoRecall` default to `false` to avoid the model echoing injected `<relevant-memories>` blocks.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memory-lancedb-pro",
   "name": "Memory (LanceDB Pro)",
   "description": "Enhanced LanceDB-backed long-term memory with hybrid retrieval, multi-scope isolation, and management CLI",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "kind": "memory",
   "configSchema": {
     "type": "object",
@@ -60,6 +60,13 @@
       "autoRecall": {
         "type": "boolean",
         "default": false
+      },
+      "autoRecallMinLength": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 200,
+        "default": 15,
+        "description": "Minimum prompt length (in characters) to trigger auto-recall. Prompts shorter than this are skipped. Default: 15 for English, 6 for CJK."
       },
       "captureAssistant": {
         "type": "boolean"
@@ -265,6 +272,11 @@
     "autoRecall": {
       "label": "Auto-Recall",
       "help": "Automatically inject relevant memories into context"
+    },
+    "autoRecallMinLength": {
+      "label": "Auto-Recall Min Length",
+      "help": "Minimum prompt length to trigger auto-recall (shorter prompts are skipped). Default: 15 chars for English, 6 for CJK.",
+      "advanced": true
     },
     "captureAssistant": {
       "label": "Capture Assistant Messages",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memory-lancedb-pro",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "OpenClaw enhanced LanceDB memory plugin with hybrid retrieval (Vector + BM25), cross-encoder rerank, multi-scope isolation, and management CLI",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
## Problem

After using `memory_forget` to delete a memory, the deleted entry keeps appearing in `autoRecall` context injection (`<relevant-memories>`), even though `memory_recall` can no longer find it.

## Root Cause

**FTS (BM25) index cache creates ghost entries.** When a memory is deleted from LanceDB, the FTS index may retain stale entries. During `fuseResults()`, BM25-only results (no vector match) received a hardcoded floor score of **0.5**, which exceeded `hardMinScore` (0.35), allowing ghost memories to pass through the entire scoring pipeline and appear in autoRecall.

## Fixes

### 1. Ghost memory elimination (core fix)
- `fuseResults()` now validates BM25-only entries via `store.hasId()` to filter out ghost records from stale FTS index
- Removed the BM25-only floor score of 0.5; uses raw BM25 normalized score instead (double defense)
- `fuseResults()` changed from sync to async to support the hasId check

### 2. HEARTBEAT handling (reported in issue)
- HEARTBEAT regex relaxed from `/^HEARTBEAT/i` to `/HEARTBEAT/i` to handle prefixed formats like `[System] HEARTBEAT`
- Added `ping`, `pong`, `test`, `debug` to skip patterns

### 3. New `autoRecallMinLength` config (feature request from issue)
- New config option: `autoRecallMinLength` (integer, 1-200, default: uses built-in thresholds of 15 for English / 6 for CJK)
- `shouldSkipRetrieval()` now accepts an optional `minLength` parameter
- Added to both `openclaw.plugin.json` schema and UI hints

## Files Changed
- `src/retriever.ts` — Ghost memory fix in `fuseResults()`
- `src/adaptive-retrieval.ts` — HEARTBEAT pattern + minLength param
- `index.ts` — `autoRecallMinLength` config parsing + hook wiring
- `openclaw.plugin.json` — Schema + UI hints for new config
- `package.json` — Version bump to 1.0.12
- `CHANGELOG.md` — Release notes

Closes #15