### PR TITLE
fix(retrieval): make proj: tag queries exact (BM25-only + mustContain)

### DIFF
--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -280,6 +280,7 @@ function cosineSimilarity(a: number[], b: number[]): number {
 // ============================================================================
 
 export class MemoryRetriever {
+  private static TAG_QUERY_RE = /\bproj:[A-Za-z0-9][A-Za-z0-9._-]{0,63}\b/g;
   private accessTracker: AccessTracker | null = null;
 
   constructor(
@@ -295,6 +296,28 @@ export class MemoryRetriever {
   async retrieve(context: RetrievalContext): Promise<RetrievalResult[]> {
     const { query, limit, scopeFilter, category, source } = context;
     const safeLimit = clampInt(limit, 1, 20);
+
+    // Tag-style queries (e.g. "proj:AIF") should behave like exact filters.
+    // Hybrid vector search tends to introduce semantic false positives for short tokens.
+    const tags = this.extractTagTokens(query);
+    if (tags.length > 0 && this.config.mode !== "vector" && this.store.hasFtsSupport) {
+      const bm25 = await this.bm25OnlyRetrieval(
+        query,
+        safeLimit,
+        scopeFilter,
+        category,
+        tags,
+      );
+      if (bm25.length > 0) {
+        // Record access for reinforcement (manual recall only)
+        if (this.accessTracker && source === "manual") {
+          this.accessTracker.recordAccess(bm25.map((r) => r.entry.id));
+        }
+        return bm25;
+      }
+      // If there are no literal matches, fall back to normal retrieval so
+      // users can still find related wording.
+    }
 
     let results: RetrievalResult[];
     if (this.config.mode === "vector" || !this.store.hasFtsSupport) {
@@ -319,6 +342,64 @@ export class MemoryRetriever {
     }
 
     return results;
+  }
+
+  private extractTagTokens(query: string): string[] {
+    const matches = query.match(MemoryRetriever.TAG_QUERY_RE) || [];
+    const uniq = Array.from(
+      new Set(matches.map((s) => s.trim()).filter(Boolean)),
+    );
+    return uniq.slice(0, 5);
+  }
+
+  private async bm25OnlyRetrieval(
+    query: string,
+    limit: number,
+    scopeFilter?: string[],
+    category?: string,
+    mustContain?: string[],
+  ): Promise<RetrievalResult[]> {
+    const results = await this.store.bm25Search(
+      query,
+      Math.max(limit * 4, 20),
+      scopeFilter,
+    );
+
+    const filteredByCategory = category
+      ? results.filter((r) => r.entry.category === category)
+      : results;
+
+    const required = mustContain || [];
+    const literalFiltered = required.length
+      ? filteredByCategory.filter((r) =>
+          required.every((t) => r.entry.text.includes(t)),
+        )
+      : filteredByCategory;
+
+    const mapped = literalFiltered.map(
+      (result, index) =>
+        ({
+          ...result,
+          sources: {
+            bm25: { score: result.score, rank: index + 1 },
+            fused: { score: result.score },
+          },
+        }) as RetrievalResult,
+    );
+
+    const temporal = this.applyRecencyBoost(mapped);
+    const importance = this.applyImportanceWeight(temporal);
+    const lengthNormalized = this.applyLengthNormalization(importance);
+    const timeDecayed = this.applyTimeDecay(lengthNormalized);
+    const hardFiltered = timeDecayed.filter(
+      (r) => r.score >= this.config.hardMinScore,
+    );
+    const denoised = this.config.filterNoise
+      ? filterNoise(hardFiltered, (r) => r.entry.text)
+      : hardFiltered;
+    const deduplicated = this.applyMMRDiversity(denoised);
+
+    return deduplicated.slice(0, limit);
   }
 
   private async vectorOnlyRetrieval(


### PR DESCRIPTION
## What
When a query contains tag-style tokens like `proj:AIF`, treat it as an exact filter instead of a semantic query:
- Use BM25 (FTS-only) first
- Hard filter results: mustContain all extracted `proj:` tokens
- If no literal matches, fall back to existing hybrid retrieval (to avoid returning nothing)

## Why
Short tokens are prone to semantic false positives in hybrid retrieval because vector search dominates the candidate pool. For project tags, users usually expect exact matching, not related-content recall.

## Scope / Compatibility
- Only affects queries containing `proj:` tokens
- Normal natural-language queries keep the original hybrid path

## Implementation
`src/retriever.ts`:
- Added tag token extraction (`proj:[A-Za-z0-9._-]+`)
- Added `bm25OnlyRetrieval()` helper with mustContain filter
- Hooked in early in `retrieve()`

## Related issue
Fixes: win4r/memory-lancedb-pro#55
