### PR TITLE
feat: add auto-recall deduplication to prevent redundant memory injection

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -416,6 +416,13 @@ const memoryLanceDBProPlugin = {
 
     const pluginVersion = getPluginVersion();
 
+    // Session-based recall history to prevent redundant injections
+    // Map<sessionId, Map<memoryId, turnIndex>>
+    const recallHistory = new Map<string, Map<string, number>>();
+
+    // Map<sessionId, turnCounter> - manual turn tracking per session
+    const turnCounter = new Map<string, number>();
+
     api.logger.info(
       `memory-lancedb-pro@${pluginVersion}: plugin registered (db: ${resolvedDbPath}, model: ${config.embedding.model || "text-embedding-3-small"})`,
     );
@@ -468,6 +475,11 @@ const memoryLanceDBProPlugin = {
           return;
         }
 
+        // Manually increment turn counter for this session
+        const sessionId = ctx?.sessionId || "default";
+        const currentTurn = (turnCounter.get(sessionId) || 0) + 1;
+        turnCounter.set(sessionId, currentTurn);
+
         try {
           // Determine agent ID and accessible scopes
           const agentId = ctx?.agentId || "main";
@@ -484,7 +496,46 @@ const memoryLanceDBProPlugin = {
             return;
           }
 
-          const memoryContext = results
+          // Filter out redundant memories based on session history
+          const minRepeated = config.autoRecallMinRepeated ?? 0;
+
+          // Only enable dedup logic when minRepeated > 0
+          let finalResults = results;
+
+          if (minRepeated > 0) {
+            const sessionHistory = recallHistory.get(sessionId) || new Map<string, number>();
+            const filteredResults = results.filter((r) => {
+              const lastTurn = sessionHistory.get(r.entry.id) ?? -999;
+              const diff = currentTurn - lastTurn;
+              const isRedundant = diff < minRepeated;
+
+              if (isRedundant) {
+                api.logger.debug?.(
+                  `memory-lancedb-pro: skipping redundant memory ${r.entry.id.slice(0, 8)} (last seen at turn ${lastTurn}, current turn ${currentTurn}, min ${minRepeated})`,
+                );
+              }
+              return !isRedundant;
+            });
+
+            if (filteredResults.length === 0) {
+              if (results.length > 0) {
+                api.logger.info?.(
+                  `memory-lancedb-pro: all ${results.length} memories were filtered out due to redundancy policy`,
+                );
+              }
+              return;
+            }
+
+            // Update history with successfully injected memories
+            for (const r of filteredResults) {
+              sessionHistory.set(r.entry.id, currentTurn);
+            }
+            recallHistory.set(sessionId, sessionHistory);
+
+            finalResults = filteredResults;
+          }
+
+          const memoryContext = finalResults
             .map(
               (r) =>
                 `- [${r.entry.category}:${r.entry.scope}] ${sanitizeForContext(r.entry.text)} (${(r.score * 100).toFixed(0)}%${r.sources?.bm25 ? ", vector+BM25" : ""}${r.sources?.reranked ? "+reranked" : ""})`,
@@ -492,7 +543,7 @@ const memoryLanceDBProPlugin = {
             .join("\n");
 
           api.logger.info?.(
-            `memory-lancedb-pro: injecting ${results.length} memories into context for agent ${agentId}`,
+            `memory-lancedb-pro: injecting ${finalResults.length} memories into context for agent ${agentId}`,
           );
 
           return {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -87,6 +87,13 @@
         "default": 15,
         "description": "Minimum prompt length (in characters) to trigger auto-recall. Prompts shorter than this are skipped. Default: 15 for English, 6 for CJK."
       },
+      "autoRecallMinRepeated": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 100,
+        "default": 0,
+        "description": "Minimum number of turns before the same memory can be recalled again in the same session. Set to 0 to disable deduplication (default behavior: inject all memories)."
+      },
       "captureAssistant": {
         "type": "boolean"
       },
@@ -332,6 +339,11 @@
     "autoRecallMinLength": {
       "label": "Auto-Recall Min Length",
       "help": "Minimum prompt length to trigger auto-recall (shorter prompts are skipped). Default: 15 chars for English, 6 for CJK.",
+      "advanced": true
+    },
+    "autoRecallMinRepeated": {
+      "label": "Auto-Recall Min Repeated",
+      "help": "Minimum number of conversation turns before a specific memory can be re-injected in the same session.",
       "advanced": true
     },
     "captureAssistant": {


### PR DESCRIPTION
## 概要
通常短時間內的對話可能在聊類似的內容，`autoRecall`會一直撈取重複的記憶有點浪費 token。
新增 `autoRecall` 自動檢索消重機制，避免在同一個 session 中重複注入相同的記憶，有效節省 Token 並提升對話效率。

## 變更說明

### 核心功能
- **Session-based 記憶去重**：追蹤每個 session 的記憶檢索歷史，根據配置的 `autoRecallMinRepeated` 閾值，過濾掉在最近 N 個 turns 內已經出現過的記憶。
- **Turn 追蹤器**：新增手動 turn counter 追蹤每個 session 的對話輪次。

### 新增配置項
| 配置項 | 類型 | 範圍 | 預設值 | 說明 |
| :--- | :--- | :--- | :--- | :--- |
| `autoRecallMinRepeated` | integer | 0-100 | 0 | 記憶可被重新注入的最小 turn 間隔。設為 0 即停用消重機制（預設行為：注入所有記憶）。 |

### 技術細節
- 使用 `Map<sessionId, Map<memoryId, turnIndex>>` 追蹤記憶檢索歷史
- 使用 `Map<sessionId, turnCounter>` 追蹤每個 session 的當前 turn
- 過濾邏輯：`currentTurn - lastSeenTurn < minRepeated` → 視為冗餘，跳過注入
- 日誌輸出：記錄被過濾的記憶 ID、最後出現的 turn、當前 turn 等除錯資訊

## 優勢
- ✅ **節省 Token**：避免重複注入相同的記憶，減少上下文浪費
- ✅ **提升效率**：減少不必要的記憶檢索與注入開銷
- ✅ **靈活配置**：可透過 `autoRecallMinRepeated` 調整消重強度（0 = 停用）

## 向後兼容
- `autoRecallMinRepeated` 預設為 0，完全保持原有行為
- 若未配置此項，功能處於停用狀態，不影響現有用戶

## 建議
`autoRecallMinRepeated: 10` 可以預設 5-10，如果不常 compact 的可以設長一點．
