### PR TITLE
fix: honor embedding chunking config

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -42,6 +42,7 @@ interface PluginConfig {
     taskQuery?: string;
     taskPassage?: string;
     normalized?: boolean;
+    chunking?: boolean;
   };
   dbPath?: string;
   autoCapture?: boolean;
@@ -1226,6 +1227,7 @@ const memoryLanceDBProPlugin = {
       taskQuery: config.embedding.taskQuery,
       taskPassage: config.embedding.taskPassage,
       normalized: config.embedding.normalized,
+      chunking: config.embedding.chunking,
     });
     const retriever = createRetriever(store, embedder, {
       ...DEFAULT_RETRIEVAL_CONFIG,
@@ -2411,6 +2413,10 @@ export function parsePluginConfig(value: unknown): PluginConfig {
       normalized:
         typeof embedding.normalized === "boolean"
           ? embedding.normalized
+          : undefined,
+      chunking:
+        typeof embedding.chunking === "boolean"
+          ? embedding.chunking
           : undefined,
     },
     dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : undefined,

--- a/test/config-session-strategy-migration.test.mjs
+++ b/test/config-session-strategy-migration.test.mjs
@@ -52,4 +52,15 @@ describe("sessionStrategy legacy compatibility mapping", () => {
     const parsed = parsePluginConfig(baseConfig());
     assert.equal(parsed.sessionStrategy, "systemSessionMemory");
   });
+
+  it("preserves embedding.chunking when explicitly configured", () => {
+    const parsed = parsePluginConfig({
+      ...baseConfig(),
+      embedding: {
+        ...baseConfig().embedding,
+        chunking: false,
+      },
+    });
+    assert.equal(parsed.embedding.chunking, false);
+  });
 });


### PR DESCRIPTION
## Summary
- preserve `embedding.chunking` during plugin config parsing
- pass the chunking flag through to embedder initialization
- add a regression test to keep the config from being silently dropped

## Testing
- node --test test/config-session-strategy-migration.test.mjs
- npm test
