### PR TITLE
fix: coerce LanceDB BigInt values to Number for Arrow compatibility

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -490,8 +490,8 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
               vector,
               category: (row.category as any) || "other",
               scope: (row.scope as string | undefined) || "global",
-              importance: typeof row.importance === "number" ? row.importance : 0.7,
-              timestamp: typeof row.timestamp === "number" ? row.timestamp : Date.now(),
+              importance: (row.importance != null) ? Number(row.importance) : 0.7,
+              timestamp: (row.timestamp != null) ? Number(row.timestamp) : Date.now(),
               metadata: typeof row.metadata === "string" ? row.metadata : "{}",
             };
 

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -153,9 +153,9 @@ export class MemoryMigrator {
         id: row.id as string,
         text: row.text as string,
         vector: row.vector as number[],
-        importance: row.importance as number,
+        importance: Number(row.importance),
         category: (row.category as LegacyMemoryEntry["category"]) || "other",
-        createdAt: row.createdAt as number,
+        createdAt: Number(row.createdAt),
         scope: row.scope as string | undefined,
       }));
     } catch (error) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -258,7 +258,7 @@ export class MemoryStore {
     const mapped: MemorySearchResult[] = [];
 
     for (const row of results) {
-      const distance = row._distance ?? 0;
+      const distance = Number(row._distance ?? 0);
       const score = 1 / (1 + distance);
 
       if (score < minScore) continue;
@@ -277,8 +277,8 @@ export class MemoryStore {
           vector: row.vector as number[],
           category: row.category as MemoryEntry["category"],
           scope: rowScope,
-          importance: row.importance as number,
-          timestamp: row.timestamp as number,
+          importance: Number(row.importance),
+          timestamp: Number(row.timestamp),
           metadata: (row.metadata as string) || "{}",
         },
         score,
@@ -323,7 +323,8 @@ export class MemoryStore {
         }
 
         // LanceDB FTS _score is raw BM25 (unbounded). Normalize with sigmoid.
-        const rawScore = typeof row._score === "number" ? row._score : 0;
+        // LanceDB may return BigInt for numeric columns; coerce safely.
+        const rawScore = (row._score != null) ? Number(row._score) : 0;
         const normalizedScore = rawScore > 0 ? 1 / (1 + Math.exp(-rawScore / 5)) : 0.5;
 
         mapped.push({
@@ -333,8 +334,8 @@ export class MemoryStore {
             vector: row.vector as number[],
             category: row.category as MemoryEntry["category"],
             scope: rowScope,
-            importance: row.importance as number,
-            timestamp: row.timestamp as number,
+            importance: Number(row.importance),
+            timestamp: Number(row.timestamp),
             metadata: (row.metadata as string) || "{}",
           },
           score: normalizedScore,
@@ -423,8 +424,8 @@ export class MemoryStore {
         vector: [], // Don't include vectors in list results for performance
         category: row.category as MemoryEntry["category"],
         scope: (row.scope as string | undefined) ?? "global",
-        importance: row.importance as number,
-        timestamp: row.timestamp as number,
+        importance: Number(row.importance),
+        timestamp: Number(row.timestamp),
         metadata: (row.metadata as string) || "{}",
       }))
       .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))
@@ -514,8 +515,8 @@ export class MemoryStore {
       vector: updates.vector ?? (Array.from(row.vector as Iterable<number>)),
       category: updates.category ?? (row.category as MemoryEntry["category"]),
       scope: rowScope,
-      importance: updates.importance ?? (row.importance as number),
-      timestamp: row.timestamp as number, // preserve original
+      importance: updates.importance ?? Number(row.importance),
+      timestamp: Number(row.timestamp), // preserve original
       metadata: updates.metadata ?? ((row.metadata as string) || "{}"),
     };
 


### PR DESCRIPTION
## Summary

- LanceDB 0.26+ uses Apache Arrow internally, which returns numeric columns (`timestamp`, `importance`, `_distance`, `_score`) as `BigInt` instead of `Number`
- The existing code uses TypeScript `as number` casts, which only affect compile-time types — at runtime the values remain `BigInt`
- This causes `TypeError: Cannot mix BigInt and other types` when these values are used in arithmetic with `Date.now()` or other `Number` operations (e.g. recency boost, time decay, score normalization)
- `JSON.stringify()` also fails on `BigInt`, breaking the backup function

## Changes

- **`src/store.ts`**: Replace all `row.timestamp as number` / `row.importance as number` with `Number(row.timestamp)` / `Number(row.importance)`. Same for `row._distance` and `row._score`
- **`src/migrate.ts`**: Same fix for `row.createdAt` and `row.importance`
- **`cli.ts`**: Replace `typeof row.x === "number"` guards (which return `false` for BigInt) with `row.x != null` null-checks followed by `Number()` coercion

## Error log (before fix)

```
memory-lancedb-pro: recall failed: TypeError: Cannot mix BigInt and other types, use explicit conversions  (×372)
memory-lancedb-pro: backup failed: TypeError: Cannot convert a BigInt value to a number  (×11)
memory-lancedb-pro: retrieval test failed: Cannot mix BigInt and other types, use explicit conversions  (×12)
```

## Test plan

- [x] Gateway restarts without `memory-lancedb-pro` errors
- [x] Plugin initializes successfully: `initialized successfully (embedding: OK, retrieval: OK, mode: hybrid, FTS: enabled)`
- [x] No BigInt errors in error log after fix


🤖 Generated with [Claude Code](https://claude.com/claude-code)