### PR TITLE
feat: add import-openclaw CLI and improve Gemini diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,9 @@ openclaw memory-pro delete-bulk --scope global [--before 2025-01-01] [--dry-run]
 openclaw memory-pro export [--scope global] [--output memories.json]
 openclaw memory-pro import memories.json [--scope global] [--dry-run]
 
+# Import file-based memory from an OpenClaw workspace
+openclaw memory-pro import-openclaw ~/.openclaw/workspace [--scope global] [--since 2026-03-01] [--dry-run]
+
 # Re-embed all entries with a new model
 openclaw memory-pro reembed --source-db /path/to/old-db [--batch-size 32] [--skip-existing]
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -559,6 +559,9 @@ openclaw memory-pro delete-bulk --scope global [--before 2025-01-01] [--dry-run]
 openclaw memory-pro export [--scope global] [--output memories.json]
 openclaw memory-pro import memories.json [--scope global] [--dry-run]
 
+# 从 OpenClaw workspace 导入文件记忆
+openclaw memory-pro import-openclaw ~/.openclaw/workspace [--scope global] [--since 2026-03-01] [--dry-run]
+
 # 使用新模型重新生成 Embedding
 openclaw memory-pro reembed --source-db /path/to/old-db [--batch-size 32] [--skip-existing]
 
@@ -588,6 +591,15 @@ LanceDB 表 `memories`：
 ---
 
 ## 常见问题 / 排错
+
+### Gemini 配置排错
+
+- 使用 `embedding.baseURL: "https://generativelanguage.googleapis.com/v1beta/openai/"`
+- 使用 `embedding.model: "gemini-embedding-001"`
+- 设置 `embedding.dimensions: 3072`
+- 确保 `GEMINI_API_KEY` 存在于 Gateway 进程环境中，而不只是当前 shell
+- 如果看到 404 / model-not-found 错误，请重点检查 `v1beta/openai/` 后缀与模型名是否正确
+
 
 ### "Cannot mix BigInt and other types"（LanceDB / Apache Arrow）
 

--- a/cli.ts
+++ b/cli.ts
@@ -8,6 +8,7 @@ import { loadLanceDB, type MemoryEntry, type MemoryStore } from "./src/store.js"
 import type { MemoryRetriever } from "./src/retriever.js";
 import type { MemoryScopeManager } from "./src/scopes.js";
 import type { MemoryMigrator } from "./src/migrate.js";
+import { collectOpenClawMemories } from "./src/import-openclaw.js";
 
 // ============================================================================
 // Types
@@ -51,6 +52,120 @@ function formatMemory(memory: any, index?: number): string {
 
 function formatJson(obj: any): string {
   return JSON.stringify(obj, null, 2);
+}
+
+
+async function importMemoryObjects(
+  context: CLIContext,
+  memories: any[],
+  options: { scope?: string; dryRun?: boolean },
+): Promise<void> {
+  if (options.dryRun) {
+    console.log("DRY RUN - No memories will be imported");
+    console.log(`Would import ${memories.length} memories`);
+    if (options.scope) console.log(`Target scope: ${options.scope}`);
+    return;
+  }
+
+  console.log(`Importing ${memories.length} memories...`);
+
+  let imported = 0;
+  let skipped = 0;
+
+  if (!context.embedder) {
+    console.error("Import requires an embedder (not available in basic CLI mode).");
+    console.error("Use the plugin's memory_store tool or pass embedder to createMemoryCLI.");
+    return;
+  }
+
+  const targetScope = options.scope || context.scopeManager.getDefaultScope();
+
+  for (const memory of memories) {
+    try {
+      const text = memory.text;
+      if (!text || typeof text !== "string" || text.length < 2) {
+        skipped++;
+        continue;
+      }
+
+      const categoryRaw = memory.category;
+      const category: MemoryEntry["category"] =
+        categoryRaw === "preference" ||
+        categoryRaw === "fact" ||
+        categoryRaw === "decision" ||
+        categoryRaw === "entity" ||
+        categoryRaw === "other"
+          ? categoryRaw
+          : "other";
+
+      const importanceRaw = Number(memory.importance);
+      const importance = Number.isFinite(importanceRaw)
+        ? Math.max(0, Math.min(1, importanceRaw))
+        : 0.7;
+
+      const timestampRaw = Number(memory.timestamp);
+      const timestamp = Number.isFinite(timestampRaw) ? timestampRaw : Date.now();
+
+      const metadataRaw = memory.metadata;
+      const metadata =
+        typeof metadataRaw === "string"
+          ? metadataRaw
+          : metadataRaw != null
+            ? JSON.stringify(metadataRaw)
+            : "{}";
+
+      const idRaw = memory.id;
+      const id = typeof idRaw === "string" && idRaw.length > 0 ? idRaw : undefined;
+
+      if (id && (await context.store.hasId(id))) {
+        skipped++;
+        continue;
+      }
+
+      if (!id) {
+        const existing = await context.retriever.retrieve({
+          query: text,
+          limit: 1,
+          scopeFilter: [targetScope],
+        });
+        if (existing.length > 0 && existing[0].score > 0.95) {
+          skipped++;
+          continue;
+        }
+      }
+
+      const vector = await context.embedder.embedPassage(text);
+
+      if (id) {
+        await context.store.importEntry({
+          id,
+          text,
+          vector,
+          category,
+          scope: targetScope,
+          importance,
+          timestamp,
+          metadata,
+        });
+      } else {
+        await context.store.store({
+          text,
+          vector,
+          importance,
+          category,
+          scope: targetScope,
+          metadata,
+        });
+      }
+
+      imported++;
+    } catch (error) {
+      console.warn(`Failed to import memory: ${error}`);
+      skipped++;
+    }
+  }
+
+  console.log(`Import completed: ${imported} imported, ${skipped} skipped`);
 }
 
 // ============================================================================
@@ -349,118 +464,39 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
           throw new Error("Invalid import file format");
         }
 
-        if (options.dryRun) {
-          console.log("DRY RUN - No memories will be imported");
-          console.log(`Would import ${data.memories.length} memories`);
-          if (options.scope) {
-            console.log(`Target scope: ${options.scope}`);
-          }
-          return;
-        }
-
-        console.log(`Importing ${data.memories.length} memories...`);
-
-        let imported = 0;
-        let skipped = 0;
-
-        if (!context.embedder) {
-          console.error("Import requires an embedder (not available in basic CLI mode).");
-          console.error("Use the plugin's memory_store tool or pass embedder to createMemoryCLI.");
-          return;
-        }
-
-        const targetScope = options.scope || context.scopeManager.getDefaultScope();
-
-        for (const memory of data.memories) {
-          try {
-            const text = memory.text;
-            if (!text || typeof text !== "string" || text.length < 2) {
-              skipped++;
-              continue;
-            }
-
-            const categoryRaw = memory.category;
-            const category: MemoryEntry["category"] =
-              categoryRaw === "preference" ||
-              categoryRaw === "fact" ||
-              categoryRaw === "decision" ||
-              categoryRaw === "entity" ||
-              categoryRaw === "other"
-                ? categoryRaw
-                : "other";
-
-            const importanceRaw = Number(memory.importance);
-            const importance = Number.isFinite(importanceRaw)
-              ? Math.max(0, Math.min(1, importanceRaw))
-              : 0.7;
-
-            const timestampRaw = Number(memory.timestamp);
-            const timestamp = Number.isFinite(timestampRaw) ? timestampRaw : Date.now();
-
-            const metadataRaw = memory.metadata;
-            const metadata =
-              typeof metadataRaw === "string"
-                ? metadataRaw
-                : metadataRaw != null
-                  ? JSON.stringify(metadataRaw)
-                  : "{}";
-
-            const idRaw = memory.id;
-            const id = typeof idRaw === "string" && idRaw.length > 0 ? idRaw : undefined;
-
-            // Idempotency: if the import file includes an id and we already have it, skip.
-            if (id && (await context.store.hasId(id))) {
-              skipped++;
-              continue;
-            }
-
-            // Back-compat dedupe: if no id provided, do a best-effort similarity check.
-            if (!id) {
-              const existing = await context.retriever.retrieve({
-                query: text,
-                limit: 1,
-                scopeFilter: [targetScope],
-              });
-              if (existing.length > 0 && existing[0].score > 0.95) {
-                skipped++;
-                continue;
-              }
-            }
-
-            const vector = await context.embedder.embedPassage(text);
-
-            if (id) {
-              await context.store.importEntry({
-                id,
-                text,
-                vector,
-                category,
-                scope: targetScope,
-                importance,
-                timestamp,
-                metadata,
-              });
-            } else {
-              await context.store.store({
-                text,
-                vector,
-                importance,
-                category,
-                scope: targetScope,
-                metadata,
-              });
-            }
-
-            imported++;
-          } catch (error) {
-            console.warn(`Failed to import memory: ${error}`);
-            skipped++;
-          }
-        }
-
-        console.log(`Import completed: ${imported} imported, ${skipped} skipped`);
+        await importMemoryObjects(context, data.memories, options);
       } catch (error) {
         console.error("Import failed:", error);
+        process.exit(1);
+      }
+    });
+
+  // Import OpenClaw file-based memory
+  memory
+    .command("import-openclaw <workspace>")
+    .description("Import MEMORY.md and memory/*.md from an OpenClaw workspace")
+    .option("--scope <scope>", "Import into specific scope")
+    .option("--since <date>", "Only import daily files on/after YYYY-MM-DD")
+    .option("--dry-run", "Show what would be imported without actually importing")
+    .action(async (workspace, options) => {
+      try {
+        const memories = collectOpenClawMemories(workspace, { since: options.since });
+        if (options.dryRun) {
+          const byCategory = memories.reduce((acc: Record<string, number>, m) => {
+            acc[m.category] = (acc[m.category] || 0) + 1;
+            return acc;
+          }, {});
+          console.log("DRY RUN - No memories will be imported");
+          console.log(`Would import ${memories.length} memories from OpenClaw workspace`);
+          if (options.scope) console.log(`Target scope: ${options.scope}`);
+          if (options.since) console.log(`Since: ${options.since}`);
+          Object.entries(byCategory).forEach(([k, v]) => console.log(`  • ${k}: ${v}`));
+          return;
+        }
+
+        await importMemoryObjects(context, memories, options);
+      } catch (error) {
+        console.error("OpenClaw import failed:", error);
         process.exit(1);
       }
     });

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "scripts": {
-    "test": "node test/embedder-error-hints.test.mjs && node test/cli-smoke.mjs"
+    "test": "node test/embedder-error-hints.test.mjs && node test/cli-smoke.mjs && node test/access-tracker.test.mjs"
   },
   "devDependencies": {
     "commander": "^14.0.0",

--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -164,6 +164,7 @@ function getProviderLabel(baseURL: string | undefined, model: string): string {
   if (base) {
     if (/api\.jina\.ai/i.test(base)) return "Jina";
     if (/localhost:11434|127\.0\.0\.1:11434|\/ollama\b/i.test(base)) return "Ollama";
+    if (/generativelanguage\.googleapis\.com/i.test(base) || /^gemini-/i.test(model)) return "Gemini";
     if (/api\.openai\.com/i.test(base)) return "OpenAI";
 
     try {
@@ -174,6 +175,7 @@ function getProviderLabel(baseURL: string | undefined, model: string): string {
   }
 
   if (/^jina-/i.test(model)) return "Jina";
+  if (/^gemini-/i.test(model)) return "Gemini";
 
   return "embedding provider";
 }
@@ -197,6 +199,16 @@ function isNetworkError(error: unknown): boolean {
 
   const msg = getErrorMessage(error);
   return /ECONNREFUSED|ECONNRESET|ENOTFOUND|EHOSTUNREACH|ETIMEDOUT|fetch failed|network error|socket hang up|connection refused|getaddrinfo/i.test(msg);
+}
+
+function isNotFoundOrModelError(error: unknown): boolean {
+  const status = getErrorStatus(error);
+  if (status === 404 || status == 400) {
+    const msg = getErrorMessage(error);
+    return /model|not found|unsupported|unknown|invalid/i.test(msg);
+  }
+  const msg = getErrorMessage(error);
+  return /model.*not found|unsupported model|unknown model|invalid model/i.test(msg);
 }
 
 export function formatEmbeddingProviderError(
@@ -232,8 +244,15 @@ export function formatEmbeddingProviderError(
     } else if (provider === "Ollama") {
       hint +=
         " Ollama usually works with a dummy apiKey; verify the local server is running, the model is pulled, and embedding.dimensions matches the model output.";
+    } else if (provider === "Gemini") {
+      hint +=
+        " For Gemini, use an OpenAI-compatible baseURL such as https://generativelanguage.googleapis.com/v1beta/openai/, set embedding.model to gemini-embedding-001, set embedding.dimensions to 3072, and ensure GEMINI_API_KEY is valid in the gateway environment.";
     }
     return `Embedding provider authentication failed (${detailText}). ${hint}`;
+  }
+
+  if (isNotFoundOrModelError(error) && provider === "Gemini") {
+    return `Failed to generate embedding from ${provider} (${detailText}). Verify embedding.baseURL is https://generativelanguage.googleapis.com/v1beta/openai/, embedding.model is gemini-embedding-001, and embedding.dimensions is 3072.`;
   }
 
   if (isNetworkError(error)) {

--- a/src/import-openclaw.ts
+++ b/src/import-openclaw.ts
@@ -1,0 +1,108 @@
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
+import { join, basename } from "node:path";
+import type { MemoryEntry } from "./store.js";
+
+type ImportableMemory = Omit<MemoryEntry, "vector" | "scope">;
+
+interface CollectOptions {
+  since?: string;
+}
+
+function normalizeText(text: string): string {
+  return text.replace(/^[-*]\s+/, "").replace(/\s+/g, " ").trim();
+}
+
+function stableId(parts: string[]): string {
+  return createHash("sha256").update(parts.join("\n")).digest("hex").slice(0, 24);
+}
+
+function isDailyFile(name: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}\.md$/.test(name);
+}
+
+function parseDateMs(name: string): number | undefined {
+  const base = basename(name, ".md");
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(base)) return undefined;
+  const ms = new Date(`${base}T00:00:00Z`).getTime();
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+function classify(text: string, section: string, source: string): { category: ImportableMemory["category"]; importance: number } {
+  const content = `${section} ${text}`.toLowerCase();
+  if (
+    source.endsWith("MEMORY.md") ||
+    /user preferences|偏好|铁律|prefer|prefers|wants the assistant|requires strict|must|喜欢|要求/.test(content)
+  ) {
+    return { category: "preference", importance: 1.0 };
+  }
+  if (
+    /decid|agreed|updated|enabled|disabled|removed|installed|implemented|fixed|positioning|改成|启用|移除|安装|修复|实现|决定|同意/.test(content)
+  ) {
+    return { category: "decision", importance: 0.84 };
+  }
+  return { category: "fact", importance: 0.76 };
+}
+
+function parseBullets(content: string, source: string, timestamp: number): ImportableMemory[] {
+  const memories: ImportableMemory[] = [];
+  let section = "root";
+  let inCode = false;
+  const lines = content.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    if (/^```/.test(line.trim())) {
+      inCode = !inCode;
+      continue;
+    }
+    if (inCode) continue;
+
+    const heading = line.match(/^##\s+(.+)/);
+    if (heading) {
+      section = heading[1].trim();
+      continue;
+    }
+
+    const bullet = line.match(/^[-*]\s+(.+)/);
+    if (!bullet) continue;
+    const text = normalizeText(bullet[1]);
+    if (text.length < 8) continue;
+
+    const { category, importance } = classify(text, section, source);
+    const id = stableId([source, section, text]);
+    memories.push({
+      id,
+      text,
+      category,
+      importance,
+      timestamp,
+      metadata: JSON.stringify({ source, section, line: index + 1 }),
+    });
+  }
+
+  return memories;
+}
+
+export function collectOpenClawMemories(workspace: string, options: CollectOptions = {}): ImportableMemory[] {
+  const results: ImportableMemory[] = [];
+  const memoryFile = join(workspace, "MEMORY.md");
+  if (existsSync(memoryFile)) {
+    const stat = statSync(memoryFile);
+    results.push(...parseBullets(readFileSync(memoryFile, "utf8"), "MEMORY.md", Math.trunc(stat.mtimeMs)));
+  }
+
+  const memoryDir = join(workspace, "memory");
+  if (!existsSync(memoryDir)) return results;
+  const sinceMs = options.since ? parseDateMs(`${options.since}.md`) : undefined;
+
+  for (const file of readdirSync(memoryDir).filter(isDailyFile).sort()) {
+    const fileDate = parseDateMs(file);
+    if (sinceMs && fileDate && fileDate < sinceMs) continue;
+    const full = join(memoryDir, file);
+    const timestamp = fileDate ?? Math.trunc(statSync(full).mtimeMs);
+    results.push(...parseBullets(readFileSync(full, "utf8"), `memory/${file}`, timestamp));
+  }
+
+  return results;
+}

--- a/test/cli-smoke.mjs
+++ b/test/cli-smoke.mjs
@@ -151,7 +151,43 @@ async function runCliSmoke() {
   ]);
   assert.match(out2, /Import completed: 0 imported, 1 skipped/, out2);
 
-  // 4) Access reinforcement formula smoke test
+  // 4) import-openclaw should parse MEMORY.md + daily notes
+  const ocWorkspace = path.join(workDir, "openclaw-workspace");
+  const fs = await import("node:fs");
+  fs.mkdirSync(path.join(ocWorkspace, "memory"), { recursive: true });
+  fs.writeFileSync(
+    path.join(ocWorkspace, "MEMORY.md"),
+    "# MEMORY\n\n## User Preferences\n- Xiaoyf prefers concise technical replies.\n",
+  );
+  fs.writeFileSync(
+    path.join(ocWorkspace, "memory", "2026-03-06.md"),
+    "# 2026-03-06\n\n## Daily Summary\n- Enabled memory-lancedb-pro with Gemini embeddings.\n",
+  );
+
+  const out3 = await captureLogs([
+    "node",
+    "openclaw",
+    "memory-pro",
+    "import-openclaw",
+    ocWorkspace,
+    "--scope",
+    "agent:smoke",
+  ]);
+  assert.match(out3, /Import completed: 2 imported/, out3);
+
+  const out4 = await captureLogs([
+    "node",
+    "openclaw",
+    "memory-pro",
+    "import-openclaw",
+    ocWorkspace,
+    "--scope",
+    "agent:smoke",
+    "--dry-run",
+  ]);
+  assert.match(out4, /Would import 2 memories/, out4);
+
+  // 5) Access reinforcement formula smoke test
   const { parseAccessMetadata, buildUpdatedMetadata, computeEffectiveHalfLife } =
     jiti("../src/access-tracker.ts");
 

--- a/test/embedder-error-hints.test.mjs
+++ b/test/embedder-error-hints.test.mjs
@@ -100,6 +100,30 @@ async function run() {
   );
   assert.match(formattedBatch, /^Failed to generate batch embeddings from /, formattedBatch);
 
+  const geminiAuth = formatEmbeddingProviderError(
+    Object.assign(new Error("403 API key invalid"), {
+      status: 403,
+      code: "invalid_api_key",
+    }),
+    {
+      baseURL: "https://generativelanguage.googleapis.com/v1beta/openai/",
+      model: "gemini-embedding-001",
+    },
+  );
+  assert.match(geminiAuth, /Gemini/i, geminiAuth);
+  assert.match(geminiAuth, /gemini-embedding-001/i, geminiAuth);
+  assert.match(geminiAuth, /3072/i, geminiAuth);
+
+  const geminiNotFound = formatEmbeddingProviderError(
+    Object.assign(new Error("404 model not found"), { status: 404 }),
+    {
+      baseURL: "https://generativelanguage.googleapis.com/v1beta/openai/",
+      model: "bad-model",
+    },
+  );
+  assert.match(geminiNotFound, /v1beta\/openai\//i, geminiNotFound);
+  assert.match(geminiNotFound, /gemini-embedding-001/i, geminiNotFound);
+
   console.log("OK: embedder auth/network error hints verified");
 }
 


### PR DESCRIPTION
## Summary
This PR adds two user-facing improvements:

1. `memory-pro import-openclaw <workspace>` to import `MEMORY.md` and `memory/*.md` from an OpenClaw workspace into LanceDB Pro
2. better Gemini embedding diagnostics and setup guidance

## Changes
- add `src/import-openclaw.ts` for conservative OpenClaw file-memory parsing
- add `memory-pro import-openclaw` CLI command with `--scope`, `--since`, and `--dry-run`
- refactor CLI import path so JSON import and OpenClaw import share the same import pipeline
- improve Gemini-specific embedding error messages (auth + model/baseURL misconfiguration)
- add README / README_CN examples for `import-openclaw` and Gemini troubleshooting
- extend smoke/error-hint tests

## Why
- many OpenClaw users already have file-based memory in `MEMORY.md` and `memory/YYYY-MM-DD.md`, but migration currently requires manual JSON conversion
- Gemini is already supported, but setup errors are still easy to make in practice (wrong OpenAI-compatible baseURL, wrong model name, missing dimensions, shell-only env vars)

## Testing
- `npm test`

Closes #82
Closes #83
