### PR TITLE
docs: mention dev dist-tag (smart-memory preview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,9 @@ Add a line to your agent system prompt, e.g.:
 >
 > See [Release Notes](https://github.com/win4r/memory-lancedb-pro/releases/tag/v1.1.0-beta.6) for details. Feedback welcome via [GitHub Issues](https://github.com/win4r/memory-lancedb-pro/issues).
 
+> The `dev` dist-tag is an experimental track intended for early testing of the smart-memory feature set and may diverge from the mainline beta.
+
+
 ### AI-safe install notes (anti-hallucination)
 
 If you are following this README using an AI assistant, **do not assume defaults**. Always run these commands first and use the real output:

--- a/README_CN.md
+++ b/README_CN.md
@@ -340,6 +340,9 @@ Query → BM25 FTS ─────┘
 >
 > 详见 [Release Notes](https://github.com/win4r/memory-lancedb-pro/releases/tag/v1.1.0-beta.6)。欢迎通过 [GitHub Issues](https://github.com/win4r/memory-lancedb-pro/issues) 反馈问题。
 
+> `dev` dist-tag 是实验性渠道，用于提前测试 smart-memory 相关能力，可能与主线 beta 不完全同步。
+
+
 ### AI 安装指引（防幻觉版）
 
 如果你是用 AI 按 README 操作，**不要假设任何默认值**。请先运行以下命令，并以真实输出为准：


### PR DESCRIPTION
Updates README/README_CN to include an optional dev dist-tag install line and clarifies that the dev channel is experimental.