### PR TITLE
fix(retrieval): don't skip hybrid on cold start

### DIFF
--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -297,7 +297,12 @@ export class MemoryRetriever {
     const safeLimit = clampInt(limit, 1, 20);
 
     let results: RetrievalResult[];
-    if (this.config.mode === "vector" || !this.store.hasFtsSupport) {
+    // Vector-only mode: force the legacy path.
+    // Note: do NOT gate hybrid retrieval on store.hasFtsSupport here.
+    // On cold-start (e.g. one-shot CLI), hasFtsSupport may be false until the
+    // store initializes / creates the FTS index, which would incorrectly skip
+    // BM25 + reranking.
+    if (this.config.mode === "vector") {
       results = await this.vectorOnlyRetrieval(
         query,
         safeLimit,


### PR DESCRIPTION
Problem
- One-shot CLI `openclaw memory-pro search` could incorrectly fall back to vector-only on cold start, skipping BM25 + rerank, because `store.hasFtsSupport` may be false before store init/FTS index creation.

Fix
- Only force vector-only when `retrieval.mode === "vector"`.
- Always run hybrid retrieval otherwise; BM25 safely returns [] when unavailable.

Verification
- `openclaw memory-pro search <token>` now consistently shows sources `vector+BM25+reranked` (previously could be `vector` only).
- Gateway restarted after clearing /tmp/jiti; plugin initialized OK.