### PR TITLE
fix: remove stray closing brace in parsePluginConfig

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -894,7 +894,6 @@ function parsePluginConfig(value: unknown): PluginConfig {
   if (!apiKey || (Array.isArray(apiKey) && apiKey.length === 0)) {
     throw new Error("embedding.apiKey is required (set directly or via OPENAI_API_KEY env var)");
   }
-  }
 
   return {
     embedding: {


### PR DESCRIPTION
Fixes #39

There was an extra `}` after the `apiKey` validation block in `parsePluginConfig`, causing a syntax error on gateway startup.

Removed the one stray brace. No other changes.