### PR TITLE
feat: Add plugin manifest regression test, implement `embedding.chunk…

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,12 @@ openclaw config get plugins.slots.memory
 }
 ```
 
+OpenClaw-specific defaults:
+
+- `autoCapture`: enabled by default
+- `embedding.chunking`: enabled by default and now wired through to the embedder runtime
+- `sessionMemory.enabled`: disabled by default; set it explicitly to `true` if you want the plugin to register the `/new` session-summary hook
+
 </details>
 
 ### Access Reinforcement (1.0.26)

--- a/README_CN.md
+++ b/README_CN.md
@@ -597,6 +597,12 @@ openclaw config get plugins.slots.memory
 }
 ```
 
+OpenClaw 默认行为补充：
+
+- `autoCapture`：默认开启
+- `embedding.chunking`：默认开启，且现在已经真正传递到 embedder 运行时
+- `sessionMemory.enabled`：默认关闭；如果你希望插件注册 `/new` 的 session-summary Hook，需要显式设置为 `true`
+
 </details>
 
 ### 访问强化（1.0.26）

--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,6 @@ import { createScopeManager } from "./src/scopes.js";
 import { createMigrator } from "./src/migrate.js";
 import { registerAllMemoryTools } from "./src/tools.js";
 import { shouldSkipRetrieval } from "./src/adaptive-retrieval.js";
-import { AccessTracker } from "./src/access-tracker.js";
 import { createMemoryCLI } from "./cli.js";
 import { isNoise } from "./src/noise-filter.js";
 
@@ -48,6 +47,7 @@ interface PluginConfig {
     taskQuery?: string;
     taskPassage?: string;
     normalized?: boolean;
+    chunking?: boolean;
   };
   dbPath?: string;
   autoCapture?: boolean;
@@ -457,6 +457,7 @@ const memoryLanceDBProPlugin = {
       taskQuery: config.embedding.taskQuery,
       taskPassage: config.embedding.taskPassage,
       normalized: config.embedding.normalized,
+      chunking: config.embedding.chunking,
     });
     // Initialize decay engine
     const decayEngine = createDecayEngine({
@@ -1140,14 +1141,6 @@ const memoryLanceDBProPlugin = {
         backupTimer = setInterval(() => void runBackup(), BACKUP_INTERVAL_MS);
       },
       stop: async () => {
-        // Flush pending access reinforcement data before shutdown
-        try {
-          await accessTracker.flush();
-        } catch (err) {
-          api.logger.warn("memory-lancedb-pro: flush failed on stop:", err);
-        }
-        accessTracker.destroy();
-
         if (backupTimer) {
           clearInterval(backupTimer);
           backupTimer = null;
@@ -1222,6 +1215,10 @@ function parsePluginConfig(value: unknown): PluginConfig {
         typeof embedding.normalized === "boolean"
           ? embedding.normalized
           : undefined,
+      chunking:
+        typeof embedding.chunking === "boolean"
+          ? embedding.chunking
+          : undefined,
     },
     dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : undefined,
     autoCapture: cfg.autoCapture !== false,
@@ -1243,7 +1240,7 @@ function parsePluginConfig(value: unknown): PluginConfig {
       typeof cfg.sessionMemory === "object" && cfg.sessionMemory !== null
         ? {
             enabled:
-              (cfg.sessionMemory as Record<string, unknown>).enabled !== false,
+              (cfg.sessionMemory as Record<string, unknown>).enabled === true,
             messageCount:
               typeof (cfg.sessionMemory as Record<string, unknown>)
                 .messageCount === "number"

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memory-lancedb-pro",
   "name": "Memory (LanceDB Pro)",
   "description": "Enhanced LanceDB-backed long-term memory with hybrid retrieval, multi-scope isolation, long-context chunking, and management CLI",
-  "version": "1.0.22",
+  "version": "1.1.0-beta.2",
   "kind": "memory",
   "configSchema": {
     "type": "object",
@@ -74,7 +74,8 @@
         "description": "Enable memory_list and memory_stats management tools"
       },
       "autoCapture": {
-        "type": "boolean"
+        "type": "boolean",
+        "default": true
       },
       "autoRecall": {
         "type": "boolean",
@@ -89,6 +90,25 @@
       },
       "captureAssistant": {
         "type": "boolean"
+      },
+      "smartExtraction": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable LLM-powered memory extraction. Falls back to regex capture when false."
+      },
+      "extractMinMessages": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 100,
+        "default": 4,
+        "description": "Minimum conversation messages required before smart extraction runs."
+      },
+      "extractMaxChars": {
+        "type": "integer",
+        "minimum": 256,
+        "maximum": 100000,
+        "default": 8000,
+        "description": "Maximum conversation characters sent to the smart extraction LLM."
       },
       "retrieval": {
         "type": "object",
@@ -254,8 +274,8 @@
         "properties": {
           "enabled": {
             "type": "boolean",
-            "default": true,
-            "description": "Store session summaries to LanceDB on /new command (replaces built-in session-memory hook)"
+            "default": false,
+            "description": "Store session summaries to LanceDB on /new command. Disabled by default to avoid duplicate session-summary paths."
           },
           "messageCount": {
             "type": "integer",
@@ -360,7 +380,7 @@
     },
     "embedding.chunking": {
       "label": "Auto-Chunk Documents",
-      "help": "Automatically split long documents into chunks when they exceed embedding context limits. Set to false to disable and let the model fail on long documents.",
+      "help": "Automatically split long documents into chunks when they exceed embedding context limits. Enabled by default.",
       "advanced": true
     },
     "dbPath": {
@@ -401,7 +421,7 @@
     },
     "autoCapture": {
       "label": "Auto-Capture",
-      "help": "Automatically capture important information from conversations"
+      "help": "Automatically capture important information from conversations (enabled by default)"
     },
     "autoRecall": {
       "label": "Auto-Recall",
@@ -538,7 +558,7 @@
     },
     "sessionMemory.enabled": {
       "label": "Session Memory",
-      "help": "Store session summaries to LanceDB when /new is triggered (replaces built-in session-memory hook)"
+      "help": "Store session summaries to LanceDB when /new is triggered. Disabled by default to avoid duplicate session-summary paths."
     },
     "sessionMemory.messageCount": {
       "label": "Session Message Count",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "scripts": {
-    "test": "node test/cli-smoke.mjs && node test/retriever-rerank-regression.mjs && node test/smart-memory-lifecycle.mjs && node test/smart-extractor-branches.mjs"
+    "test": "node test/cli-smoke.mjs && node test/retriever-rerank-regression.mjs && node test/smart-memory-lifecycle.mjs && node test/smart-extractor-branches.mjs && node test/plugin-manifest-regression.mjs"
   },
   "devDependencies": {
     "commander": "^14.0.0",

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -1,0 +1,263 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import http from "node:http";
+import Module from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import jitiFactory from "jiti";
+
+process.env.NODE_PATH = [
+  process.env.NODE_PATH,
+  "/opt/homebrew/lib/node_modules/openclaw/node_modules",
+  "/opt/homebrew/lib/node_modules",
+].filter(Boolean).join(":");
+Module._initPaths();
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const plugin = jiti("../index.ts");
+
+const manifest = JSON.parse(
+  readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+);
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
+
+function createMockApi(pluginConfig, options = {}) {
+  return {
+    pluginConfig,
+    hooks: {},
+    toolFactories: {},
+    logger: {
+      info() {},
+      warn() {},
+      error() {},
+      debug() {},
+    },
+    resolvePath(value) {
+      return value;
+    },
+    registerTool(toolOrFactory, meta) {
+      this.toolFactories[meta.name] =
+        typeof toolOrFactory === "function" ? toolOrFactory : () => toolOrFactory;
+    },
+    registerCli() {},
+    registerService(service) {
+      options.services?.push(service);
+    },
+    on(name, handler) {
+      this.hooks[name] = handler;
+    },
+    registerHook(name, handler) {
+      this.hooks[name] = handler;
+    },
+  };
+}
+
+for (const key of ["smartExtraction", "extractMinMessages", "extractMaxChars"]) {
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(manifest.configSchema.properties, key),
+    `configSchema should declare ${key}`,
+  );
+}
+
+assert.equal(
+  manifest.configSchema.properties.autoCapture.default,
+  true,
+  "autoCapture schema default should match runtime default",
+);
+assert.equal(
+  manifest.configSchema.properties.embedding.properties.chunking.default,
+  true,
+  "embedding.chunking schema default should match runtime default",
+);
+assert.equal(
+  manifest.configSchema.properties.sessionMemory.properties.enabled.default,
+  false,
+  "sessionMemory.enabled schema default should match runtime default",
+);
+
+assert.equal(
+  manifest.version,
+  pkg.version,
+  "openclaw.plugin.json version should stay aligned with package.json",
+);
+
+const workDir = mkdtempSync(path.join(tmpdir(), "memory-plugin-regression-"));
+const services = [];
+
+try {
+  const api = createMockApi(
+    {
+      dbPath: path.join(workDir, "db"),
+      autoRecall: false,
+      embedding: {
+        provider: "openai-compatible",
+        apiKey: "dummy",
+        model: "text-embedding-3-small",
+        baseURL: "http://127.0.0.1:9/v1",
+        dimensions: 1536,
+      },
+    },
+    { services },
+  );
+  plugin.register(api);
+  assert.equal(services.length, 1, "plugin should register its background service");
+  assert.equal(typeof api.hooks.agent_end, "function", "autoCapture should remain enabled by default");
+  assert.equal(api.hooks["command:new"], undefined, "sessionMemory should stay disabled by default");
+  await assert.doesNotReject(
+    services[0].stop(),
+    "service stop should not throw when no access tracker is configured",
+  );
+
+  const sessionDefaultApi = createMockApi({
+    dbPath: path.join(workDir, "db-session-default"),
+    autoCapture: false,
+    autoRecall: false,
+    sessionMemory: {},
+    embedding: {
+      provider: "openai-compatible",
+      apiKey: "dummy",
+      model: "text-embedding-3-small",
+      baseURL: "http://127.0.0.1:9/v1",
+      dimensions: 1536,
+    },
+  });
+  plugin.register(sessionDefaultApi);
+  assert.equal(
+    sessionDefaultApi.hooks["command:new"],
+    undefined,
+    "sessionMemory:{} should not implicitly enable the /new hook",
+  );
+
+  const sessionEnabledApi = createMockApi({
+    dbPath: path.join(workDir, "db-session-enabled"),
+    autoCapture: false,
+    autoRecall: false,
+    sessionMemory: { enabled: true },
+    embedding: {
+      provider: "openai-compatible",
+      apiKey: "dummy",
+      model: "text-embedding-3-small",
+      baseURL: "http://127.0.0.1:9/v1",
+      dimensions: 1536,
+    },
+  });
+  plugin.register(sessionEnabledApi);
+  assert.equal(
+    typeof sessionEnabledApi.hooks["command:new"],
+    "function",
+    "sessionMemory.enabled=true should register the /new hook",
+  );
+
+  const longText = `${"Long embedding payload. ".repeat(420)}tail`;
+  const threshold = 6000;
+  const embeddingServer = http.createServer(async (req, res) => {
+    if (req.method !== "POST" || req.url !== "/v1/embeddings") {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    const inputs = Array.isArray(payload.input) ? payload.input : [payload.input];
+
+    if (inputs.some((input) => String(input).length > threshold)) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        error: {
+          message: "context length exceeded for mock embedding endpoint",
+          type: "invalid_request_error",
+        },
+      }));
+      return;
+    }
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      object: "list",
+      data: inputs.map((_, index) => ({
+        object: "embedding",
+        index,
+        embedding: [0.5, 0.5, 0.5, 0.5],
+      })),
+      model: payload.model || "mock-embedding-model",
+      usage: {
+        prompt_tokens: 0,
+        total_tokens: 0,
+      },
+    }));
+  });
+
+  await new Promise((resolve) => embeddingServer.listen(0, "127.0.0.1", resolve));
+  const embeddingPort = embeddingServer.address().port;
+  const embeddingBaseURL = `http://127.0.0.1:${embeddingPort}/v1`;
+
+  try {
+    const chunkingOffApi = createMockApi({
+      dbPath: path.join(workDir, "db-chunking-off"),
+      autoCapture: false,
+      autoRecall: false,
+      embedding: {
+        provider: "openai-compatible",
+        apiKey: "dummy",
+        model: "text-embedding-3-small",
+        baseURL: embeddingBaseURL,
+        dimensions: 4,
+        chunking: false,
+      },
+    });
+    plugin.register(chunkingOffApi);
+    const chunkingOffTool = chunkingOffApi.toolFactories.memory_store({
+      agentId: "main",
+      sessionKey: "agent:main:test",
+    });
+    const chunkingOffResult = await chunkingOffTool.execute("tool-1", {
+      text: longText,
+      scope: "global",
+    });
+    assert.equal(
+      chunkingOffResult.details.error,
+      "store_failed",
+      "embedding.chunking=false should let long-document embedding fail",
+    );
+
+    const chunkingOnApi = createMockApi({
+      dbPath: path.join(workDir, "db-chunking-on"),
+      autoCapture: false,
+      autoRecall: false,
+      embedding: {
+        provider: "openai-compatible",
+        apiKey: "dummy",
+        model: "text-embedding-3-small",
+        baseURL: embeddingBaseURL,
+        dimensions: 4,
+        chunking: true,
+      },
+    });
+    plugin.register(chunkingOnApi);
+    const chunkingOnTool = chunkingOnApi.toolFactories.memory_store({
+      agentId: "main",
+      sessionKey: "agent:main:test",
+    });
+    const chunkingOnResult = await chunkingOnTool.execute("tool-2", {
+      text: longText,
+      scope: "global",
+    });
+    assert.equal(
+      chunkingOnResult.details.action,
+      "created",
+      "embedding.chunking=true should recover from long-document embedding errors",
+    );
+  } finally {
+    await new Promise((resolve) => embeddingServer.close(resolve));
+  }
+} finally {
+  rmSync(workDir, { recursive: true, force: true });
+}
+
+console.log("OK: plugin manifest regression test passed");


### PR DESCRIPTION
…ing` configuration, clarify default behaviors, and remove `AccessTracker` flush.