### PR TITLE
chore: bump openclaw.plugin.json version to 1.0.16

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memory-lancedb-pro",
   "name": "Memory (LanceDB Pro)",
   "description": "Enhanced LanceDB-backed long-term memory with hybrid retrieval, multi-scope isolation, and management CLI",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "kind": "memory",
   "configSchema": {
     "type": "object",


### PR DESCRIPTION
This aligns openclaw.plugin.json version with the current release (v1.0.16) so OpenClaw plugin info shows the correct version.

Change: openclaw.plugin.json: 1.0.13 -> 1.0.16