### PR TITLE
fix: fail-open dedup pre-check to avoid blocking memory writes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -625,9 +625,17 @@ const memoryLanceDBProPlugin = {
             const vector = await embedder.embedPassage(text);
 
             // Check for duplicates using raw vector similarity (bypasses importance/recency weighting)
-            const existing = await store.vectorSearch(vector, 1, 0.1, [
-              defaultScope,
-            ]);
+            // Fail-open by design: dedup should not block auto-capture writes.
+            let existing: Awaited<ReturnType<typeof store.vectorSearch>> = [];
+            try {
+              existing = await store.vectorSearch(vector, 1, 0.1, [
+                defaultScope,
+              ]);
+            } catch (err) {
+              api.logger.warn(
+                `memory-lancedb-pro: auto-capture duplicate pre-check failed, continue store: ${String(err)}`,
+              );
+            }
 
             if (existing.length > 0 && existing[0].score > 0.95) {
               continue;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -263,9 +263,17 @@ export function registerMemoryStoreTool(
           const vector = await context.embedder.embedPassage(text);
 
           // Check for duplicates using raw vector similarity (bypasses importance/recency weighting)
-          const existing = await context.store.vectorSearch(vector, 1, 0.1, [
-            targetScope,
-          ]);
+          // Fail-open by design: dedup must never block a legitimate memory write.
+          let existing: Awaited<ReturnType<typeof context.store.vectorSearch>> = [];
+          try {
+            existing = await context.store.vectorSearch(vector, 1, 0.1, [
+              targetScope,
+            ]);
+          } catch (err) {
+            console.warn(
+              `memory-lancedb-pro: duplicate pre-check failed, continue store: ${String(err)}`,
+            );
+          }
 
           if (existing.length > 0 && existing[0].score > 0.98) {
             return {


### PR DESCRIPTION
## Summary
This PR makes duplicate pre-check fail-open in two paths:

1. `memory_store` tool path (`src/tools.ts`)
2. auto-capture path (`index.ts`)

If `vectorSearch(...)` throws during dedup pre-check (e.g. fresh/empty-table edge case), we now:
- log a warning
- continue to store memory instead of failing the write

## Why
Dedup is an optimization and should not block legitimate writes.
Observed in real usage that pre-check exceptions can happen on edge cases, causing memory_store failure.

## Changes
- Wrap dedup pre-check `vectorSearch` in try/catch
- Default `existing = []` on failure (fail-open)
- Keep original duplicate-skip behavior when pre-check succeeds

## Validation
- Ran plugin tests/build locally:
  - `npm run -s test`
  - `npm run -s build`
- Smoke checks passed.

Refs: #30
