### PR TITLE
feat: add optional Markdown mirror (dual-write) for memory entries

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { homedir } from "node:os";
 import { join, dirname, basename } from "node:path";
-import { readFile, readdir, writeFile, mkdir } from "node:fs/promises";
+import { readFile, readdir, writeFile, mkdir, appendFile } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 
 // Import core components
@@ -16,6 +16,7 @@ import { createRetriever, DEFAULT_RETRIEVAL_CONFIG } from "./src/retriever.js";
 import { createScopeManager } from "./src/scopes.js";
 import { createMigrator } from "./src/migrate.js";
 import { registerAllMemoryTools } from "./src/tools.js";
+import type { MdMirrorWriter } from "./src/tools.js";
 import { shouldSkipRetrieval } from "./src/adaptive-retrieval.js";
 import { AccessTracker } from "./src/access-tracker.js";
 import { createMemoryCLI } from "./cli.js";
@@ -67,6 +68,7 @@ interface PluginConfig {
   };
   enableManagementTools?: boolean;
   sessionMemory?: { enabled?: boolean; messageCount?: number };
+  mdMirror?: { enabled?: boolean; dir?: string };
 }
 
 // ============================================================================
@@ -338,6 +340,92 @@ async function findPreviousSessionFile(
 }
 
 // ============================================================================
+// Markdown Mirror (dual-write)
+// ============================================================================
+
+type AgentWorkspaceMap = Record<string, string>;
+
+function resolveAgentWorkspaceMap(api: OpenClawPluginApi): AgentWorkspaceMap {
+  const map: AgentWorkspaceMap = {};
+
+  // Try api.config first (runtime config)
+  const agents = Array.isArray((api as any).config?.agents?.list)
+    ? (api as any).config.agents.list
+    : [];
+
+  for (const agent of agents) {
+    if (agent?.id && typeof agent.workspace === "string") {
+      map[String(agent.id)] = agent.workspace;
+    }
+  }
+
+  // Fallback: read from openclaw.json (respect OPENCLAW_HOME if set)
+  if (Object.keys(map).length === 0) {
+    try {
+      const openclawHome = process.env.OPENCLAW_HOME || join(homedir(), ".openclaw");
+      const configPath = join(openclawHome, "openclaw.json");
+      const raw = readFileSync(configPath, "utf8");
+      const parsed = JSON.parse(raw);
+      const list = parsed?.agents?.list;
+      if (Array.isArray(list)) {
+        for (const agent of list) {
+          if (agent?.id && typeof agent.workspace === "string") {
+            map[String(agent.id)] = agent.workspace;
+          }
+        }
+      }
+    } catch {
+      /* silent */
+    }
+  }
+
+  return map;
+}
+
+function createMdMirrorWriter(
+  api: OpenClawPluginApi,
+  config: PluginConfig,
+): MdMirrorWriter | null {
+  if (config.mdMirror?.enabled !== true) return null;
+
+  const fallbackDir = api.resolvePath(config.mdMirror.dir || "memory-md");
+  const workspaceMap = resolveAgentWorkspaceMap(api);
+
+  if (Object.keys(workspaceMap).length > 0) {
+    api.logger.info(
+      `mdMirror: resolved ${Object.keys(workspaceMap).length} agent workspace(s)`,
+    );
+  } else {
+    api.logger.warn(
+      `mdMirror: no agent workspaces found, writes will use fallback dir: ${fallbackDir}`,
+    );
+  }
+
+  return async (entry, meta) => {
+    try {
+      const ts = new Date(entry.timestamp || Date.now());
+      const dateStr = ts.toISOString().split("T")[0];
+
+      let mirrorDir = fallbackDir;
+      if (meta?.agentId && workspaceMap[meta.agentId]) {
+        mirrorDir = join(workspaceMap[meta.agentId], "memory");
+      }
+
+      const filePath = join(mirrorDir, `${dateStr}.md`);
+      const agentLabel = meta?.agentId ? ` agent=${meta.agentId}` : "";
+      const sourceLabel = meta?.source ? ` source=${meta.source}` : "";
+      const safeText = entry.text.replace(/\n/g, " ").slice(0, 500);
+      const line = `- ${ts.toISOString()} [${entry.category}:${entry.scope}]${agentLabel}${sourceLabel} ${safeText}\n`;
+
+      await mkdir(mirrorDir, { recursive: true });
+      await appendFile(filePath, line, "utf8");
+    } catch (err) {
+      api.logger.warn(`mdMirror: write failed: ${String(err)}`);
+    }
+  };
+}
+
+// ============================================================================
 // Version
 // ============================================================================
 
@@ -428,6 +516,12 @@ const memoryLanceDBProPlugin = {
     );
 
     // ========================================================================
+    // Markdown Mirror
+    // ========================================================================
+
+    const mdMirror = createMdMirrorWriter(api, config);
+
+    // ========================================================================
     // Register Tools
     // ========================================================================
 
@@ -439,6 +533,7 @@ const memoryLanceDBProPlugin = {
         scopeManager,
         embedder,
         agentId: undefined, // Will be determined at runtime from context
+        mdMirror,
       },
       {
         enableManagementTools: config.enableManagementTools,
@@ -641,6 +736,14 @@ const memoryLanceDBProPlugin = {
               scope: defaultScope,
             });
             stored++;
+
+            // Dual-write to Markdown mirror if enabled
+            if (mdMirror) {
+              await mdMirror(
+                { text, category, scope: defaultScope, timestamp: Date.now() },
+                { source: "auto-capture", agentId },
+              );
+            }
           }
 
           if (stored > 0) {
@@ -749,6 +852,14 @@ const memoryLanceDBProPlugin = {
               date: dateStr,
             }),
           });
+
+          // Dual-write to Markdown mirror if enabled
+          if (mdMirror) {
+            await mdMirror(
+              { text: memoryText.replace(/\n/g, " ").slice(0, 500), category: "fact", scope: "global", timestamp: Date.now() },
+              { source: "session-memory" },
+            );
+          }
 
           api.logger.info(
             `session-memory: stored session summary for ${currentSessionId || "unknown"}`,
@@ -999,6 +1110,17 @@ function parsePluginConfig(value: unknown): PluginConfig {
                 .messageCount === "number"
                 ? ((cfg.sessionMemory as Record<string, unknown>)
                     .messageCount as number)
+                : undefined,
+          }
+        : undefined,
+    mdMirror:
+      typeof cfg.mdMirror === "object" && cfg.mdMirror !== null
+        ? {
+            enabled:
+              (cfg.mdMirror as Record<string, unknown>).enabled === true,
+            dir:
+              typeof (cfg.mdMirror as Record<string, unknown>).dir === "string"
+                ? ((cfg.mdMirror as Record<string, unknown>).dir as string)
                 : undefined,
           }
         : undefined,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -270,6 +270,21 @@
             }
           }
         }
+      },
+      "mdMirror": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable dual-write: store memories in both LanceDB and human-readable Markdown files"
+          },
+          "dir": {
+            "type": "string",
+            "description": "Fallback directory for Markdown mirror files when agent workspace is unknown"
+          }
+        }
       }
     },
     "required": [
@@ -447,6 +462,15 @@
     "enableManagementTools": {
       "label": "Management Tools",
       "help": "Enable memory_list and memory_stats tools for debugging and auditing",
+      "advanced": true
+    },
+    "mdMirror.enabled": {
+      "label": "Markdown Mirror",
+      "help": "Write a human-readable Markdown copy alongside LanceDB storage (dual-write mode)"
+    },
+    "mdMirror.dir": {
+      "label": "Mirror Fallback Directory",
+      "help": "Fallback directory when agent workspace mapping is unavailable",
       "advanced": true
     }
   }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -24,12 +24,18 @@ export const MEMORY_CATEGORIES = [
   "other",
 ] as const;
 
+export type MdMirrorWriter = (
+  entry: { text: string; category: string; scope: string; timestamp?: number },
+  meta?: { source?: string; agentId?: string },
+) => Promise<void>;
+
 interface ToolContext {
   retriever: MemoryRetriever;
   store: MemoryStore;
   scopeManager: MemoryScopeManager;
   embedder: Embedder;
   agentId?: string;
+  mdMirror?: MdMirrorWriter | null;
 }
 
 function resolveAgentId(runtimeAgentId: unknown, fallback?: string): string | undefined {
@@ -292,6 +298,14 @@ export function registerMemoryStoreTool(
             category: category as any,
             scope: targetScope,
           });
+
+          // Dual-write to Markdown mirror if enabled
+          if (context.mdMirror) {
+            await context.mdMirror(
+              { text, category: category as string, scope: targetScope, timestamp: entry.timestamp },
+              { source: "memory_store", agentId },
+            );
+          }
 
           return {
             content: [


### PR DESCRIPTION
Summary

  Add an optional mdMirror feature that writes a human-readable Markdown copy of each memory entry alongside the
  LanceDB storage.

  When enabled, every memory write (memory_store, auto-capture, and session-memory) appends a one-line summary to a
  date-stamped .md file. The feature is off by default and controlled by a config toggle.

  How it works

  - Agent workspace routing: reads agents.list from the OpenClaw runtime config (or falls back to
  $OPENCLAW_HOME/openclaw.json) to map each agentId to its workspace directory. Writes go to
  <workspace>/memory/YYYY-MM-DD.md.
  - Fallback directory: when an agent has no workspace mapping, writes go to a configurable fallback path (default:
  memory-md relative to plugin root).
  - Append-only: the MD files are an audit log. memory_update and memory_forget do not modify them — LanceDB remains
  the source of truth.

  Config

  {
    "mdMirror": {
      "enabled": true,
      "dir": "/path/to/fallback"
    }
  }

  Line format

  - 2026-03-05T00:43:31.237Z [preference:global] agent=main source=memory_store The user prefers Vue as frontend
  framework

  Changes

  - index.ts: add resolveAgentWorkspaceMap(), createMdMirrorWriter(), wire mdMirror into auto-capture and
  session-memory hooks, add config parsing
  - src/tools.ts: export MdMirrorWriter type, add mdMirror to ToolContext, call mdMirror after store.store() in
  memory_store tool
  - openclaw.plugin.json: add mdMirror config schema and UI hints

  Test plan

  - Smoke-tested with 15 unit tests (format, truncation, dir routing, file I/O)
  - Integration-tested on live OpenClaw instance with 5 agents (main + 4 sub-agents)
  - Verified scope isolation: each agent's MD writes to its own workspace
  - Verified enabled: false produces no MD files
  - Verified auto-capture and manual memory_store both trigger dual-write

  ---
  概要

  新增可选的 mdMirror 功能：在写入 LanceDB 的同时，将每条记忆以人类可读的 Markdown 格式追加写入到按日期命名的文件中。

  启用后，所有写入路径（手动 memory_store、auto-capture、session-memory）都会向 YYYY-MM-DD.md
  文件追加一行摘要。默认关闭，通过配置开关控制。

  工作原理

  - Agent workspace 路由：从 OpenClaw 运行时配置（或 $OPENCLAW_HOME/openclaw.json）读取 agents.list，将 agentId
  映射到对应的 workspace 目录，写入 <workspace>/memory/YYYY-MM-DD.md
  - Fallback 目录：当 agent 没有 workspace 映射时，写入可配置的 fallback 路径（默认：插件根目录下的 memory-md）
  - 仅追加：MD 文件是审计日志，memory_update 和 memory_forget 不会修改它们，LanceDB 始终是数据源

  改动文件

  - index.ts：新增 resolveAgentWorkspaceMap()、createMdMirrorWriter()，接入 auto-capture 和 session-memory
  hook，增加配置解析
  - src/tools.ts：导出 MdMirrorWriter 类型，ToolContext 新增 mdMirror 字段，memory_store 工具写入后调用 mdMirror
  - openclaw.plugin.json：新增 mdMirror 配置 schema 和 UI hints