### PR TITLE
feat(reflection): split inherit/derive memories and weight derive focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,16 +194,22 @@ Filters out low-quality content at both auto-capture and tool-store stages:
   - Filename uses high-resolution timestamp + agent/session token (with conflict-safe suffix), for example `HHMMSSmmm-agent-session[-xxxxxx].md`.
 - Store to LanceDB (optional):
   - Controlled by `memoryReflection.storeToLanceDB` (effective only under `sessionStrategy=memoryReflection`).
-  - Only non-fallback reflections are eligible for LanceDB persistence.
-  - Additional similarity dedupe is applied before write (`> 0.97` hit skips storing).
-  - Reflections are stored with category `reflection`, and are displayed as `reflection:<scope>`.
-  - Stored metadata includes reflection execution fields such as `type`, `stage`, `sessionKey`, `sessionId`, `agentId`, `command`, `storedAt`, `invariants[]`, `derived[]`, `usedFallback`, and `errorSignals[]`.
+  - Reflection persistence is split into two category=`reflection` entries:
+    - Inherit entry (`metadata.reflectionKind = "inherit"`, display tag `reflection:Inherit`)
+    - Derive entry (`metadata.reflectionKind = "derive"`, display tag `reflection:Derive`)
+  - Legacy combined reflection rows (only `metadata.invariants[]` + `metadata.derived[]`, without `reflectionKind`) remain readable/injectable with a safe legacy display path (`reflection:<scope>`).
+  - Additional similarity dedupe is applied per split entry before write (`> 0.97` hit skips storing that entry).
+  - New metadata fields explicitly include subtype and decay semantics: `reflectionKind`, `reflectionVersion`, `storedAt`, `invariants[]` or `derived[]`, and for derive entries `decayModel`, `decayMidpointDays`, `decayK`, `deriveBaseWeight`, `deriveQuality`, `deriveSource`.
 - Dedicated agent (optional): run reflection generation with another agent via `memoryReflection.agentId` (e.g. `memory-distiller`)
   - If configured `memoryReflection.agentId` is not found in `cfg.agents.list`, plugin logs a clear warning and falls back to runtime agent id.
   - For embedded runs, the plugin resolves the target agent's primary model ref (`provider/model`) and passes `provider` + `model` explicitly.
-- Inherit: `before_agent_start` injects `<inherited-rules>` from stable reflection invariants.
+- Inherit: `before_agent_start` injects `<inherited-rules>` from Inherit memories (`reflectionKind=inherit`) plus legacy `invariants[]` compatibility rows.
 - Derive: `before_prompt_build` injects `<derived-focus>` and `<error-detected>` blocks.
-  - `<derived-focus>` is sourced only from the latest recent non-fallback reflection and skips placeholder lines.
+  - `<derived-focus>` is sourced only from Derive memories (`reflectionKind=derive`) plus legacy `derived[]` compatibility rows.
+  - Multiple recent derive memories are weighted with logistic decay during reflection loading/injection (not in global retriever scoring):
+    - `weight = 1 / (1 + exp(k * (ageDays - midpointDays)))`
+    - defaults: `midpointDays = 3`, `k = 1.2`
+    - fallback-generated derive rows use lower base weight (`deriveBaseWeight = 0.35`) than normal derive rows (`1.0`)
   - Reflection-derived lines are extracted with `reflect|inherit|derive|change|apply` matching.
 - Error loop: `after_tool_call` captures and deduplicates tool error signatures for reminder/reflection context
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -194,16 +194,22 @@ Query → BM25 FTS ─────┘
   - 文件名为高精度时间戳 + agent/session token（带冲突后缀），例如 `HHMMSSmmm-agent-session[-xxxxxx].md`。
 - 写入 LanceDB（可选）：
   - 由 `memoryReflection.storeToLanceDB` 控制（且仅在 `sessionStrategy=memoryReflection` 下生效）。
-  - 只有非 fallback 反思才会进入 LanceDB 持久化流程。
-  - 写入前会做相似度去重（命中 `> 0.97` 则跳过入库）。
-  - 反思记忆写入时使用分类 `reflection`，展示标签为 `reflection:<scope>`。
-  - 写入的 metadata 会包含反思执行字段，例如 `type`、`stage`、`sessionKey`、`sessionId`、`agentId`、`command`、`storedAt`、`invariants[]`、`derived[]`、`usedFallback`、`errorSignals[]`。
+  - 反思持久化会拆分为两条 category=`reflection` 记录：
+    - Inherit 记录（`metadata.reflectionKind = "inherit"`，展示为 `reflection:Inherit`）
+    - Derive 记录（`metadata.reflectionKind = "derive"`，展示为 `reflection:Derive`）
+  - 旧版合并反思记录（只有 `metadata.invariants[]` + `metadata.derived[]`，没有 `reflectionKind`）会继续兼容读取/注入，并走安全的旧版展示路径（`reflection:<scope>`）。
+  - 写入前会对每条拆分记录做相似度去重（命中 `> 0.97` 时仅跳过该条写入）。
+  - 新版 metadata 会显式写入子类型与衰减语义：`reflectionKind`、`reflectionVersion`、`storedAt`、`invariants[]` 或 `derived[]`；Derive 还包含 `decayModel`、`decayMidpointDays`、`decayK`、`deriveBaseWeight`、`deriveQuality`、`deriveSource`。
 - 独立代理（可选）：通过 `memoryReflection.agentId` 指定用于反思生成的代理（例如 `memory-distiller`）
   - 若配置的 `memoryReflection.agentId` 不在 `cfg.agents.list` 中，插件会明确 `warn` 并回退到当前 runtime agent id。
   - 对 embedded 运行，插件会解析目标代理主模型引用（`provider/model`），并显式传入 `provider` 与 `model`。
-- Inherit：`before_agent_start` 注入 `<inherited-rules>`，来源是稳定的 reflection invariants。
+- Inherit：`before_agent_start` 注入 `<inherited-rules>`，来源仅为 Inherit 记忆（`reflectionKind=inherit`）和旧版兼容记录中的 `invariants[]`。
 - Derive：`before_prompt_build` 注入 `<derived-focus>` 与 `<error-detected>`。
-  - `<derived-focus>` 仅取最近且非 fallback 的反思，并过滤占位行。
+  - `<derived-focus>` 来源仅为 Derive 记忆（`reflectionKind=derive`）和旧版兼容记录中的 `derived[]`。
+  - 反思加载/注入阶段会对多条近期 derive 记忆做 logistic 衰减加权（不会改动全局 retriever 评分）：
+    - `weight = 1 / (1 + exp(k * (ageDays - midpointDays)))`
+    - 默认值：`midpointDays = 3`、`k = 1.2`
+    - fallback 生成的 derive 记录使用更低基础权重（`deriveBaseWeight = 0.35`，普通 derive 为 `1.0`）
   - 派生行提取关键词：`reflect|inherit|derive|change|apply`。
 - 错误闭环：`after_tool_call` 捕获并去重工具错误签名，用于提醒与反思上下文
 

--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,11 @@ import { shouldSkipRetrieval } from "./src/adaptive-retrieval.js";
 import { AccessTracker } from "./src/access-tracker.js";
 import { runWithReflectionTransientRetryOnce } from "./src/reflection-retry.js";
 import { resolveReflectionSessionSearchDirs, stripResetSuffix } from "./src/session-recovery.js";
+import {
+  storeReflectionToLanceDB,
+  loadAgentReflectionSlicesFromEntries,
+  DEFAULT_REFLECTION_DERIVED_MAX_AGE_MS,
+} from "./src/reflection-store.js";
 import { createMemoryCLI } from "./cli.js";
 
 // ============================================================================
@@ -173,7 +178,6 @@ const DEFAULT_REFLECTION_DEDUPE_ERROR_SIGNALS = true;
 const DEFAULT_REFLECTION_SESSION_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_REFLECTION_MAX_TRACKED_SESSIONS = 200;
 const DEFAULT_REFLECTION_ERROR_SCAN_MAX_CHARS = 8_000;
-const DEFAULT_REFLECTION_DERIVED_MAX_AGE_MS = 2 * 60 * 60 * 1000;
 const REFLECTION_FALLBACK_MARKER = "(fallback) Reflection generation failed; storing minimal pointer only.";
 
 type ReflectionErrorSignal = {
@@ -1313,198 +1317,17 @@ const memoryLanceDBProPlugin = {
       return clipped;
     };
 
-    const parseSectionBullets = (markdown: string, heading: string): string[] => {
-      const lines = markdown.split(/\r?\n/);
-      const headingNeedle = `## ${heading}`.toLowerCase();
-      let inSection = false;
-      const collected: string[] = [];
-      for (const raw of lines) {
-        const line = raw.trim();
-        const lower = line.toLowerCase();
-        if (lower.startsWith("## ")) {
-          inSection = lower === headingNeedle;
-          continue;
-        }
-        if (!inSection) continue;
-        if (line.startsWith("- ") || line.startsWith("* ")) {
-          const normalized = line.slice(2).trim();
-          if (normalized) collected.push(normalized);
-        }
-      }
-      return collected;
-    };
-
-    const extractReflectionSlices = (reflectionText: string): { invariants: string[]; derived: string[] } => {
-      const isPlaceholderSlice = (line: string): boolean => {
-        const normalized = line.replace(/\*\*/g, "").trim();
-        if (!normalized) return true;
-        if (/^\(none( captured)?\)$/i.test(normalized)) return true;
-        if (/^(invariants?|reflections?|derived)[:：]$/i.test(normalized)) return true;
-        if (/apply this session'?s deltas next run/i.test(normalized)) return true;
-        if (/apply this session'?s distilled changes next run/i.test(normalized)) return true;
-        if (/investigate why embedded reflection generation failed/i.test(normalized)) return true;
-        return false;
-      };
-      const normalizeSliceLine = (line: string): string =>
-        line
-          .replace(/\*\*/g, "")
-          .replace(/^(invariants?|reflections?|derived)[:：]\s*/i, "")
-          .trim();
-      const cleanSliceLines = (lines: string[]): string[] =>
-        lines
-          .map(normalizeSliceLine)
-          .filter((line) => !isPlaceholderSlice(line));
-      const isInvariantRuleLike = (line: string): boolean =>
-        /^(always|never|when\b|if\b|before\b|after\b|prefer\b|avoid\b|require\b|only\b|do not\b|must\b|should\b)/i.test(line) ||
-        /\b(must|should|never|always|prefer|avoid|required?)\b/i.test(line);
-      const isDerivedDeltaLike = (line: string): boolean =>
-        /^(this run|next run|going forward|follow-up|re-check|retest|verify|confirm|avoid repeating|adjust|change|update|retry|keep|watch)\b/i.test(line) ||
-        /\b(this run|next run|delta|change|adjust|retry|re-check|retest|verify|confirm|avoid repeating|follow-up)\b/i.test(line);
-      const isOpenLoopAction = (line: string): boolean =>
-        /^(investigate|verify|confirm|re-check|retest|update|add|remove|fix|avoid|keep|watch|document)\b/i.test(line);
-
-      const invariantSection = parseSectionBullets(reflectionText, "Invariants");
-      const derivedSection = parseSectionBullets(reflectionText, "Derived");
-      const mergedSection = parseSectionBullets(reflectionText, "Invariants & Reflections");
-
-      const invariantsPrimary = cleanSliceLines(invariantSection).filter(isInvariantRuleLike);
-      const derivedPrimary = cleanSliceLines(derivedSection).filter(isDerivedDeltaLike);
-
-      const invariantLinesLegacy = cleanSliceLines(
-        mergedSection.filter((line) => /invariant|stable|policy|rule/i.test(line))
-      ).filter(isInvariantRuleLike);
-      const reflectionLinesLegacy = cleanSliceLines(
-        mergedSection.filter((line) => /reflect|inherit|derive|change|apply/i.test(line))
-      ).filter(isDerivedDeltaLike);
-      const openLoopLines = cleanSliceLines(parseSectionBullets(reflectionText, "Open loops / next actions"))
-        .filter(isOpenLoopAction)
-        .filter(isDerivedDeltaLike);
-      const durableDecisionLines = cleanSliceLines(parseSectionBullets(reflectionText, "Decisions (durable)"))
-        .filter(isInvariantRuleLike);
-
-      const invariants = invariantsPrimary.length > 0
-        ? invariantsPrimary
-        : (invariantLinesLegacy.length > 0 ? invariantLinesLegacy : durableDecisionLines);
-      const derived = derivedPrimary.length > 0
-        ? derivedPrimary
-        : [...reflectionLinesLegacy, ...openLoopLines];
-      return {
-        invariants: invariants.slice(0, 8),
-        derived: derived.slice(0, 10),
-      };
-    };
-
-    const parseMemoryMetadata = (metadataRaw: string | undefined): Record<string, unknown> => {
-      if (!metadataRaw) return {};
-      try {
-        const parsed = JSON.parse(metadataRaw);
-        return parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : {};
-      } catch {
-        return {};
-      }
-    };
-
-    const storeReflectionToLanceDB = async (params: {
-      reflectionText: string;
-      sessionKey: string;
-      sessionId: string;
-      agentId: string;
-      command: string;
-      scope: string;
-      toolErrorSignals: ReflectionErrorSignal[];
-      runAt: number;
-      usedFallback: boolean;
-    }) => {
-      const slices = extractReflectionSlices(params.reflectionText);
-      const dateYmd = new Date(params.runAt).toISOString().split("T")[0];
-      const payload = [
-        `reflection:${params.scope} · ${dateYmd}`,
-        `Session Reflection (${new Date(params.runAt).toISOString()})`,
-        `Session Key: ${params.sessionKey}`,
-        `Session ID: ${params.sessionId}`,
-        "",
-        "Invariants:",
-        ...(slices.invariants.length > 0 ? slices.invariants.map((x) => `- ${x}`) : ["- (none)"]),
-        "",
-        "Derived:",
-        ...(slices.derived.length > 0 ? slices.derived.map((x) => `- ${x}`) : ["- (none)"]),
-        "",
-        "Reflection:",
-        params.reflectionText.trim(),
-      ].join("\n");
-
-      const vector = await embedder.embedPassage(payload);
-      const existing = await store.vectorSearch(vector, 1, 0.1, [params.scope]);
-      if (existing.length > 0 && existing[0].score > 0.97) {
-        return { stored: false, slices };
-      }
-
-      await store.store({
-        text: payload,
-        vector,
-        category: "reflection",
-        scope: params.scope,
-        importance: 0.75,
-        metadata: JSON.stringify({
-          type: "memory-reflection",
-          stage: "reflect-store",
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-          agentId: params.agentId,
-          command: params.command,
-          storedAt: params.runAt,
-          invariants: slices.invariants,
-          derived: slices.derived,
-          usedFallback: params.usedFallback,
-          errorSignals: params.toolErrorSignals.map((s) => s.signatureHash),
-        }),
-      });
-      return { stored: true, slices };
-    };
-
     const loadAgentReflectionSlices = async (agentId: string, scopeFilter: string[]) => {
       const cacheKey = `${agentId}::${[...scopeFilter].sort().join(",")}`;
       const cached = reflectionByAgentCache.get(cacheKey);
       if (cached && Date.now() - cached.updatedAt < 15_000) return cached;
 
-      const now = Date.now();
       const entries = await store.list(scopeFilter, undefined, 120, 0);
-      const reflections = entries
-        .map((entry) => ({ entry, metadata: parseMemoryMetadata(entry.metadata) }))
-        .filter(({ metadata }) =>
-          metadata.type === "memory-reflection" && (metadata.agentId === agentId || metadata.agentId === "main")
-        )
-        .sort((a, b) => b.entry.timestamp - a.entry.timestamp)
-        .slice(0, 6);
-      const recentReflections = reflections.filter(
-        ({ entry }) => now - entry.timestamp <= DEFAULT_REFLECTION_DERIVED_MAX_AGE_MS
-      );
-
-      const invariants: string[] = [];
-      const derived: string[] = [];
-      for (const { metadata } of recentReflections) {
-        const inv = Array.isArray(metadata.invariants) ? metadata.invariants.map((x) => String(x)) : [];
-        for (const item of inv) {
-          if (item && !invariants.includes(item)) invariants.push(item);
-          if (invariants.length >= 8) break;
-        }
-      }
-
-      // Derived focus should come from the latest recent non-fallback reflection with actual delta lines.
-      const latestForDerived = recentReflections.find(({ metadata }) =>
-        metadata.usedFallback !== true &&
-        Array.isArray(metadata.derived) &&
-        metadata.derived.some((x: unknown) => typeof x === "string" && x.trim().length > 0 && !/^\(none/i.test(x.trim()))
-      );
-      if (latestForDerived) {
-        const der = Array.isArray(latestForDerived.metadata.derived)
-          ? latestForDerived.metadata.derived.map((x) => String(x))
-          : [];
-        for (const item of der) {
-          if (item && !derived.includes(item)) derived.push(item);
-          if (derived.length >= 10) break;
-        }
-      }
+      const { invariants, derived } = loadAgentReflectionSlicesFromEntries({
+        entries,
+        agentId,
+        deriveMaxAgeMs: DEFAULT_REFLECTION_DERIVED_MAX_AGE_MS,
+      });
       const next = { updatedAt: Date.now(), invariants, derived };
       reflectionByAgentCache.set(cacheKey, next);
       return next;
@@ -1968,7 +1791,7 @@ const memoryLanceDBProPlugin = {
               blocks.push(
                 [
                   "<derived-focus>",
-                  "Latest derived execution deltas from reflection memory:",
+                  "Weighted recent derived execution deltas from reflection memory:",
                   ...derivedLines.slice(0, 6).map((line, i) => `${i + 1}. ${line}`),
                   "</derived-focus>",
                 ].join("\n")
@@ -2114,7 +1937,7 @@ const memoryLanceDBProPlugin = {
             throw new Error(`Failed to allocate unique reflection file for ${dateStr} ${timeCompact}`);
           }
 
-          if (reflectionStoreToLanceDB && !reflectionGenerated.usedFallback) {
+          if (reflectionStoreToLanceDB) {
             const stored = await storeReflectionToLanceDB({
               reflectionText,
               sessionKey,
@@ -2125,6 +1948,10 @@ const memoryLanceDBProPlugin = {
               toolErrorSignals,
               runAt: nowTs,
               usedFallback: reflectionGenerated.usedFallback,
+              embedPassage: (text) => embedder.embedPassage(text),
+              vectorSearch: (vector, limit, minScore, scopeFilter) =>
+                store.vectorSearch(vector, limit, minScore, scopeFilter),
+              store: (entry) => store.store(entry),
             });
             if (sessionKey && stored.slices.derived.length > 0) {
               reflectionDerivedBySession.set(sessionKey, {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -564,7 +564,7 @@
     },
     "memoryReflection.storeToLanceDB": {
       "label": "Store Reflection To LanceDB",
-      "help": "Persist reflection artifacts to LanceDB for inheritance/derived injection",
+      "help": "Persist split reflection entries (Inherit/Derive) to LanceDB for inheritance/derived injection with legacy compatibility",
       "advanced": true
     },
     "memoryReflection.injectMode": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "scripts": {
-    "test": "node test/embedder-error-hints.test.mjs && node test/cli-smoke.mjs"
+    "test": "node test/embedder-error-hints.test.mjs && node test/cli-smoke.mjs && node --test test/reflection-storage-evolution.test.mjs test/reflection-display-tags.test.mjs"
   },
   "devDependencies": {
     "commander": "^14.0.0",

--- a/src/reflection-metadata.ts
+++ b/src/reflection-metadata.ts
@@ -1,0 +1,32 @@
+export type ReflectionKind = "inherit" | "derive";
+
+export function parseReflectionMetadata(metadataRaw: string | undefined): Record<string, unknown> {
+  if (!metadataRaw) return {};
+  try {
+    const parsed = JSON.parse(metadataRaw);
+    return parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+export function getReflectionKind(metadata: Record<string, unknown>): ReflectionKind | undefined {
+  const kindRaw = typeof metadata.reflectionKind === "string" ? metadata.reflectionKind.trim().toLowerCase() : "";
+  if (kindRaw === "inherit" || kindRaw === "derive") return kindRaw;
+  return undefined;
+}
+
+export function isReflectionEntry(entry: { category: string; metadata?: string }): boolean {
+  if (entry.category === "reflection") return true;
+  const metadata = parseReflectionMetadata(entry.metadata);
+  return metadata.type === "memory-reflection";
+}
+
+export function getDisplayCategoryTag(entry: { category: string; scope: string; metadata?: string }): string {
+  if (!isReflectionEntry(entry)) return `${entry.category}:${entry.scope}`;
+  const metadata = parseReflectionMetadata(entry.metadata);
+  const kind = getReflectionKind(metadata);
+  if (kind === "inherit") return "reflection:Inherit";
+  if (kind === "derive") return "reflection:Derive";
+  return `reflection:${entry.scope}`;
+}

--- a/src/reflection-slices.ts
+++ b/src/reflection-slices.ts
@@ -1,0 +1,96 @@
+export interface ReflectionSlices {
+  invariants: string[];
+  derived: string[];
+}
+
+function parseSectionBullets(markdown: string, heading: string): string[] {
+  const lines = markdown.split(/\r?\n/);
+  const headingNeedle = `## ${heading}`.toLowerCase();
+  let inSection = false;
+  const collected: string[] = [];
+  for (const raw of lines) {
+    const line = raw.trim();
+    const lower = line.toLowerCase();
+    if (lower.startsWith("## ")) {
+      inSection = lower === headingNeedle;
+      continue;
+    }
+    if (!inSection) continue;
+    if (line.startsWith("- ") || line.startsWith("* ")) {
+      const normalized = line.slice(2).trim();
+      if (normalized) collected.push(normalized);
+    }
+  }
+  return collected;
+}
+
+export function isPlaceholderReflectionSliceLine(line: string): boolean {
+  const normalized = line.replace(/\*\*/g, "").trim();
+  if (!normalized) return true;
+  if (/^\(none( captured)?\)$/i.test(normalized)) return true;
+  if (/^(invariants?|reflections?|derived)[:：]$/i.test(normalized)) return true;
+  if (/apply this session'?s deltas next run/i.test(normalized)) return true;
+  if (/apply this session'?s distilled changes next run/i.test(normalized)) return true;
+  if (/investigate why embedded reflection generation failed/i.test(normalized)) return true;
+  return false;
+}
+
+export function normalizeReflectionSliceLine(line: string): string {
+  return line
+    .replace(/\*\*/g, "")
+    .replace(/^(invariants?|reflections?|derived)[:：]\s*/i, "")
+    .trim();
+}
+
+export function sanitizeReflectionSliceLines(lines: string[]): string[] {
+  return lines
+    .map(normalizeReflectionSliceLine)
+    .filter((line) => !isPlaceholderReflectionSliceLine(line));
+}
+
+function isInvariantRuleLike(line: string): boolean {
+  return /^(always|never|when\b|if\b|before\b|after\b|prefer\b|avoid\b|require\b|only\b|do not\b|must\b|should\b)/i.test(line) ||
+    /\b(must|should|never|always|prefer|avoid|required?)\b/i.test(line);
+}
+
+function isDerivedDeltaLike(line: string): boolean {
+  return /^(this run|next run|going forward|follow-up|re-check|retest|verify|confirm|avoid repeating|adjust|change|update|retry|keep|watch)\b/i.test(line) ||
+    /\b(this run|next run|delta|change|adjust|retry|re-check|retest|verify|confirm|avoid repeating|follow-up)\b/i.test(line);
+}
+
+function isOpenLoopAction(line: string): boolean {
+  return /^(investigate|verify|confirm|re-check|retest|update|add|remove|fix|avoid|keep|watch|document)\b/i.test(line);
+}
+
+export function extractReflectionSlices(reflectionText: string): ReflectionSlices {
+  const invariantSection = parseSectionBullets(reflectionText, "Invariants");
+  const derivedSection = parseSectionBullets(reflectionText, "Derived");
+  const mergedSection = parseSectionBullets(reflectionText, "Invariants & Reflections");
+
+  const invariantsPrimary = sanitizeReflectionSliceLines(invariantSection).filter(isInvariantRuleLike);
+  const derivedPrimary = sanitizeReflectionSliceLines(derivedSection).filter(isDerivedDeltaLike);
+
+  const invariantLinesLegacy = sanitizeReflectionSliceLines(
+    mergedSection.filter((line) => /invariant|stable|policy|rule/i.test(line))
+  ).filter(isInvariantRuleLike);
+  const reflectionLinesLegacy = sanitizeReflectionSliceLines(
+    mergedSection.filter((line) => /reflect|inherit|derive|change|apply/i.test(line))
+  ).filter(isDerivedDeltaLike);
+  const openLoopLines = sanitizeReflectionSliceLines(parseSectionBullets(reflectionText, "Open loops / next actions"))
+    .filter(isOpenLoopAction)
+    .filter(isDerivedDeltaLike);
+  const durableDecisionLines = sanitizeReflectionSliceLines(parseSectionBullets(reflectionText, "Decisions (durable)"))
+    .filter(isInvariantRuleLike);
+
+  const invariants = invariantsPrimary.length > 0
+    ? invariantsPrimary
+    : (invariantLinesLegacy.length > 0 ? invariantLinesLegacy : durableDecisionLines);
+  const derived = derivedPrimary.length > 0
+    ? derivedPrimary
+    : [...reflectionLinesLegacy, ...openLoopLines];
+
+  return {
+    invariants: invariants.slice(0, 8),
+    derived: derived.slice(0, 10),
+  };
+}

--- a/src/reflection-store.ts
+++ b/src/reflection-store.ts
@@ -1,0 +1,282 @@
+import type { MemoryEntry, MemorySearchResult } from "./store.js";
+import { extractReflectionSlices, sanitizeReflectionSliceLines, type ReflectionSlices } from "./reflection-slices.js";
+import { getReflectionKind, parseReflectionMetadata } from "./reflection-metadata.js";
+
+export const REFLECTION_DERIVE_LOGISTIC_MIDPOINT_DAYS = 3;
+export const REFLECTION_DERIVE_LOGISTIC_K = 1.2;
+export const REFLECTION_DERIVE_FALLBACK_BASE_WEIGHT = 0.35;
+export const DEFAULT_REFLECTION_DERIVED_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+
+type ReflectionStoreKind = "inherit" | "derive";
+
+type ReflectionErrorSignalLike = {
+  signatureHash: string;
+};
+
+interface ReflectionStorePayload {
+  text: string;
+  metadata: Record<string, unknown>;
+  kind: ReflectionStoreKind;
+}
+
+interface BuildReflectionStorePayloadsParams {
+  reflectionText: string;
+  sessionKey: string;
+  sessionId: string;
+  agentId: string;
+  command: string;
+  scope: string;
+  toolErrorSignals: ReflectionErrorSignalLike[];
+  runAt: number;
+  usedFallback: boolean;
+}
+
+export function buildReflectionStorePayloads(params: BuildReflectionStorePayloadsParams): {
+  slices: ReflectionSlices;
+  payloads: ReflectionStorePayload[];
+} {
+  const slices = extractReflectionSlices(params.reflectionText);
+  const dateYmd = new Date(params.runAt).toISOString().split("T")[0];
+  const payloads: ReflectionStorePayload[] = [];
+
+  if (slices.invariants.length > 0) {
+    payloads.push({
+      kind: "inherit",
+      text: [
+        `reflection:Inherit · ${params.scope} · ${dateYmd}`,
+        `Session Reflection Inherit (${new Date(params.runAt).toISOString()})`,
+        `Session Key: ${params.sessionKey}`,
+        `Session ID: ${params.sessionId}`,
+        "",
+        "Invariants:",
+        ...slices.invariants.map((x) => `- ${x}`),
+      ].join("\n"),
+      metadata: {
+        type: "memory-reflection",
+        stage: "reflect-store",
+        reflectionKind: "inherit",
+        reflectionVersion: 2,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+        agentId: params.agentId,
+        command: params.command,
+        storedAt: params.runAt,
+        invariants: slices.invariants,
+        usedFallback: params.usedFallback,
+        errorSignals: params.toolErrorSignals.map((s) => s.signatureHash),
+      },
+    });
+  }
+
+  if (slices.derived.length > 0) {
+    const deriveQuality = computeDerivedLineQuality(slices.derived.length);
+    const deriveBaseWeight = params.usedFallback ? REFLECTION_DERIVE_FALLBACK_BASE_WEIGHT : 1;
+    payloads.push({
+      kind: "derive",
+      text: [
+        `reflection:Derive · ${params.scope} · ${dateYmd}`,
+        `Session Reflection Derive (${new Date(params.runAt).toISOString()})`,
+        `Session Key: ${params.sessionKey}`,
+        `Session ID: ${params.sessionId}`,
+        "",
+        "Derived:",
+        ...slices.derived.map((x) => `- ${x}`),
+      ].join("\n"),
+      metadata: {
+        type: "memory-reflection",
+        stage: "reflect-store",
+        reflectionKind: "derive",
+        reflectionVersion: 2,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+        agentId: params.agentId,
+        command: params.command,
+        storedAt: params.runAt,
+        derived: slices.derived,
+        usedFallback: params.usedFallback,
+        errorSignals: params.toolErrorSignals.map((s) => s.signatureHash),
+        decayModel: "logistic",
+        decayMidpointDays: REFLECTION_DERIVE_LOGISTIC_MIDPOINT_DAYS,
+        decayK: REFLECTION_DERIVE_LOGISTIC_K,
+        deriveBaseWeight,
+        deriveQuality,
+        deriveSource: params.usedFallback ? "fallback" : "normal",
+      },
+    });
+  }
+
+  return { slices, payloads };
+}
+
+interface ReflectionStoreDeps {
+  embedPassage: (text: string) => Promise<number[]>;
+  vectorSearch: (
+    vector: number[],
+    limit?: number,
+    minScore?: number,
+    scopeFilter?: string[]
+  ) => Promise<MemorySearchResult[]>;
+  store: (entry: Omit<MemoryEntry, "id" | "timestamp">) => Promise<MemoryEntry>;
+}
+
+interface StoreReflectionToLanceDBParams extends BuildReflectionStorePayloadsParams, ReflectionStoreDeps {
+  dedupeThreshold?: number;
+}
+
+export async function storeReflectionToLanceDB(params: StoreReflectionToLanceDBParams): Promise<{
+  stored: boolean;
+  slices: ReflectionSlices;
+  storedKinds: ReflectionStoreKind[];
+}> {
+  const { slices, payloads } = buildReflectionStorePayloads(params);
+  const storedKinds: ReflectionStoreKind[] = [];
+  const dedupeThreshold = Number.isFinite(params.dedupeThreshold) ? Number(params.dedupeThreshold) : 0.97;
+
+  for (const payload of payloads) {
+    const vector = await params.embedPassage(payload.text);
+    const existing = await params.vectorSearch(vector, 1, 0.1, [params.scope]);
+    if (existing.length > 0 && existing[0].score > dedupeThreshold) {
+      continue;
+    }
+
+    await params.store({
+      text: payload.text,
+      vector,
+      category: "reflection",
+      scope: params.scope,
+      importance: 0.75,
+      metadata: JSON.stringify(payload.metadata),
+    });
+    storedKinds.push(payload.kind);
+  }
+
+  return { stored: storedKinds.length > 0, slices, storedKinds };
+}
+
+export interface LoadReflectionSlicesParams {
+  entries: MemoryEntry[];
+  agentId: string;
+  now?: number;
+  deriveMaxAgeMs?: number;
+}
+
+export function loadAgentReflectionSlicesFromEntries(params: LoadReflectionSlicesParams): {
+  invariants: string[];
+  derived: string[];
+} {
+  const now = Number.isFinite(params.now) ? Number(params.now) : Date.now();
+  const deriveMaxAgeMs = Number.isFinite(params.deriveMaxAgeMs)
+    ? Math.max(0, Number(params.deriveMaxAgeMs))
+    : DEFAULT_REFLECTION_DERIVED_MAX_AGE_MS;
+
+  const reflections = params.entries
+    .map((entry) => ({ entry, metadata: parseReflectionMetadata(entry.metadata) }))
+    .filter(({ metadata }) => {
+      if (metadata.type !== "memory-reflection") return false;
+      const owner = typeof metadata.agentId === "string" ? metadata.agentId.trim() : "";
+      if (!owner) return true;
+      return owner === params.agentId || owner === "main";
+    })
+    .sort((a, b) => b.entry.timestamp - a.entry.timestamp)
+    .slice(0, 40);
+
+  const invariants: string[] = [];
+  for (const { metadata } of reflections) {
+    const kind = getReflectionKind(metadata);
+    if (kind === "derive") continue;
+    const inv = sanitizeReflectionSliceLines(toStringArray(metadata.invariants));
+    for (const item of inv) {
+      if (!item || invariants.includes(item)) continue;
+      invariants.push(item);
+      if (invariants.length >= 8) break;
+    }
+    if (invariants.length >= 8) break;
+  }
+
+  type WeightedLine = { line: string; score: number; latestTs: number };
+  const lineScores = new Map<string, WeightedLine>();
+
+  for (const { entry, metadata } of reflections) {
+    const kind = getReflectionKind(metadata);
+    if (kind === "inherit") continue;
+
+    const derivedLines = sanitizeReflectionSliceLines(toStringArray(metadata.derived));
+    if (derivedLines.length === 0) continue;
+
+    const timestamp = metadataTimestamp(metadata, entry.timestamp);
+    if (now - timestamp > deriveMaxAgeMs) continue;
+
+    const ageDays = Math.max(0, (now - timestamp) / 86_400_000);
+    const decayMidpointDays = readPositiveNumber(metadata.decayMidpointDays, REFLECTION_DERIVE_LOGISTIC_MIDPOINT_DAYS);
+    const decayK = readPositiveNumber(metadata.decayK, REFLECTION_DERIVE_LOGISTIC_K);
+    const logistic = 1 / (1 + Math.exp(decayK * (ageDays - decayMidpointDays)));
+    const deriveBaseWeight = resolveDeriveBaseWeight(metadata);
+    const deriveQuality = readClampedNumber(metadata.deriveQuality, computeDerivedLineQuality(derivedLines.length), 0.2, 1);
+    const entryWeight = logistic * deriveBaseWeight * deriveQuality;
+    if (entryWeight <= 0) continue;
+
+    for (const line of derivedLines) {
+      const current = lineScores.get(line);
+      if (!current) {
+        lineScores.set(line, { line, score: entryWeight, latestTs: timestamp });
+        continue;
+      }
+      current.score += entryWeight;
+      if (timestamp > current.latestTs) current.latestTs = timestamp;
+    }
+  }
+
+  const derived = [...lineScores.values()]
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      if (b.latestTs !== a.latestTs) return b.latestTs - a.latestTs;
+      return a.line.localeCompare(b.line);
+    })
+    .slice(0, 10)
+    .map((item) => item.line);
+
+  return { invariants, derived };
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => String(item).trim())
+    .filter(Boolean);
+}
+
+function metadataTimestamp(metadata: Record<string, unknown>, fallbackTs: number): number {
+  const storedAt = Number(metadata.storedAt);
+  if (Number.isFinite(storedAt) && storedAt > 0) return storedAt;
+  return Number.isFinite(fallbackTs) ? fallbackTs : Date.now();
+}
+
+function readPositiveNumber(value: unknown, fallback: number): number {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) return fallback;
+  return num;
+}
+
+function readClampedNumber(value: unknown, fallback: number, min: number, max: number): number {
+  const num = Number(value);
+  const resolved = Number.isFinite(num) ? num : fallback;
+  return Math.max(min, Math.min(max, resolved));
+}
+
+export function computeDerivedLineQuality(nonPlaceholderLineCount: number): number {
+  const n = Number.isFinite(nonPlaceholderLineCount) ? Math.max(0, Math.floor(nonPlaceholderLineCount)) : 0;
+  if (n <= 0) return 0.2;
+  // Small quality factor boost for richer non-placeholder derive outputs.
+  return Math.min(1, 0.55 + Math.min(6, n) * 0.075);
+}
+
+function resolveDeriveBaseWeight(metadata: Record<string, unknown>): number {
+  const explicit = Number(metadata.deriveBaseWeight);
+  if (Number.isFinite(explicit) && explicit > 0) {
+    return Math.max(0.1, Math.min(1, explicit));
+  }
+  if (metadata.usedFallback === true) {
+    return REFLECTION_DERIVE_FALLBACK_BASE_WEIGHT;
+  }
+  return 1;
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -15,6 +15,7 @@ import { isNoise } from "./noise-filter.js";
 import type { MemoryScopeManager } from "./scopes.js";
 import type { Embedder } from "./embedder.js";
 import { ensureSelfImprovementLearningFiles } from "./self-improvement-files.js";
+import { getDisplayCategoryTag } from "./reflection-metadata.js";
 
 // ============================================================================
 // Types
@@ -75,29 +76,6 @@ function sanitizeMemoryForSerialization(results: RetrievalResult[]) {
     score: r.score,
     sources: r.sources,
   }));
-}
-
-function parseEntryMetadata(entry: { metadata?: string }): Record<string, unknown> {
-  if (!entry.metadata) return {};
-  try {
-    const parsed = JSON.parse(entry.metadata);
-    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
-  } catch {
-    return {};
-  }
-}
-
-function isReflectionEntry(entry: { category: string; metadata?: string }): boolean {
-  if (entry.category === "reflection") return true;
-  const metadata = parseEntryMetadata(entry);
-  return metadata.type === "memory-reflection";
-}
-
-function getDisplayCategoryTag(entry: { category: string; scope: string; metadata?: string }): string {
-  if (isReflectionEntry(entry)) {
-    return `reflection:${entry.scope}`;
-  }
-  return `${entry.category}:${entry.scope}`;
 }
 
 function resolveWorkspaceDir(toolCtx: unknown, fallback?: string): string {

--- a/test/reflection-display-tags.test.mjs
+++ b/test/reflection-display-tags.test.mjs
@@ -1,0 +1,50 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const { getDisplayCategoryTag } = jiti("../src/reflection-metadata.ts");
+
+describe("reflection display category tags", () => {
+  it("shows subtype labels for new reflection entries", () => {
+    assert.equal(
+      getDisplayCategoryTag({
+        category: "reflection",
+        scope: "global",
+        metadata: JSON.stringify({ type: "memory-reflection", reflectionKind: "inherit" }),
+      }),
+      "reflection:Inherit"
+    );
+
+    assert.equal(
+      getDisplayCategoryTag({
+        category: "reflection",
+        scope: "global",
+        metadata: JSON.stringify({ type: "memory-reflection", reflectionKind: "derive" }),
+      }),
+      "reflection:Derive"
+    );
+  });
+
+  it("keeps legacy-safe reflection display path when subtype metadata is absent", () => {
+    assert.equal(
+      getDisplayCategoryTag({
+        category: "reflection",
+        scope: "project-a",
+        metadata: JSON.stringify({ type: "memory-reflection", invariants: ["Always verify output"] }),
+      }),
+      "reflection:project-a"
+    );
+  });
+
+  it("preserves non-reflection display categories", () => {
+    assert.equal(
+      getDisplayCategoryTag({
+        category: "fact",
+        scope: "global",
+        metadata: "{}",
+      }),
+      "fact:global"
+    );
+  });
+});

--- a/test/reflection-storage-evolution.test.mjs
+++ b/test/reflection-storage-evolution.test.mjs
@@ -1,0 +1,213 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+
+const {
+  storeReflectionToLanceDB,
+  loadAgentReflectionSlicesFromEntries,
+  REFLECTION_DERIVE_LOGISTIC_K,
+  REFLECTION_DERIVE_LOGISTIC_MIDPOINT_DAYS,
+  REFLECTION_DERIVE_FALLBACK_BASE_WEIGHT,
+} = jiti("../src/reflection-store.ts");
+
+function makeEntry({ timestamp, metadata, category = "reflection", scope = "global" }) {
+  return {
+    id: `mem-${Math.random().toString(36).slice(2, 8)}`,
+    text: "reflection-entry",
+    vector: [],
+    category,
+    scope,
+    importance: 0.7,
+    timestamp,
+    metadata: JSON.stringify(metadata),
+  };
+}
+
+describe("reflection split persistence", () => {
+  it("stores split inherit/derive entries with subtype metadata and logistic fields", async () => {
+    const storedEntries = [];
+    const vectorSearchCalls = [];
+
+    const result = await storeReflectionToLanceDB({
+      reflectionText: [
+        "## Invariants",
+        "- Always confirm assumptions before changing files.",
+        "## Derived",
+        "- Next run verify reflection split with targeted tests.",
+      ].join("\n"),
+      sessionKey: "agent:main:session:abc",
+      sessionId: "abc",
+      agentId: "main",
+      command: "command:reset",
+      scope: "global",
+      toolErrorSignals: [{ signatureHash: "deadbeef" }],
+      runAt: 1_700_000_000_000,
+      usedFallback: false,
+      embedPassage: async (text) => [text.length],
+      vectorSearch: async (vector) => {
+        vectorSearchCalls.push(vector);
+        return [];
+      },
+      store: async (entry) => {
+        storedEntries.push(entry);
+        return { ...entry, id: `id-${storedEntries.length}`, timestamp: 1_700_000_000_000 };
+      },
+    });
+
+    assert.equal(result.stored, true);
+    assert.deepEqual(new Set(result.storedKinds), new Set(["inherit", "derive"]));
+    assert.equal(storedEntries.length, 2);
+    assert.equal(vectorSearchCalls.length, 2);
+
+    const inherit = storedEntries.find((entry) => JSON.parse(entry.metadata).reflectionKind === "inherit");
+    const derive = storedEntries.find((entry) => JSON.parse(entry.metadata).reflectionKind === "derive");
+    assert.ok(inherit);
+    assert.ok(derive);
+
+    const inheritMeta = JSON.parse(inherit.metadata);
+    const deriveMeta = JSON.parse(derive.metadata);
+
+    assert.equal(inherit.category, "reflection");
+    assert.equal(derive.category, "reflection");
+    assert.deepEqual(inheritMeta.invariants, ["Always confirm assumptions before changing files."]);
+    assert.equal(inheritMeta.reflectionKind, "inherit");
+
+    assert.equal(deriveMeta.reflectionKind, "derive");
+    assert.deepEqual(deriveMeta.derived, ["Next run verify reflection split with targeted tests."]);
+    assert.equal(deriveMeta.decayModel, "logistic");
+    assert.equal(deriveMeta.decayK, REFLECTION_DERIVE_LOGISTIC_K);
+    assert.equal(deriveMeta.decayMidpointDays, REFLECTION_DERIVE_LOGISTIC_MIDPOINT_DAYS);
+    assert.equal(deriveMeta.deriveBaseWeight, 1);
+  });
+});
+
+describe("reflection legacy compatibility + source separation", () => {
+  it("loads legacy combined entries and separates inherit/derive sources", () => {
+    const now = Date.UTC(2026, 2, 7);
+
+    const entries = [
+      makeEntry({
+        timestamp: now - 30 * 60 * 1000,
+        metadata: {
+          type: "memory-reflection",
+          agentId: "main",
+          reflectionKind: "inherit",
+          invariants: ["Always keep fixes minimal."],
+          derived: ["should-not-appear-from-inherit"],
+          storedAt: now - 30 * 60 * 1000,
+        },
+      }),
+      makeEntry({
+        timestamp: now - 25 * 60 * 1000,
+        metadata: {
+          type: "memory-reflection",
+          agentId: "main",
+          reflectionKind: "derive",
+          invariants: ["should-not-appear-from-derive"],
+          derived: ["Next run keep logs concise."],
+          storedAt: now - 25 * 60 * 1000,
+        },
+      }),
+      makeEntry({
+        timestamp: now - 20 * 60 * 1000,
+        metadata: {
+          type: "memory-reflection",
+          agentId: "main",
+          invariants: ["Legacy invariant still applies."],
+          derived: ["Legacy derived delta still applies."],
+          storedAt: now - 20 * 60 * 1000,
+        },
+      }),
+    ];
+
+    const slices = loadAgentReflectionSlicesFromEntries({
+      entries,
+      agentId: "main",
+      now,
+      deriveMaxAgeMs: 7 * 24 * 60 * 60 * 1000,
+    });
+
+    assert.ok(slices.invariants.includes("Always keep fixes minimal."));
+    assert.ok(slices.invariants.includes("Legacy invariant still applies."));
+    assert.ok(!slices.invariants.includes("should-not-appear-from-derive"));
+
+    assert.ok(slices.derived.includes("Next run keep logs concise."));
+    assert.ok(slices.derived.includes("Legacy derived delta still applies."));
+    assert.ok(!slices.derived.includes("should-not-appear-from-inherit"));
+  });
+});
+
+describe("reflection derive logistic scoring", () => {
+  it("aggregates multiple recent derive memories and down-weights fallback entries", () => {
+    const now = Date.UTC(2026, 2, 7);
+    const day = 24 * 60 * 60 * 1000;
+
+    const entries = [
+      makeEntry({
+        timestamp: now - 1 * day,
+        metadata: {
+          type: "memory-reflection",
+          agentId: "main",
+          reflectionKind: "derive",
+          derived: ["Fresh normal derive"],
+          storedAt: now - 1 * day,
+          deriveBaseWeight: 1,
+          usedFallback: false,
+        },
+      }),
+      makeEntry({
+        timestamp: now - 1 * day,
+        metadata: {
+          type: "memory-reflection",
+          agentId: "main",
+          reflectionKind: "derive",
+          derived: ["Fresh fallback derive"],
+          storedAt: now - 1 * day,
+          usedFallback: true,
+        },
+      }),
+      makeEntry({
+        timestamp: now - 5 * day,
+        metadata: {
+          type: "memory-reflection",
+          agentId: "main",
+          reflectionKind: "derive",
+          derived: ["Older normal derive"],
+          storedAt: now - 5 * day,
+          usedFallback: false,
+        },
+      }),
+      makeEntry({
+        timestamp: now - 2 * day,
+        metadata: {
+          type: "memory-reflection",
+          agentId: "main",
+          reflectionKind: "derive",
+          derived: ["Second recent derive signal"],
+          storedAt: now - 2 * day,
+          usedFallback: false,
+        },
+      }),
+    ];
+
+    const slices = loadAgentReflectionSlicesFromEntries({
+      entries,
+      agentId: "main",
+      now,
+      deriveMaxAgeMs: 10 * day,
+    });
+
+    assert.equal(slices.derived[0], "Fresh normal derive");
+    assert.ok(slices.derived.includes("Second recent derive signal"));
+
+    const fallbackIdx = slices.derived.indexOf("Fresh fallback derive");
+    const olderIdx = slices.derived.indexOf("Older normal derive");
+    assert.notEqual(fallbackIdx, -1);
+    assert.notEqual(olderIdx, -1);
+    assert.ok(fallbackIdx < olderIdx, "fallback should still rank above much older derive due recency, but below normal fresh derive");
+
+    assert.equal(REFLECTION_DERIVE_FALLBACK_BASE_WEIGHT, 0.35);
+  });
+});


### PR DESCRIPTION
## Summary
- split reflection persistence into separate Inherit and Derive entries while keeping `category=reflection`
- add logistic weighting for Derive injection instead of relying on only the latest reflection row
- keep legacy combined reflection rows readable/injectable without a required migration
- extract part of the reflection metadata/slice/store logic out of `index.ts`

## Why
- stable carry-over rules and short-lived next-run deltas should not live in the same reflection memory shape
- the previous derive path was too dependent on the latest reflection row
- reflection injection needs a decay-aware way to surface recent execution deltas without changing global retriever scoring
- the reflection path in `index.ts` had grown enough to justify a focused structural cleanup

## Changes
- store split reflection rows with `metadata.reflectionKind = "inherit" | "derive"`
- display new rows as `reflection:Inherit` and `reflection:Derive`
- preserve a legacy-safe read/display path for old combined reflection rows
- apply logistic derive weighting during reflection loading/injection only
- use defaults:
  - `midpointDays = 3`
  - `k = 1.2`
  - fallback derive base weight = `0.35`
- keep `<inherited-rules>` sourced from inherit memories only
- keep `<derived-focus>` sourced from derive memories only
- add focused tests for split persistence, legacy compatibility, subtype display tags, and derive weighting

## Verification
- `npm test`

## Risks / Compatibility
- compatibility is preserved by keeping `category=reflection` and continuing to read legacy combined reflection metadata
- derive injection behavior now aggregates multiple recent derive rows with decay instead of only using the latest row
- no global retriever scoring behavior was changed
