### PR TITLE
Fix: missing autoRecallMinRepeated config parsing (follow-up to #40)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -39,6 +39,7 @@ interface PluginConfig {
   autoCapture?: boolean;
   autoRecall?: boolean;
   autoRecallMinLength?: number;
+  autoRecallMinRepeated?: number;
   captureAssistant?: boolean;
   retrieval?: {
     mode?: "hybrid" | "vector";
@@ -987,6 +988,7 @@ function parsePluginConfig(value: unknown): PluginConfig {
     // Default OFF: only enable when explicitly set to true.
     autoRecall: cfg.autoRecall === true,
     autoRecallMinLength: parsePositiveInt(cfg.autoRecallMinLength),
+    autoRecallMinRepeated: parsePositiveInt(cfg.autoRecallMinRepeated),
     captureAssistant: cfg.captureAssistant === true,
     retrieval:
       typeof cfg.retrieval === "object" && cfg.retrieval !== null


### PR DESCRIPTION
## 問題說明

PR #40 新增了 autoRecall 去重機制，但漏掉了兩個關鍵設定：

1. `PluginConfig` 介面缺少 `autoRecallMinRepeated?` 定義
2. `parsePluginConfig` 函數缺少 `autoRecallMinRepeated` 解析邏輯

導致 `openclaw.json` 中的 `autoRecallMinRepeated` 配置無法正確讀入，功能失效。

## 修正內容

- 第 42 行：在 `PluginConfig` 介面新增 `autoRecallMinRepeated?: number;`
- 第 991 行：在 `parsePluginConfig` 新增解析邏輯 `autoRecallMinRepeated: parsePositiveInt(cfg.autoRecallMinRepeated),`

## 影響範圍

- 不影響現有功能
- 僅補上配置解析邏輯，讓去重機制能正常運作