### PR TITLE
fix: enhance normalizeQuery to strip OpenClaw v3.2 metadata and timestamps

### DIFF
--- a/src/adaptive-retrieval.ts
+++ b/src/adaptive-retrieval.ts
@@ -46,21 +46,24 @@ const FORCE_RETRIEVE_PATTERNS = [
 function normalizeQuery(query: string): string {
   let s = query.trim();
 
-  // Strip OpenClaw cron wrapper prefix.
-  s = s.replace(/^\[cron:[^\]]+\]\s*/i, "");
-
-  // Strip OpenClaw timestamp prefix [Mon 2026-03-02 04:21 GMT+8].
-  s = s.replace(/^\[[A-Za-z]{3}\s\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}\s[^\]]+\]\s*/, "");
-
-  // Strip OpenClaw injected metadata header used in some transcripts.
-  if (/^Conversation info \(untrusted metadata\):/i.test(s)) {
-    s = s.replace(/^Conversation info \(untrusted metadata\):\s*/i, "");
-    // If there is a blank-line separator, keep only the part after it.
+  // 1. Strip OpenClaw injected metadata header (Conversation info or Sender).
+  if (/^(Conversation info|Sender) \(untrusted metadata\):/i.test(s)) {
+    s = s.replace(/^(Conversation info|Sender) \(untrusted metadata\):\s*/i, "");
+    // If there is a blank-line separator (after JSON block), keep only the part after it.
     const parts = s.split(/\n\s*\n/, 2);
-    if (parts.length === 2) s = parts[1];
+    if (parts.length === 2) {
+      s = parts[1].trim();
+    }
   }
 
-  return s.trim();
+  // 2. Strip OpenClaw cron wrapper prefix.
+  s = s.trim().replace(/^\[cron:[^\]]+\]\s*/i, "");
+
+  // 3. Strip OpenClaw timestamp prefix [Mon 2026-03-02 04:21 GMT+8].
+  s = s.trim().replace(/^\[[A-Za-z]{3}\s\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}\s[^\]]+\]\s*/, "");
+
+  const result = s.trim();
+  return result;
 }
 
 /**


### PR DESCRIPTION
This PR improves the normalizeQuery logic in adaptive-retrieval.ts to correctly handle the message metadata and timestamp formats introduced in recent OpenClaw versions (v3.2+).

Context:
As reported in [openclaw/openclaw#34153](https://github.com/openclaw/openclaw/issues/34153), the WebSocket gateway now injects an untrusted metadata header and a JSON envelope. This "noise" often causes adaptive-retrieval to treat short messages (like ping) as long, unique queries, incorrectly triggering expensive and noisy memory retrievals.

Changes:

- Support for Sender metadata: Added support for stripping the Sender (untrusted metadata): header used in the new versions.
- Improved JSON block stripping: Refined the regex and added .split() logic to isolate the message body from the JSON envelope.
- Robust normalization flow: Added .trim() operations between steps to ensure regex anchors (^) match patterns correctly even when separated by newlines or leading whitespace.
- Optimized Order: Metadata headers (the outermost wrapper) are now stripped before internal timestamps and cron prefixes.

Impact:
Successfully prevents "Auto-Recall" from being triggered by system metadata noise, saving tokens and improving conversation clarity.