### PR TITLE
Make apiKey optional for local embedding endpoints

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -61,9 +61,7 @@
             "description": "Enable automatic chunking for documents exceeding embedding context limits"
           }
         },
-        "required": [
-          "apiKey"
-        ]
+        "required": []
       },
       "dbPath": {
         "type": "string"

--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -85,8 +85,8 @@ class EmbeddingCache {
 
 export interface EmbeddingConfig {
   provider: "openai-compatible";
-  /** Single API key or array of keys for round-robin rotation with failover. */
-  apiKey: string | string[];
+  /** Single API key or array of keys for round-robin rotation with failover. Optional for local endpoints like Ollama. */
+  apiKey?: string | string[];
   model: string;
   baseURL?: string;
   dimensions?: number;
@@ -289,7 +289,11 @@ export class Embedder {
 
   constructor(config: EmbeddingConfig & { chunking?: boolean }) {
     // Normalize apiKey to array and resolve environment variables
-    const apiKeys = Array.isArray(config.apiKey) ? config.apiKey : [config.apiKey];
+    // For local endpoints like Ollama, apiKey can be omitted - use a dummy value
+    const defaultApiKey = "sk-dummy-local";
+    const apiKeys = config.apiKey
+      ? (Array.isArray(config.apiKey) ? config.apiKey : [config.apiKey])
+      : [defaultApiKey];
     const resolvedKeys = apiKeys.map(k => resolveEnvVars(k));
 
     this._model = config.model;


### PR DESCRIPTION
Local embedding services like Ollama do not require API keys for authentication. Previously, the config schema required apiKey, causing validation failures when configuring Ollama or other local endpoints.

This fix makes apiKey optional in both the schema and TypeScript interface, and provides a default dummy value when not specified.

Fixes #71