### PR TITLE
fix: add Chinese noise filter patterns

### DIFF
--- a/src/noise-filter.ts
+++ b/src/noise-filter.ts
@@ -2,6 +2,8 @@
  * Noise Filter
  * Filters out low-quality memories (meta-questions, agent denials, session boilerplate)
  * Inspired by openclaw-plugin-continuity's noise filtering approach.
+ *
+ * Supports both English and Chinese patterns.
  */
 
 // Agent-side denial patterns
@@ -14,6 +16,15 @@ const DENIAL_PATTERNS = [
   /i wasn'?t able to find/i,
   /no (relevant )?memories found/i,
   /i don'?t have access to/i,
+  // Chinese denial patterns (agent-side)
+  /我没有(任何)?(相关)?(信息|数据|记忆|记录)/,
+  /我不(太)?确定/,
+  /我不记得/,
+  /我想不起来/,
+  /我没(有)?找到/,
+  /找不到(相关)?记忆/,
+  /没有(相关)?记忆/,
+  /我无法(访问|获取)/,
 ];
 
 // User-side meta-question patterns (about memory itself, not content)
@@ -23,15 +34,48 @@ const META_QUESTION_PATTERNS = [
   /\bdid i (tell|mention|say|share)\b/i,
   /\bhave i (told|mentioned|said)\b/i,
   /\bwhat did i (tell|say|mention)\b/i,
+  // Chinese meta-question patterns (user-side)
+  /你(还)?记得吗/,
+  /你(还)?记不记得/,
+  /你知道.*吗/,
+  /我(有没有|是不是)(说过|提过|告诉|提到)/,
+  /我之前(说过|提过|提到|告诉)/,
+  /我(跟你)?说过.*吗/,
 ];
 
-// Session boilerplate
+// Session boilerplate — safe patterns that won't cause false positives
 const BOILERPLATE_PATTERNS = [
   /^(hi|hello|hey|good morning|good evening|greetings)/i,
   /^fresh session/i,
   /^new session/i,
   /^HEARTBEAT/i,
+  // Chinese boilerplate — anchored to start AND end to prevent false positives
+  // e.g. "你好厉害" should NOT match, but "你好" or "你好！" should
+  /^你好[!！\s,.，。]?$/,
+  /^(早上好|早安|午安|晚上好|晚安)[!！\s,.，。]?$/,
+  /^(嗨|哈[喽啰]|哈[喽啰]呀)[!！\s,.，。]?$/,
+  /^(嗯|哦|噢|呃)[!！\s,.，。]?$/,
+  /^新(会话|对话|聊天)/,
 ];
+
+/**
+ * Short boilerplate patterns — these are prefix patterns that are only
+ * treated as noise when the total text length is short (≤ BOILERPLATE_MAX_LENGTH).
+ *
+ * This prevents false positives on longer messages that happen to start
+ * with acknowledgment words:
+ *   "好的" → noise (2 chars)
+ *   "好的方案是使用Redis做缓存层" → NOT noise (meaningful content after)
+ *   "谢谢你的帮助" → noise (7 chars, still just thanks)
+ *   "谢谢分享，我觉得这个思路很好" → NOT noise (substantive content)
+ */
+const SHORT_BOILERPLATE_PATTERNS = [
+  /^(好的|好吧|行|可以|没问题|OK|ok|收到|明白|了解|知道了)/i,
+  /^(谢谢|感谢|多谢|谢啦|3Q|thx)/i,
+];
+
+/** Max character length for short boilerplate to be considered noise */
+const BOILERPLATE_MAX_LENGTH = 10;
 
 export interface NoiseFilterOptions {
   /** Filter agent denial responses (default: true) */
@@ -60,7 +104,12 @@ export function isNoise(text: string, options: NoiseFilterOptions = {}): boolean
 
   if (opts.filterDenials && DENIAL_PATTERNS.some(p => p.test(trimmed))) return true;
   if (opts.filterMetaQuestions && META_QUESTION_PATTERNS.some(p => p.test(trimmed))) return true;
-  if (opts.filterBoilerplate && BOILERPLATE_PATTERNS.some(p => p.test(trimmed))) return true;
+  if (opts.filterBoilerplate) {
+    if (BOILERPLATE_PATTERNS.some(p => p.test(trimmed))) return true;
+    // Short boilerplate: only filter when text is short enough to be pure filler
+    if (trimmed.length <= BOILERPLATE_MAX_LENGTH &&
+        SHORT_BOILERPLATE_PATTERNS.some(p => p.test(trimmed))) return true;
+  }
 
   return false;
 }

--- a/test/noise-filter-chinese.mjs
+++ b/test/noise-filter-chinese.mjs
@@ -1,0 +1,156 @@
+/**
+ * Test: Chinese noise filter patterns
+ *
+ * Verifies that Chinese greetings, denials, meta-questions, and boilerplate
+ * are correctly identified as noise, while meaningful Chinese content passes through.
+ *
+ * Usage: node test/noise-filter-chinese.mjs
+ */
+
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const { isNoise, filterNoise } = jiti("../src/noise-filter.ts");
+
+// ============================================================================
+// Test cases
+// ============================================================================
+
+const SHOULD_BE_NOISE = [
+  // Chinese denials
+  { text: "我没有相关信息", category: "denial" },
+  { text: "我没有任何相关记录", category: "denial" },
+  { text: "我不确定", category: "denial" },
+  { text: "我不太确定这件事", category: "denial" },
+  { text: "我不记得了", category: "denial" },
+  { text: "我想不起来了", category: "denial" },
+  { text: "我没找到相关内容", category: "denial" },
+  { text: "找不到相关记忆", category: "denial" },
+  { text: "没有相关记忆", category: "denial" },
+
+  // Chinese meta-questions
+  { text: "你还记得吗", category: "meta-question" },
+  { text: "你记得吗？", category: "meta-question" },
+  { text: "你记不记得上次说的", category: "meta-question" },
+  { text: "我有没有说过这件事", category: "meta-question" },
+  { text: "我之前提到过什么", category: "meta-question" },
+  { text: "我是不是告诉过你", category: "meta-question" },
+  { text: "我跟你说过这个吗", category: "meta-question" },
+
+  // Chinese boilerplate
+  { text: "你好", category: "boilerplate" },
+  { text: "早上好", category: "boilerplate" },
+  { text: "晚上好！", category: "boilerplate" },
+  { text: "早安", category: "boilerplate" },
+  { text: "晚安", category: "boilerplate" },
+  { text: "哈喽", category: "boilerplate" },
+  { text: "好的", category: "boilerplate" },
+  { text: "行", category: "boilerplate" },  // length < 5, caught by min-length
+  { text: "可以", category: "boilerplate" }, // length < 5, caught by min-length
+  { text: "没问题", category: "boilerplate" },
+  { text: "收到", category: "boilerplate" }, // length < 5, caught by min-length
+  { text: "谢谢", category: "boilerplate" }, // length < 5, caught by min-length
+  { text: "谢谢你的帮助", category: "boilerplate" },
+  { text: "好吧我知道了", category: "boilerplate" },
+  { text: "OK", category: "boilerplate" },   // length < 5, caught by min-length
+  { text: "明白了", category: "boilerplate" },
+  { text: "了解", category: "boilerplate" }, // length < 5, caught by min-length
+  { text: "知道了", category: "boilerplate" },
+  { text: "新会话开始", category: "boilerplate" },
+
+  // English patterns (should still work)
+  { text: "I don't have any information about that", category: "denial" },
+  { text: "hello there", category: "boilerplate" },
+  { text: "do you remember what I said", category: "meta-question" },
+];
+
+const SHOULD_NOT_BE_NOISE = [
+  // Meaningful Chinese content that must NOT be filtered
+  "我的MacBook Pro电池续航大概8小时",
+  "项目部署在阿里云的ECS实例上，用的是2核4G配置",
+  "SDDP算法的Level Bundle方法收敛速度比较慢",
+  "记得明天下午3点开会讨论需求",
+  "API Key是sk-xxx，配置在.env文件里",
+  "你好厉害，这个方案解决了我的问题",  // starts with 你好 but has meaningful content after
+  "好的方案是使用Redis做缓存层",        // starts with 好的 but has meaningful content
+  "谢谢分享，我觉得这个思路很好，可以用在我们的EVRP项目里",
+];
+
+// ============================================================================
+// Run tests
+// ============================================================================
+
+let passed = 0;
+let failed = 0;
+
+console.log("## Chinese Noise Filter Test Results\n");
+
+// Test noise detection
+console.log("### Should be detected as noise\n");
+console.log("| Text | Category | Result |");
+console.log("|------|----------|--------|");
+
+for (const { text, category } of SHOULD_BE_NOISE) {
+  const result = isNoise(text);
+  const status = result ? "✅ filtered" : "❌ MISSED";
+  console.log(`| ${text} | ${category} | ${status} |`);
+  if (result) {
+    passed++;
+  } else {
+    failed++;
+  }
+}
+
+// Test false-positive protection
+console.log("\n### Should NOT be detected as noise\n");
+console.log("| Text | Result |");
+console.log("|------|--------|");
+
+for (const text of SHOULD_NOT_BE_NOISE) {
+  const result = isNoise(text);
+  const status = result ? "❌ FALSE POSITIVE" : "✅ kept";
+  console.log(`| ${text} | ${status} |`);
+  if (!result) {
+    passed++;
+  } else {
+    failed++;
+  }
+}
+
+// Test filterNoise function with mixed content
+console.log("\n### filterNoise() integration test\n");
+
+const mixedItems = [
+  { id: 1, text: "你好" },
+  { id: 2, text: "MacBook Pro电池续航很好" },
+  { id: 3, text: "我不记得了" },
+  { id: 4, text: "SDDP算法收敛速度提升了30%" },
+  { id: 5, text: "好的" },
+  { id: 6, text: "谢谢你的帮助" },
+];
+
+const filtered = filterNoise(mixedItems, (item) => item.text);
+const keptIds = filtered.map((item) => item.id);
+
+console.log(`Input: ${mixedItems.length} items`);
+console.log(`Output: ${filtered.length} items (kept IDs: ${keptIds.join(", ")})`);
+
+assert.ok(keptIds.includes(2), "Should keep: MacBook Pro电池续航很好");
+assert.ok(keptIds.includes(4), "Should keep: SDDP算法收敛速度提升了30%");
+assert.ok(!keptIds.includes(1), "Should filter: 你好");
+assert.ok(!keptIds.includes(3), "Should filter: 我不记得了");
+assert.ok(!keptIds.includes(5), "Should filter: 好的");
+assert.ok(!keptIds.includes(6), "Should filter: 谢谢你的帮助");
+passed += 6;
+
+// Summary
+console.log(`\n### Summary\n`);
+console.log(`Total: ${passed + failed} | Passed: ${passed} | Failed: ${failed}`);
+
+if (failed > 0) {
+  console.error(`\n❌ ${failed} test(s) failed`);
+  process.exit(1);
+} else {
+  console.log(`\n✅ All tests passed`);
+}


### PR DESCRIPTION
Closes #48

## Problem

`noise-filter.ts` only contains English patterns. Chinese greetings (`你好`), denials (`我不记得`), meta-questions (`你还记得吗`), and acknowledgments (`好的`, `谢谢`) pass through unfiltered and get stored as memories — polluting retrieval results over time.

This is especially impactful with `autoCapture` enabled, as every `好的` and `谢谢` becomes a permanent memory entry.

## Solution

Add Chinese patterns to all three filter categories:

| Category | Examples | Count |
|----------|----------|-------|
| Denial | 我不记得, 找不到相关记忆, 我没有相关信息 | 8 patterns |
| Meta-question | 你还记得吗, 我之前提到过, 我有没有说过 | 6 patterns |
| Boilerplate | 你好, 早上好, 好的, 谢谢, 知道了 | 7+2 patterns |

### False-positive prevention

Chinese acknowledgment words (`好的`, `谢谢`) often appear at the start of meaningful sentences:
- `好的方案是使用Redis做缓存层` — should NOT be filtered
- `谢谢分享，我觉得这个思路很好` — should NOT be filtered

Solution: **length-gated `SHORT_BOILERPLATE_PATTERNS`** — prefix matches like `好的`/`谢谢` are only treated as noise when total text length ≤ 10 characters. Short = filler, long = real content.

## Test Results

52/52 tests pass:
- 38 noise cases correctly filtered (9 denial + 7 meta-question + 19 boilerplate + 3 English)
- 8 false-positive guards all pass (meaningful text kept)
- 6 integration test assertions pass

## Changes

- `src/noise-filter.ts` — Add Chinese patterns + `SHORT_BOILERPLATE_PATTERNS` with length gate
- `test/noise-filter-chinese.mjs` — New test: 52 cases covering all categories + false-positive protection

No new dependencies. Existing `npm test` passes.