### PR TITLE
docs: clarify recall parameter mapping and practical baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,11 +410,12 @@ openclaw config get plugins.slots.memory
   "dbPath": "~/.openclaw/memory/lancedb-pro",
   "autoCapture": true,
   "autoRecall": false,
+  "autoRecallMinLength": 8,
   "retrieval": {
     "mode": "hybrid",
     "vectorWeight": 0.7,
     "bm25Weight": 0.3,
-    "minScore": 0.3,
+    "minScore": 0.45,
     "rerank": "cross-encoder",
     "rerankApiKey": "${JINA_API_KEY}",
     "rerankModel": "jina-reranker-v3",
@@ -425,7 +426,7 @@ openclaw config get plugins.slots.memory
     "recencyWeight": 0.1,
     "filterNoise": true,
     "lengthNormAnchor": 500,
-    "hardMinScore": 0.35,
+    "hardMinScore": 0.55,
     "timeDecayHalfLifeDays": 60,
     "reinforcementFactor": 0.5,
     "maxHalfLifeMultiplier": 3
@@ -467,6 +468,30 @@ openclaw config get plugins.slots.memory
 ```
 
 </details>
+
+### Parameter Mapping Notes (avoid common misconfig)
+
+`memory-lancedb-pro` does **not** support `recallTopK` / `recallThreshold`.
+
+Use these equivalents instead:
+
+- `recallTopK` → `retrieval.candidatePoolSize`
+- `recallThreshold` → combine `retrieval.minScore` + `retrieval.hardMinScore`
+
+A practical starting point for Chinese chat workloads:
+
+```json
+{
+  "autoCapture": true,
+  "autoRecall": true,
+  "autoRecallMinLength": 8,
+  "retrieval": {
+    "candidatePoolSize": 20,
+    "minScore": 0.45,
+    "hardMinScore": 0.55
+  }
+}
+```
 
 ### Access Reinforcement (1.0.26)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -410,11 +410,12 @@ openclaw config get plugins.slots.memory
   "dbPath": "~/.openclaw/memory/lancedb-pro",
   "autoCapture": true,
   "autoRecall": false,
+  "autoRecallMinLength": 8,
   "retrieval": {
     "mode": "hybrid",
     "vectorWeight": 0.7,
     "bm25Weight": 0.3,
-    "minScore": 0.3,
+    "minScore": 0.45,
     "rerank": "cross-encoder",
     "rerankApiKey": "${JINA_API_KEY}",
     "rerankModel": "jina-reranker-v3",
@@ -465,6 +466,30 @@ openclaw config get plugins.slots.memory
 ```
 
 </details>
+
+### 参数映射提示（避免常见误配）
+
+`memory-lancedb-pro` **不支持** `recallTopK` / `recallThreshold` 这两个字段。
+
+如果你希望达到类似效果，请使用下列等价参数：
+
+- `recallTopK` → `retrieval.candidatePoolSize`
+- `recallThreshold` → 组合使用 `retrieval.minScore` + `retrieval.hardMinScore`
+
+实战上，中文对话可先从以下配置起步（再按误召回情况微调）：
+
+```json
+{
+  "autoCapture": true,
+  "autoRecall": true,
+  "autoRecallMinLength": 8,
+  "retrieval": {
+    "candidatePoolSize": 20,
+    "minScore": 0.45,
+    "hardMinScore": 0.55
+  }
+}
+```
 
 ### 访问强化（1.0.26）
 


### PR DESCRIPTION
## Summary
This PR improves both English and Chinese docs to reduce common misconfiguration around recall tuning.

### What changed
- Updated full config examples:
  - add `autoRecallMinLength: 8`
  - tune `retrieval.minScore` from `0.3` to `0.45`
  - tune `retrieval.hardMinScore` from `0.35` to `0.55`
- Added a new section in both `README.md` and `README_CN.md`:
  - explicitly notes `recallTopK` / `recallThreshold` are **not** supported
  - maps them to supported equivalents:
    - `recallTopK` -> `retrieval.candidatePoolSize`
    - `recallThreshold` -> `retrieval.minScore` + `retrieval.hardMinScore`
  - includes a practical baseline profile for Chinese chat workloads.

## Why
In real use, users often try to set `recallTopK` and `recallThreshold` (coming from other memory systems). This leads to confusion because the plugin schema uses different knobs.

The added mapping + baseline helps users quickly reach a stable "lower-noise" setup and avoids invalid config attempts.

## Validation
- Verified against current `openclaw.plugin.json` schema in this repo:
  - `autoRecallMinLength`: supported
  - `retrieval.candidatePoolSize`: supported
  - `retrieval.minScore` / `retrieval.hardMinScore`: supported
  - `recallTopK` / `recallThreshold`: not present

Thanks for maintaining this plugin 🙌
