### PR TITLE
feat(recall): improve auto-recall diversity with set-wise final selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Refactor: build reset/new reflection handoff note in `runMemoryReflection`.
 - Refactor: `<open-loops>` now comes from the fresh reflection run, while `<derived-focus>` comes from historical scored itemized derived rows.
 - Refactor: upgrade historical `<derived-focus>` ranking to Derived-Focus V2 (conservative strict/soft normalization, non-linear group scoring, diversity-aware shortlist up to 36 before final note injection capped at 13, with no hard `score > 0.3` gate).
+- Refactor: introduce a shared final set-wise top-k selector for generic Auto-Recall and dynamic Reflection-Recall, with deterministic output order and preserved reflection `kind + strictKey` partitioning.
+- Refactor: add a shared set-wise final selector implementation that can provide lexical-overlap suppression, embedding-based semantic near-duplicate suppression, deterministic ordering, and lexical-only fallback when vectors are missing/invalid.
+- Compatibility: generic Auto-Recall now exposes `autoRecallSelectionMode` (`legacy` default, `setwise-v2` opt-in); the enhanced lexical/semantic final-selection behavior is enabled only in `setwise-v2`. Reflection-Recall `fixed | dynamic` semantics remain unchanged.
 - Breaking: stop writing and stop reading legacy combined reflection rows (`type=memory-reflection`).
 - Docs: refresh README / README_CN for the new handoff-note behavior and remove old legacy combined guidance.
 

--- a/README.md
+++ b/README.md
@@ -55,38 +55,56 @@ The built-in `memory-lancedb` plugin in OpenClaw provides basic vector search. *
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                   index.ts (Entry Point)                │
-│  Plugin Registration · Config Parsing · Lifecycle Hooks │
-└────────┬──────────┬──────────┬──────────┬───────────────┘
-         │          │          │          │
-    ┌────▼───┐ ┌────▼───┐ ┌───▼────┐ ┌──▼──────────┐
-    │ store  │ │embedder│ │retriever│ │   scopes    │
-    │ .ts    │ │ .ts    │ │ .ts    │ │    .ts      │
-    └────────┘ └────────┘ └────────┘ └─────────────┘
-         │                     │
-    ┌────▼───┐           ┌─────▼──────────┐
-    │migrate │           │noise-filter.ts │
-    │ .ts    │           │adaptive-       │
-    └────────┘           │retrieval.ts    │
-                         └────────────────┘
-    ┌─────────────┐   ┌──────────┐
-    │  tools.ts   │   │  cli.ts  │
-    │ (Agent API) │   │ (CLI)    │
-    └─────────────┘   └──────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│                         index.ts (Entry Point)                      │
+│     Plugin registration · config parsing · lifecycle orchestration  │
+└────────┬───────────────────────────────┬─────────────────────────────┘
+         │                               │
+         │ generic auto-recall           │ reflection / inherited-rules
+         │                               │
+┌────────▼────────┐              ┌───────▼───────────────────────────┐
+│   retriever.ts  │              │       reflection-recall.ts        │
+│ vector/BM25/RRF │              │ dynamic reflection recall ranking │
+│ rerank/filters  │              └───────────────┬───────────────────┘
+└────────┬────────┘                              │
+         │                               ┌──────▼────────────────────┐
+┌────────▼───────────────┐               │ reflection-aggregation.ts │
+│ postProcessAutoRecall  │               │ strictKey-group scoring   │
+│ (index.ts local step)  │               └──────┬────────────────────┘
+└────────┬───────────────┘                      │
+         │                               ┌──────▼───────────────────────┐
+         │ legacy | setwise-v2           │ reflection-recall-final-     │
+┌────────▼────────────────────┐           │ selection.ts                 │
+│ auto-recall-final-          │           └──────┬───────────────────────┘
+│ selection.ts                │                  │
+└────────┬────────────────────┘           ┌──────▼───────────────────────┐
+         └────────────────────────────────► final-topk-setwise-         │
+                                          │ selection.ts                │
+                                          │ shared final top-k selector │
+                                          └─────────────────────────────┘
+
+Shared infrastructure: `store.ts`, `embedder.ts`, `scopes.ts`, `tools.ts`,
+`noise-filter.ts`, `adaptive-retrieval.ts`, `recall-engine.ts`, `migrate.ts`, `cli.ts`
 ```
 
 ### File Reference
 
 | File | Purpose |
 |------|---------|
-| `index.ts` | Plugin entry point. Registers with OpenClaw Plugin API, parses config, mounts `before_agent_start` (auto-recall), `agent_end` (auto-capture), integrated `self-improvement` (`agent:bootstrap`, `command:new/reset`) and integrated `memory-reflection` (`command:new/reset`) hooks |
+| `index.ts` | Plugin entry point. Registers with OpenClaw Plugin API, parses config, mounts `before_agent_start` / `agent_end` hooks, routes generic auto-recall through `legacy | setwise-v2`, and coordinates reflection injection flows |
 | `openclaw.plugin.json` | Plugin metadata + full JSON Schema config declaration (with `uiHints`) |
 | `package.json` | NPM package info. Depends on `@lancedb/lancedb`, `openai`, `@sinclair/typebox` |
 | `cli.ts` | CLI commands: `memory list/search/stats/delete/delete-bulk/export/import/reembed/migrate` |
 | `src/store.ts` | LanceDB storage layer. Table creation / FTS indexing / Vector search / BM25 search / CRUD / bulk delete / stats |
 | `src/embedder.ts` | Embedding abstraction. Compatible with any OpenAI-API provider (OpenAI, Gemini, Jina, Ollama, etc.). Supports task-aware embedding (`taskQuery`/`taskPassage`) |
-| `src/retriever.ts` | Hybrid retrieval engine. Vector + BM25 → RRF fusion → Jina Cross-Encoder Rerank → Recency Boost → Importance Weight → Length Norm → Time Decay → Hard Min Score → Noise Filter → MMR Diversity |
+| `src/retriever.ts` | Hybrid retrieval engine. Vector + BM25 → RRF fusion → rerank → recency / importance / length / decay weighting → noise filter → coarse MMR diversity. |
+| `src/recall-engine.ts` | Shared recall helpers: prompt gating, session repeated-injection suppression, tagged-block assembly, max-age filtering, and recent-per-key capping |
+| `src/auto-recall-final-selection.ts` | Generic auto-recall adapter. Maps `RetrievalResult` rows into final-selection candidates and applies generic `legacy | setwise-v2` behavior at the final cutoff seam |
+| `src/final-topk-setwise-selection.ts` | Shared final top-k selector. Owns shortlist presort, deterministic set-wise selection, lexical-overlap suppression, and optional embedding-based semantic redundancy suppression |
+| `src/reflection-recall.ts` | Dynamic Reflection-Recall ranking for `<inherited-rules>`. Filters/caps reflection items, computes scores, preserves `kind + strictKey` partitioning, and maps selected groups back to recall rows |
+| `src/reflection-aggregation.ts` | Reflection group aggregation. Combines scored reflection items into strict-key groups with representative selection and final group scoring |
+| `src/reflection-recall-final-selection.ts` | Reflection-specific adapter into the shared final selector for dynamic Reflection-Recall final top-k ordering |
+| `src/reflection-selection.ts` | Historical derived-focus diversity ordering helper retained for reflection-store / handoff-note selection flows |
 | `src/scopes.ts` | Multi-scope access control. Supports `global`, `agent:<id>`, `custom:<name>`, `project:<id>`, `user:<id>` |
 | `src/tools.ts` | Agent tool definitions: `memory_recall`, `memory_store`, `memory_forget` (core), `self_improvement_log` (default), and governance tools `self_improvement_review` / `self_improvement_extract_skill` (management mode) |
 | `src/noise-filter.ts` | Noise filter. Filters out agent refusals, meta-questions, greetings, and low-quality content |
@@ -148,117 +166,127 @@ Filters out low-quality content at both auto-capture and tool-store stages:
 
 ### 7. Session Strategy
 
-- `sessionStrategy: "systemSessionMemory"` (default): do not register plugin reflection hooks; use OpenClaw built-in `session-memory`.
-- `sessionStrategy: "memoryReflection"`: enable plugin reflection hooks for `/new` / `/reset`.
-- `sessionStrategy: "none"`: disable plugin session strategy hooks entirely.
-- Legacy compatibility: `sessionMemory.enabled=true|false` maps to `systemSessionMemory|none`.
-- `sessionMemory.messageCount` is also kept as a legacy compatibility field and maps to `memoryReflection.messageCount`.
-- Practical rule: `memoryReflection.*` settings only take effect when `sessionStrategy="memoryReflection"`.
+Use this to choose who owns `/new` / `/reset` session behavior.
+
+- `sessionStrategy: "systemSessionMemory"` (default)
+  - use OpenClaw built-in `session-memory`
+  - plugin reflection hooks stay off
+- `sessionStrategy: "memoryReflection"`
+  - enable plugin reflection flow
+  - `memoryReflection.*` settings take effect only in this mode
+- `sessionStrategy: "none"`
+  - disable plugin session strategy hooks entirely
+
+ Legacy compatibility:
+- `sessionMemory.enabled=true|false` still maps to `systemSessionMemory|none`
+- `sessionMemory.messageCount` still maps to `memoryReflection.messageCount`
+
+Recommended starter config:
+
+```json
+{
+  "sessionStrategy": "memoryReflection"
+}
+```
 
 ### 8. Self-Improvement
 
-- Hooks: `agent:bootstrap`, `command:new`, `command:reset`.
-- `agent:bootstrap`: injects `SELF_IMPROVEMENT_REMINDER.md` into bootstrap context.
-- `command:new` / `command:reset`: appends a short `/note self-improvement ...` reminder before reset.
-  - Under `sessionStrategy="memoryReflection"`, the final reset/new note is assembled in `runMemoryReflection`.
-  - In `memoryReflection.injectMode="inheritance+derived"` mode, the note can include:
-    - `<open-loops>` from the **fresh** reflection text of the current `/new` or `/reset`.
-    - `<derived-focus>` from **historical** LanceDB derived rows after dedupe+decay scoring (shortlist up to 36, final injection capped at 13, no hard score threshold gate).
-- File ensure/create path: ensures `.learnings/LEARNINGS.md` and `.learnings/ERRORS.md` exist.
-- This flow is separate from `memoryReflection`: seeing self-improvement notes or `.learnings/*` activity does not by itself mean reflection storage is enabled.
-- Append paths are intentionally distinct:
-  - explicit tool write: `self_improvement_log`
-  - reflection-driven automatic append: structured governance candidates from reflection
-  - file/template ensure path: bootstrap-time file creation
-- Tools:
-  - `self_improvement_log`: writes structured `learning` / `error` entries.
-  - `self_improvement_review`: summarizes governance backlog (pending/high/promoted).
-  - `self_improvement_extract_skill`: extracts a reusable `SKILL.md` scaffold from a learning entry via explicit tool call.
-- Reflection auto-append behavior:
-  - Source section: `## Learning governance candidates (.learnings / promotion / skill extraction)`.
-  - Preferred format: structured per-entry records (`### Entry N`, `Priority`, `Status`, `Area`, `Summary`, `Details`, `Suggested Action`).
-  - Backward compatibility: legacy bullet-style governance content is still accepted as a fallback parse path.
-  - One parsed governance candidate becomes one appended `.learnings/LEARNINGS.md` entry.
-  - `Logged` timestamps and entry ids are generated by the writer, not by the reflection text.
+Use this when you want the plugin to keep a lightweight governance trail of learnings and errors.
+
+- Main tools:
+  - `self_improvement_log`: append a structured learning/error entry
+  - `self_improvement_review`: summarize pending governance backlog
+  - `self_improvement_extract_skill`: scaffold a reusable skill from a proven learning entry
+- Main config:
+  - `selfImprovement.enabled`: master switch
+  - `selfImprovement.beforeResetNote`: show a reminder before `/new` or `/reset`
+  - `selfImprovement.ensureLearningFiles`: auto-create `.learnings/` files
+  - `selfImprovement.managementTools`: expose review/extract tools
+- Main outputs:
+  - `.learnings/LEARNINGS.md`
+  - `.learnings/ERRORS.md`
+  - extracted skill scaffold under `.learnings/skills/...`
+
+Recommended starter config:
+
+```json
+{
+  "selfImprovement": {
+    "enabled": true,
+    "beforeResetNote": true,
+    "ensureLearningFiles": true,
+    "managementTools": true
+  }
+}
+```
 
 ### 9. memoryReflection
 
-- Activation:
-  - Requires `sessionStrategy="memoryReflection"`.
-  - Triggers on `command:new` / `command:reset`.
-  - Skips generation when session context is incomplete (for example missing config, session file, or readable conversation content).
-  - Edge case: issuing `/new` immediately after a previous `/new` can land in a fresh empty session without a readable prior `sessionFile`; in that case reflection skips and logs `missing session file after recovery`. This is expected behavior.
-- Runner chain:
-  - First try embedded runner (`runEmbeddedPiAgent`).
-  - If the embedded path fails, fall back to `openclaw agent --local --json`.
-  - If both fail, write a minimal fallback reflection artifact.
-- Markdown artifact:
-  - Written under `memory/reflections/YYYY-MM-DD/`.
-  - Filename uses high-resolution timestamp + agent/session token, for example `HHMMSSmmm-agent-session[-xxxxxx].md`.
-- Prompt/output contract:
-  - Required headings are fixed and parsed by exact section names.
-  - `Invariants` = stable cross-session rules.
-  - `Derived` = recent-run distilled learnings / adjustments / follow-up heuristics that may help the next several runs, but should decay over time.
-  - Governance candidates use a structured entry template so they can be appended safely into `.learnings`.
-  - Writer-owned metadata such as `Logged` timestamps and ids is intentionally generated by the persistence layer, not by the model.
-- LanceDB persistence (optional):
-  - Controlled by `memoryReflection.storeToLanceDB`.
-  - Writes one event row (`type=memory-reflection-event`) plus item rows (`type=memory-reflection-item`) for each `Invariants` / `Derived` bullet.
-  - Event rows keep lightweight provenance/audit metadata only (`eventId`, `sessionKey`, `usedFallback`, `errorSignals`, source path).
-  - Item rows carry per-item decay metadata (`decayModel`, `decayMidpointDays`, `decayK`, `baseWeight`, `quality`) plus ordinal/group metadata.
-  - Reflection rows display as `reflection:<scope>`.
-- Reflection-derived durable memory mapping:
-  - Available memory categories in the plugin are `preference`, `fact`, `decision`, `entity`, `reflection`, `other`.
-  - Reflection auto-mapping intentionally writes only:
-    - `User model deltas` → `preference`
-    - `Agent model deltas` → `preference`
-    - `Lessons & pitfalls` → `fact`
-    - `Decisions (durable)` → `decision`
-  - `Context`, `Open loops`, `Retrieval tags`, `Invariants`, and `Derived` are not auto-mapped as ordinary durable memory categories.
-- Decay algorithm and built-in profiles:
-  - Reflection loading/injection uses logistic decay only; this does **not** modify the global retriever scoring pipeline.
-  - Formula: `weight = 1 / (1 + exp(k * (ageDays - midpointDays)))`
-  - Built-in reflection item profiles:
-    - `invariant`: midpointDays=`45`, `k=0.22`, `baseWeight=1.10`, `quality=1.00`
-    - `derived`: midpointDays=`7`, `k=0.65`, `baseWeight=1.00`, `quality=0.95`
-  - Built-in mapped durable-memory profiles:
-    - `decision`: midpointDays=`45`, `k=0.25`, `baseWeight=1.10`, `quality=1.00`
-    - `user-model`: midpointDays=`21`, `k=0.30`, `baseWeight=1.00`, `quality=0.95`
-    - `agent-model`: midpointDays=`10`, `k=0.35`, `baseWeight=0.95`, `quality=0.93`
-    - `lesson`: midpointDays=`7`, `k=0.45`, `baseWeight=0.90`, `quality=0.90`
-  - These decay parameters are currently implementation-defined metadata written by the plugin, not user-configurable `memoryReflection.*` schema fields.
-  - Fallback-generated rows receive an extra score penalty factor (`0.75`).
-- Dedicated agent (optional):
-  - `memoryReflection.agentId` can point to a dedicated reflection agent such as `memory-distiller`.
-  - If the configured agent id is not present in `cfg.agents.list`, the plugin warns and falls back to the runtime agent id.
-- Error loop:
-  - `after_tool_call` captures and deduplicates tool error signatures for reminder/reflection context.
-- Injection placement by hook (`memoryReflection.injectMode`):
-  - `before_agent_start`: injects `<inherited-rules>` via Reflection-Recall.
-  - `memoryReflection.recall.mode="fixed"` (default): compatibility path; fixed inheritance remains active even when generic Auto-Recall is disabled.
-  - `memoryReflection.recall.mode="dynamic"`: prompt-gated dynamic Reflection-Recall with independent top-k/session suppression budget from generic Auto-Recall.
-    - Ranking reuses the shared normalization/aggregation/selection helpers, including diversity-aware final ordering.
-    - Recall grouping is partitioned by `kind + strictKey`, so invariant/derived rows with identical normalized text stay separate.
-  - `command:new` / `command:reset`: `runMemoryReflection` builds the self-improvement note (`<open-loops>` from fresh reflection; `<derived-focus>` from historical scored rows when mode is `inheritance+derived`).
-  - `before_prompt_build`: injects `<error-detected>` only (no `<derived-focus>`).
+Use this when you want reflection-based rule inheritance and optional reflection persistence.
+
+What to configure first:
+- `memoryReflection.enabled`: turn reflection features on/off
+- `memoryReflection.injectMode`:
+  - `inheritance-only` = inject inherited rules only
+  - `inheritance+derived` = inherited rules + derived-focus note on `/new` / `/reset`
+- `memoryReflection.recall.mode`:
+  - `fixed` = compatibility path
+  - `dynamic` = prompt-gated `<inherited-rules>` recall
+- `memoryReflection.storeToLanceDB`: store reflection event/item rows in LanceDB
+- `memoryReflection.agentId` (optional): use a dedicated reflection agent
+
+Recommended starter config:
+
+```json
+{
+  "memoryReflection": {
+    "enabled": true,
+    "injectMode": "inheritance-only",
+    "storeToLanceDB": true,
+    "recall": {
+      "mode": "dynamic",
+      "topK": 6,
+      "includeKinds": ["invariant", "derived"],
+      "maxAgeDays": 14,
+      "maxEntriesPerKey": 7,
+      "minRepeated": 3,
+      "minScore": 0.22,
+      "minPromptLength": 12
+    }
+  }
+}
+```
+
+Quick behavior guide:
+- `before_agent_start` can inject `<inherited-rules>`
+- `/new` / `/reset` can build the reflection note
+- `before_prompt_build` only injects `<error-detected>` reminders
+- dynamic recall keeps `kind + strictKey` separation for invariant/derived rows
 
 ### 10. Markdown Mirror (`mdMirror`)
 
-- Purpose:
-  - Dual-write memory entries to readable Markdown files in addition to LanceDB.
-  - Useful for audit/debug/manual review.
-- Write paths:
-  - Preferred: mapped agent workspace `memory/YYYY-MM-DD.md`.
-  - Fallback: `mdMirror.dir` (default: `memory-md`) when agent workspace mapping is unavailable.
-- Trigger points:
-  - `memory_store` tool writes.
-  - Auto-capture writes from `agent_end`.
-- Compatibility:
-  - Does not replace LanceDB storage or retrieval flow.
-  - Existing retrieval remains vector/BM25/rerank based.
-- Config:
-  - `mdMirror.enabled`: enable/disable dual-write (`false` by default).
-  - `mdMirror.dir`: fallback directory for Markdown mirror files.
+Use this when you want a readable Markdown copy of memories in addition to LanceDB.
+
+Main config:
+- `mdMirror.enabled`: turn Markdown dual-write on/off
+- `mdMirror.dir`: fallback output directory when the agent workspace path is unavailable
+
+What it does:
+- writes memory entries to readable Markdown files
+- prefers `memory/YYYY-MM-DD.md` in the mapped workspace
+- falls back to `mdMirror.dir` when needed
+- does not replace LanceDB retrieval/storage
+
+Recommended starter config:
+
+```json
+{
+  "mdMirror": {
+    "enabled": true,
+    "dir": "memory-md"
+  }
+}
+```
 
 ### 11. Long Context Chunking
 
@@ -288,9 +316,13 @@ When embedding calls fail, the plugin provides **actionable error messages** ins
   - Skips memory-management prompts (e.g. delete/forget/cleanup memory entries) to reduce noise
 - **Auto-Recall** (`before_agent_start` hook): Injects `<relevant-memories>` context
   - Default top-k: `autoRecallTopK=3`
+  - Generic final-selection mode: `autoRecallSelectionMode` (`legacy` by default; `setwise-v2` to enable set-wise final selector)
   - Default category allowlist: `preference`, `fact`, `decision`, `entity`, `other`
   - `autoRecallExcludeReflection=true` by default, so `<relevant-memories>` stays separate from `<inherited-rules>`
   - Supports age window (`autoRecallMaxAgeDays`) and recent-per-key cap (`autoRecallMaxEntriesPerKey`)
+  - `legacy`: post-processed rows use direct truncation (`slice(0, topK)`) for compatibility
+  - `setwise-v2`: final top-k uses shared set-wise selection (base score + freshness + light category/scope coverage + lexical overlap suppression + embedding-based semantic near-duplicate suppression), with deterministic output order and safe lexical-only fallback when vectors are missing
+  - This mode is generic auto-recall only. Reflection-Recall mode remains `fixed | dynamic`.
 
 ### Prevent memories from showing up in replies
 
@@ -489,6 +521,7 @@ openclaw config get plugins.slots.memory
   "autoRecall": false,
   "autoRecallMinLength": 8,
   "autoRecallTopK": 3,
+  "autoRecallSelectionMode": "legacy",
   "autoRecallCategories": ["preference", "fact", "decision", "entity", "other"],
   "autoRecallExcludeReflection": true,
   "autoRecallMaxAgeDays": 30,
@@ -579,6 +612,7 @@ A practical starting point for Chinese chat workloads:
   "autoCapture": true,
   "autoRecall": true,
   "autoRecallMinLength": 8,
+  "autoRecallSelectionMode": "legacy",
   "autoRecallExcludeReflection": true,
   "retrieval": {
     "candidatePoolSize": 20,

--- a/README_CN.md
+++ b/README_CN.md
@@ -55,38 +55,56 @@ OpenClaw 内置的 `memory-lancedb` 插件仅提供基本的向量搜索。**mem
 ## 架构概览
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                   index.ts (入口)                        │
-│  插件注册 · 配置解析 · 生命周期钩子 · 自动捕获/回忆       │
-└────────┬──────────┬──────────┬──────────┬───────────────┘
-         │          │          │          │
-    ┌────▼───┐ ┌────▼───┐ ┌───▼────┐ ┌──▼──────────┐
-    │ store  │ │embedder│ │retriever│ │   scopes    │
-    │ .ts    │ │ .ts    │ │ .ts    │ │    .ts      │
-    └────────┘ └────────┘ └────────┘ └─────────────┘
-         │                     │
-    ┌────▼───┐           ┌─────▼──────────┐
-    │migrate │           │noise-filter.ts │
-    │ .ts    │           │adaptive-       │
-    └────────┘           │retrieval.ts    │
-                         └────────────────┘
-    ┌─────────────┐   ┌──────────┐
-    │  tools.ts   │   │  cli.ts  │
-    │ (Agent API) │   │ (CLI)    │
-    └─────────────┘   └──────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│                           index.ts（入口）                          │
+│              插件注册 · 配置解析 · 生命周期与注入流程编排           │
+└────────┬───────────────────────────────┬─────────────────────────────┘
+         │                               │
+         │ generic auto-recall           │ reflection / inherited-rules
+         │                               │
+┌────────▼────────┐              ┌───────▼───────────────────────────┐
+│   retriever.ts  │              │       reflection-recall.ts        │
+│ 向量/BM25/RRF   │              │ 动态 Reflection-Recall 排序       │
+│ rerank/filters  │              └───────────────┬───────────────────┘
+└────────┬────────┘                              │
+         │                               ┌──────▼────────────────────┐
+┌────────▼───────────────┐               │ reflection-aggregation.ts │
+│ postProcessAutoRecall  │               │ strictKey 分组与打分      │
+│ （index.ts 本地步骤）  │               └──────┬────────────────────┘
+└────────┬───────────────┘                      │
+         │                               ┌──────▼───────────────────────┐
+         │ legacy | setwise-v2           │ reflection-recall-final-     │
+┌────────▼────────────────────┐           │ selection.ts                 │
+│ auto-recall-final-          │           └──────┬───────────────────────┘
+│ selection.ts                │                  │
+└────────┬────────────────────┘           ┌──────▼───────────────────────┐
+         └────────────────────────────────► final-topk-setwise-         │
+                                          │ selection.ts                │
+                                          │ 共享最终 top-k 选择器       │
+                                          └─────────────────────────────┘
+
+共享基础设施：`store.ts`、`embedder.ts`、`scopes.ts`、`tools.ts`、
+`noise-filter.ts`、`adaptive-retrieval.ts`、`recall-engine.ts`、`migrate.ts`、`cli.ts`
 ```
 
 ### 文件说明
 
 | 文件 | 用途 |
 |------|------|
-| `index.ts` | 插件入口。注册到 OpenClaw Plugin API，解析配置，挂载 `before_agent_start`（自动回忆）、`agent_end`（自动捕获）、集成 `self-improvement`（`agent:bootstrap`、`command:new/reset`）和集成 `memory-reflection`（`command:new/reset`）钩子 |
+| `index.ts` | 插件入口。注册到 OpenClaw Plugin API，解析配置，挂载 `before_agent_start` / `agent_end` 钩子，负责 generic auto-recall 的 `legacy | setwise-v2` 分流，并编排 reflection 注入流程 |
 | `openclaw.plugin.json` | 插件元数据 + 完整 JSON Schema 配置声明（含 `uiHints`） |
 | `package.json` | NPM 包信息，依赖 `@lancedb/lancedb`、`openai`、`@sinclair/typebox` |
 | `cli.ts` | CLI 命令实现：`memory list/search/stats/delete/delete-bulk/export/import/reembed/migrate` |
 | `src/store.ts` | LanceDB 存储层。表创建 / FTS 索引 / Vector Search / BM25 Search / CRUD / 批量删除 / 统计 |
 | `src/embedder.ts` | Embedding 抽象层。兼容 OpenAI API 的任意 Provider（OpenAI、Gemini、Jina、Ollama 等），支持 task-aware embedding（`taskQuery`/`taskPassage`） |
-| `src/retriever.ts` | 混合检索引擎。Vector + BM25 → RRF 融合 → Jina Cross-Encoder Rerank → Recency Boost → Importance Weight → Length Norm → Time Decay → Hard Min Score → Noise Filter → MMR Diversity |
+| `src/retriever.ts` | 混合检索引擎。Vector + BM25 → RRF 融合 → rerank → 时效 / 重要性 / 长度 / 衰减加权 → 噪声过滤 → 粗粒度 MMR 去重。 |
+| `src/recall-engine.ts` | 共享 recall 辅助层：prompt 触发判断、session 重复注入抑制、tag block 组装、max-age 过滤、按 key 保留最近 N 条 |
+| `src/auto-recall-final-selection.ts` | generic auto-recall 适配层。把 `RetrievalResult` 映射为最终选择候选，并在最终截断点应用 generic 的 `legacy | setwise-v2` 行为 |
+| `src/final-topk-setwise-selection.ts` | 共享最终 top-k 选择器。负责 shortlist presort、确定性的 set-wise 选择、词法重叠抑制，以及可选的 embedding 语义冗余抑制 |
+| `src/reflection-recall.ts` | `<inherited-rules>` 的动态 Reflection-Recall 排序链路。负责 reflection item 过滤/截断、分数计算、保持 `kind + strictKey` 分区，并将选中的 group 映射回 recall rows |
+| `src/reflection-aggregation.ts` | Reflection group 聚合层。把打分后的 reflection item 聚合为 strict-key group，选择代表文本并计算 group final score |
+| `src/reflection-recall-final-selection.ts` | Reflection 专用适配层，把动态 Reflection-Recall 的 group 接到共享 final selector 上做最终 top-k 排序 |
+| `src/reflection-selection.ts` | 历史 derived-focus / handoff-note 仍在使用的 reflection 多样性排序 helper |
 | `src/scopes.ts` | 多 Scope 访问控制。支持 `global`、`agent:<id>`、`custom:<name>`、`project:<id>`、`user:<id>` 等 Scope 模式 |
 | `src/tools.ts` | Agent 工具定义：`memory_recall`、`memory_store`、`memory_forget`（核心）、`self_improvement_log`（默认）+ `self_improvement_review`、`self_improvement_extract_skill`（管理模式） |
 | `src/noise-filter.ts` | 噪声过滤器。过滤 Agent 拒绝回复、Meta 问题、寒暄等低质量记忆 |
@@ -148,118 +166,127 @@ Query → BM25 FTS ─────┘
 
 ### 7. Session 策略
 
-- `sessionStrategy: "systemSessionMemory"`（默认）：不注册插件 reflection hooks，改用 OpenClaw 内置 `session-memory`。
-- `sessionStrategy: "memoryReflection"`：为 `/new` / `/reset` 启用插件 reflection hooks。
-- `sessionStrategy: "none"`：完全禁用本插件的会话策略 hooks。
-- 兼容说明：`sessionMemory.enabled=true|false` 映射为 `systemSessionMemory|none`。
-- `sessionMemory.messageCount` 也作为遗留兼容字段保留，并映射到 `memoryReflection.messageCount`。
-- 实用规则：只有在 `sessionStrategy="memoryReflection"` 时，`memoryReflection.*` 配置才会真正生效。
+这一组配置决定 `/new` / `/reset` 由谁接管。
+
+- `sessionStrategy: "systemSessionMemory"`（默认）
+  - 使用 OpenClaw 内置 `session-memory`
+  - 插件自己的 reflection hooks 不启用
+- `sessionStrategy: "memoryReflection"`
+  - 启用插件 reflection 流程
+  - 只有在这个模式下，`memoryReflection.*` 配置才会生效
+- `sessionStrategy: "none"`
+  - 完全禁用本插件的 session strategy hooks
+
+兼容字段：
+- `sessionMemory.enabled=true|false` 仍映射到 `systemSessionMemory|none`
+- `sessionMemory.messageCount` 仍映射到 `memoryReflection.messageCount`
+
+推荐起步配置：
+
+```json
+{
+  "sessionStrategy": "memoryReflection"
+}
+```
 
 ### 8. Self-Improvement
 
-- 触发事件：`agent:bootstrap`、`command:new`、`command:reset`。
-- `agent:bootstrap`：将 `SELF_IMPROVEMENT_REMINDER.md` 注入 bootstrap 上下文。
-- `command:new` / `command:reset`：在重置前追加简短 `/note self-improvement ...` 提醒。
-  - 在 `sessionStrategy="memoryReflection"` 下，最终 reset/new note 由 `runMemoryReflection` 组装。
-  - 当 `memoryReflection.injectMode="inheritance+derived"` 时，note 可包含：
-    - 来自当前 `/new` 或 `/reset` 新鲜反思文本的 `<open-loops>`。
-    - 来自历史 LanceDB 派生行（去重+衰减评分后）的 `<derived-focus>`（shortlist 最多 36，最终注入上限 13，不使用硬性分数阈值门槛）。
-- 文件初始化路径：确保 `.learnings/LEARNINGS.md` 和 `.learnings/ERRORS.md` 存在。
-- 这条链路与 `memoryReflection` 分离：看到 self-improvement note 或 `.learnings/*` 写入，并不等于 reflection 存储已开启。
-- 追加路径刻意区分为三种：
-  - 显式工具写入：`self_improvement_log`
-  - reflection 驱动的自动追加：来自结构化 governance candidates
-  - 文件/模板确保路径：bootstrap 阶段创建缺失文件
-- 工具：
-  - `self_improvement_log`：写入结构化 `learning` / `error` 条目。
-  - `self_improvement_review`：汇总治理 backlog（pending/high/promoted）。
-  - `self_improvement_extract_skill`：通过显式工具调用，从学习条目提炼可复用 `SKILL.md` 脚手架。
-- Reflection 自动追加行为：
-  - 来源段落：`## Learning governance candidates (.learnings / promotion / skill extraction)`。
-  - 首选格式：结构化逐条记录（`### Entry N`、`Priority`、`Status`、`Area`、`Summary`、`Details`、`Suggested Action`）。
-  - 向后兼容：旧的 bullet-style governance 内容仍作为 fallback 解析路径保留。
-  - 每个解析出的 governance candidate 会单独追加为一条 `.learnings/LEARNINGS.md` 记录。
-  - `Logged` 时间戳和条目 id 由写入器生成，而不是由 reflection 文本提供。
+如果你希望插件顺手维护一套可审计的学习/报错记录，就开启这一组功能。
+
+- 主要工具：
+  - `self_improvement_log`：追加结构化 learning / error 条目
+  - `self_improvement_review`：查看待处理治理 backlog
+  - `self_improvement_extract_skill`：从已验证的 learning 条目提炼 skill scaffold
+- 主要配置：
+  - `selfImprovement.enabled`：总开关
+  - `selfImprovement.beforeResetNote`：在 `/new` 或 `/reset` 前给出提醒
+  - `selfImprovement.ensureLearningFiles`：自动创建 `.learnings` 文件
+  - `selfImprovement.managementTools`：暴露 review / extract 工具
+- 主要输出：
+  - `.learnings/LEARNINGS.md`
+  - `.learnings/ERRORS.md`
+  - 提炼 skill 时写入 `.learnings/skills/...`
+
+推荐起步配置：
+
+```json
+{
+  "selfImprovement": {
+    "enabled": true,
+    "beforeResetNote": true,
+    "ensureLearningFiles": true,
+    "managementTools": true
+  }
+}
+```
 
 ### 9. memoryReflection
 
-- 启用条件：
-  - 需要 `sessionStrategy="memoryReflection"`。
-  - 触发于 `command:new` / `command:reset`。
-  - 若会话上下文不完整（例如缺少配置、session 文件、或可读对话内容），则跳过生成。
-  - 边界场景：在刚 `/new` 后立即再次 `/new`，可能进入一个没有可读上一轮 `sessionFile` 的新空会话；此时 reflection 会跳过并记录 `missing session file after recovery`。这属于预期行为。
-- 执行链：
-  - 先尝试 embedded runner（`runEmbeddedPiAgent`）。
-  - 若 embedded 路径失败，则回退到 `openclaw agent --local --json`。
-  - 若两者都失败，则写入最小 fallback reflection artifact。
-- Markdown 产物：
-  - 写入 `memory/reflections/YYYY-MM-DD/`。
-  - 文件名使用高精度时间戳 + agent/session token，例如 `HHMMSSmmm-agent-session[-xxxxxx].md`。
-- Prompt / 输出契约：
-  - 必需段落使用固定标题，并按精确 section 名解析。
-  - `Invariants` = 稳定的跨会话规则。
-  - `Derived` = 本轮提炼出的近期经验 / 调整 / follow-up heuristics，可能在接下来几轮继续有用，但应随时间衰减。
-  - Governance candidates 使用结构化 entry 模板，以便安全追加到 `.learnings`。
-  - `Logged` 时间戳和 ids 等 writer-owned metadata 由持久化层生成，而非模型输出。
-- 写入 LanceDB（可选）：
-  - 由 `memoryReflection.storeToLanceDB` 控制。
-  - 每次反思会写入 1 条 event row（`type=memory-reflection-event`）以及多条 item row（`type=memory-reflection-item`，对应每个 `Invariants` / `Derived` bullet）。
-  - event row 仅保留轻量 provenance / audit 元数据（`eventId`、`sessionKey`、`usedFallback`、`errorSignals`、source path）。
-  - item row 携带逐条衰减元数据（`decayModel`、`decayMidpointDays`、`decayK`、`baseWeight`、`quality`）以及 `ordinal/groupSize`。
-  - 仅使用 itemized reflection rows；旧版 combined row（`type=memory-reflection`）已不再写入，也不再参与读取。
-  - reflection 行展示标签为 `reflection:<scope>`。
-- Reflection 派生 durable memory 映射：
-  - 插件支持的 memory categories 包括 `preference`、`fact`、`decision`、`entity`、`reflection`、`other`。
-  - 但 reflection auto-map 有意只写：
-    - `User model deltas` → `preference`
-    - `Agent model deltas` → `preference`
-    - `Lessons & pitfalls` → `fact`
-    - `Decisions (durable)` → `decision`
-  - `Context`、`Open loops`、`Retrieval tags`、`Invariants`、`Derived` 不会被自动映射成普通 durable memory 类别。
-- 衰减算法与内置档位：
-  - reflection loading / injection 阶段使用 logistic decay；这**不会**修改全局 retriever 评分链路。
-  - 公式：`weight = 1 / (1 + exp(k * (ageDays - midpointDays)))`
-  - reflection item 内置档位：
-    - `invariant`：midpointDays=`45`，`k=0.22`，`baseWeight=1.10`，`quality=1.00`
-    - `derived`：midpointDays=`7`，`k=0.65`，`baseWeight=1.00`，`quality=0.95`
-  - mapped durable-memory 内置档位：
-    - `decision`：midpointDays=`45`，`k=0.25`，`baseWeight=1.10`，`quality=1.00`
-    - `user-model`：midpointDays=`21`，`k=0.30`，`baseWeight=1.00`，`quality=0.95`
-    - `agent-model`：midpointDays=`10`，`k=0.35`，`baseWeight=0.95`，`quality=0.93`
-    - `lesson`：midpointDays=`7`，`k=0.45`，`baseWeight=0.90`，`quality=0.90`
-  - 这些衰减参数当前属于插件写入的实现内置 metadata，不是用户可直接配置的 `memoryReflection.*` schema 字段。
-  - fallback 生成的记录会额外乘以 `0.75` 惩罚因子。
-- 独立代理（可选）：
-  - `memoryReflection.agentId` 可指向专门的 reflection agent（如 `memory-distiller`）。
-  - 若配置的 agent id 不在 `cfg.agents.list` 中，插件会告警并回退到 runtime agent id。
-- 错误闭环：
-  - `after_tool_call` 捕获并去重工具错误签名，用于提醒 / reflection 上下文。
-- Hook 注入位置（`memoryReflection.injectMode`）：
-  - `before_agent_start`：通过 Reflection-Recall 注入 `<inherited-rules>`。
-  - `memoryReflection.recall.mode="fixed"`（默认）：兼容路径；即使关闭 generic Auto-Recall，固定继承仍会注入。
-  - `memoryReflection.recall.mode="dynamic"`：按 prompt 动态检索反思规则，且与 generic Auto-Recall 使用独立 top-k / session 去重预算。
-    - 排序复用共享的 normalize/aggregation/selection helper（包含多样性感知的最终排序）。
-    - 回忆分组按 `kind + strictKey` 分区；即使标准化文本相同，`invariant`/`derived` 也不会被合并成同一条。
-  - `command:new` / `command:reset`：`runMemoryReflection` 生成 self-improvement note（`<open-loops>` 来自本次新反思；`<derived-focus>` 来自历史打分行，模式为 `inheritance+derived` 时启用）。
-  - `before_prompt_build`：仅注入 `<error-detected>`（不会注入 `<derived-focus>`）。
+如果你希望插件在新会话前继承规则、并可选地把反思写入 LanceDB，就配置这一组功能。
+
+优先关注这些配置：
+- `memoryReflection.enabled`：开启/关闭 reflection 功能
+- `memoryReflection.injectMode`：
+  - `inheritance-only` = 只注入继承规则
+  - `inheritance+derived` = 继承规则 + `/new` / `/reset` 时追加 derived-focus note
+- `memoryReflection.recall.mode`：
+  - `fixed` = 兼容路径
+  - `dynamic` = 按 prompt 动态生成 `<inherited-rules>`
+- `memoryReflection.storeToLanceDB`：是否把 reflection event/item 写入 LanceDB
+- `memoryReflection.agentId`（可选）：指定专门的 reflection agent
+
+推荐起步配置：
+
+```json
+{
+  "memoryReflection": {
+    "enabled": true,
+    "injectMode": "inheritance-only",
+    "storeToLanceDB": true,
+    "recall": {
+      "mode": "dynamic",
+      "topK": 6,
+      "includeKinds": ["invariant", "derived"],
+      "maxAgeDays": 14,
+      "maxEntriesPerKey": 7,
+      "minRepeated": 3,
+      "minScore": 0.22,
+      "minPromptLength": 12
+    }
+  }
+}
+```
+
+快速行为说明：
+- `before_agent_start` 可注入 `<inherited-rules>`
+- `/new` / `/reset` 可生成 reflection note
+- `before_prompt_build` 只注入 `<error-detected>` 提醒
+- dynamic recall 会保持 `kind + strictKey` 分区，不会把 invariant / derived 混在一起
 
 ### 10. Markdown 镜像（`mdMirror`）
 
-- 作用：
-  - 在写入 LanceDB 的同时，把记忆双写到可读的 Markdown 文件。
-  - 便于审计、排查和人工复核。
-- 写入路径：
-  - 优先：按 agent workspace 映射写入 `memory/YYYY-MM-DD.md`。
-  - 回退：当 agent workspace 不可解析时，写入 `mdMirror.dir`（默认 `memory-md`）。
-- 触发路径：
-  - `memory_store` 工具写入。
-  - `agent_end` 自动捕获写入。
-- 兼容性：
-  - 不替代 LanceDB 存储，不影响现有检索链路。
-  - 检索仍走 vector/BM25/rerank。
-- 配置项：
-  - `mdMirror.enabled`：是否开启双写（默认 `false`）。
-  - `mdMirror.dir`：Markdown 镜像回退目录。
+如果你想在 LanceDB 之外，再保留一份可读的 Markdown 记忆副本，就开启这个功能。
+
+主要配置：
+- `mdMirror.enabled`：开启/关闭 Markdown 双写
+- `mdMirror.dir`：当 agent workspace 路径不可用时的回退目录
+
+它会做什么：
+- 把 memory entry 双写到可读的 Markdown 文件
+- 优先写到映射 workspace 下的 `memory/YYYY-MM-DD.md`
+- 必要时回退到 `mdMirror.dir`
+- 不会替代 LanceDB 的存储/检索
+
+推荐起步配置：
+
+```json
+{
+  "mdMirror": {
+    "enabled": true,
+    "dir": "memory-md"
+  }
+}
+```
 
 ### 11. 长文本分块嵌入（Long Context Chunking）
 
@@ -289,9 +316,13 @@ Query → BM25 FTS ─────┘
   - 触发词支持 **简体中文 + 繁體中文**（例如：记住/記住、偏好/喜好/喜歡、决定/決定 等）
 - **Auto-Recall**（`before_agent_start` hook）: 注入 `<relevant-memories>` 上下文
   - 默认 top-k：`autoRecallTopK=3`
+  - Generic 最终选择模式：`autoRecallSelectionMode`（默认 `legacy`；设置 `setwise-v2` 可启用 set-wise 最终选择器）
   - 默认类别白名单：`preference`、`fact`、`decision`、`entity`、`other`
   - 默认 `autoRecallExcludeReflection=true`，让 `<relevant-memories>` 与 `<inherited-rules>` 分离
   - 支持时间窗（`autoRecallMaxAgeDays`）和按归一化 key 的最近 N 条限制（`autoRecallMaxEntriesPerKey`）
+  - `legacy`：保留 retriever 当前的排序结果（包括内部的粗粒度 MMR 去重），再对 post-process 后的结果直接截断（`slice(0, topK)`），保持兼容行为
+  - `setwise-v2`：最终 top-k 使用共享 set-wise selector（基础分 + 新鲜度 + 轻量 category/scope 覆盖 + 词法重叠抑制 + 基于 embedding 的语义近重复抑制）；当向量缺失时会安全回退到仅词法抑制，并保持确定性顺序
+  - 该模式只作用于 generic auto-recall；Reflection-Recall 的 `fixed | dynamic` 语义不变。
 
 ### 不想在对话中"显示长期记忆"？
 
@@ -490,6 +521,7 @@ openclaw config get plugins.slots.memory
   "autoRecall": false,
   "autoRecallMinLength": 8,
   "autoRecallTopK": 3,
+  "autoRecallSelectionMode": "legacy",
   "autoRecallCategories": ["preference", "fact", "decision", "entity", "other"],
   "autoRecallExcludeReflection": true,
   "autoRecallMaxAgeDays": 30,
@@ -580,6 +612,7 @@ openclaw config get plugins.slots.memory
   "autoCapture": true,
   "autoRecall": true,
   "autoRecallMinLength": 8,
+  "autoRecallSelectionMode": "legacy",
   "autoRecallExcludeReflection": true,
   "retrieval": {
     "candidatePoolSize": 20,

--- a/index.ts
+++ b/index.ts
@@ -50,6 +50,7 @@ import {
   keepMostRecentPerNormalizedKey,
 } from "./src/recall-engine.js";
 import { rankDynamicReflectionRecallFromEntries } from "./src/reflection-recall.js";
+import { selectFinalAutoRecallResults } from "./src/auto-recall-final-selection.js";
 
 // ============================================================================
 // Configuration & Types
@@ -73,6 +74,7 @@ interface PluginConfig {
   autoRecallMinLength?: number;
   autoRecallMinRepeated?: number;
   autoRecallTopK?: number;
+  autoRecallSelectionMode?: AutoRecallSelectionMode;
   autoRecallCategories?: MemoryCategory[];
   autoRecallExcludeReflection?: boolean;
   autoRecallMaxAgeDays?: number;
@@ -142,6 +144,7 @@ type SessionStrategy = "memoryReflection" | "systemSessionMemory" | "none";
 type ReflectionInjectMode = "inheritance-only" | "inheritance+derived";
 type ReflectionRecallMode = "fixed" | "dynamic";
 type ReflectionRecallKind = "invariant" | "derived";
+type AutoRecallSelectionMode = "legacy" | "setwise-v2";
 type MemoryCategory = "preference" | "fact" | "decision" | "entity" | "other" | "reflection";
 
 // ============================================================================
@@ -259,6 +262,7 @@ const DEFAULT_REFLECTION_SESSION_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_REFLECTION_MAX_TRACKED_SESSIONS = 200;
 const DEFAULT_REFLECTION_ERROR_SCAN_MAX_CHARS = 8_000;
 const DEFAULT_AUTO_RECALL_TOP_K = 3;
+const DEFAULT_AUTO_RECALL_SELECTION_MODE: AutoRecallSelectionMode = "legacy";
 const DEFAULT_AUTO_RECALL_EXCLUDE_REFLECTION = true;
 const DEFAULT_AUTO_RECALL_MAX_AGE_DAYS = 30;
 const DEFAULT_AUTO_RECALL_MAX_ENTRIES_PER_KEY = 10;
@@ -1694,7 +1698,11 @@ const memoryLanceDBProPlugin = {
                 scopeFilter: accessibleScopes,
                 source: "auto-recall",
               });
-              return postProcessAutoRecallResults(retrieved).slice(0, topK);
+              const postProcessed = postProcessAutoRecallResults(retrieved);
+              if (config.autoRecallSelectionMode === "setwise-v2") {
+                return selectFinalAutoRecallResults(postProcessed, { topK });
+              }
+              return postProcessed.slice(0, topK);
             },
             formatLine: (row) =>
               `- [${row.entry.category}:${row.entry.scope}] ${sanitizeForContext(row.entry.text)} (${(row.score * 100).toFixed(0)}%${row.sources?.bm25 ? ", vector+BM25" : ""}${row.sources?.reranked ? "+reranked" : ""})`,
@@ -2745,6 +2753,10 @@ export function parsePluginConfig(value: unknown): PluginConfig {
   const reflectionRecallMinRepeated = parsePositiveInt(memoryReflectionRecallRaw?.minRepeated) ?? DEFAULT_REFLECTION_RECALL_MIN_REPEATED;
   const reflectionRecallMinScore = parseNonNegativeNumber(memoryReflectionRecallRaw?.minScore) ?? DEFAULT_REFLECTION_RECALL_MIN_SCORE;
   const reflectionRecallMinPromptLength = parsePositiveInt(memoryReflectionRecallRaw?.minPromptLength) ?? DEFAULT_REFLECTION_RECALL_MIN_PROMPT_LENGTH;
+  const autoRecallSelectionMode: AutoRecallSelectionMode =
+    cfg.autoRecallSelectionMode === "setwise-v2"
+      ? "setwise-v2"
+      : DEFAULT_AUTO_RECALL_SELECTION_MODE;
 
   return {
     embedding: {
@@ -2785,6 +2797,7 @@ export function parsePluginConfig(value: unknown): PluginConfig {
     autoRecallMinLength: parsePositiveInt(cfg.autoRecallMinLength),
     autoRecallMinRepeated: parsePositiveInt(cfg.autoRecallMinRepeated),
     autoRecallTopK: parsePositiveInt(cfg.autoRecallTopK) ?? DEFAULT_AUTO_RECALL_TOP_K,
+    autoRecallSelectionMode,
     autoRecallCategories: parseMemoryCategories(cfg.autoRecallCategories, DEFAULT_AUTO_RECALL_CATEGORIES),
     autoRecallExcludeReflection: typeof cfg.autoRecallExcludeReflection === "boolean"
       ? cfg.autoRecallExcludeReflection

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -111,6 +111,15 @@
         "default": 3,
         "description": "Maximum number of rows injected into <relevant-memories> for each turn."
       },
+      "autoRecallSelectionMode": {
+        "type": "string",
+        "enum": [
+          "legacy",
+          "setwise-v2"
+        ],
+        "default": "legacy",
+        "description": "Generic Auto-Recall final top-k mode. legacy keeps post-processed direct truncation compatibility; setwise-v2 uses set-wise final selection."
+      },
       "autoRecallCategories": {
         "type": "array",
         "items": {
@@ -569,6 +578,11 @@
     "autoRecallTopK": {
       "label": "Auto-Recall Top K",
       "help": "Maximum rows injected into <relevant-memories> each turn.",
+      "advanced": true
+    },
+    "autoRecallSelectionMode": {
+      "label": "Auto-Recall Selection Mode",
+      "help": "Generic final top-k mode: legacy uses direct truncation after post-processing; setwise-v2 enables set-wise final selection.",
       "advanced": true
     },
     "autoRecallCategories": {

--- a/src/auto-recall-final-selection.ts
+++ b/src/auto-recall-final-selection.ts
@@ -1,0 +1,110 @@
+import type { RetrievalResult } from "./retriever.js";
+import { normalizeRecallTextKey } from "./recall-engine.js";
+import {
+  DEFAULT_FINAL_SELECTION_FRESHNESS_HALF_LIFE_MS,
+  type FinalSelectCandidate,
+  type FinalSelectOverlapThreshold,
+  type FinalSelectSemanticThreshold,
+  selectFinalTopKSetwise,
+} from "./final-topk-setwise-selection.js";
+
+export interface AutoRecallFinalSelectionOptions {
+  topK?: number;
+  now?: number;
+  shortlistLimit?: number;
+}
+
+const GENERIC_OVERLAP_THRESHOLDS: FinalSelectOverlapThreshold[] = [
+  { minOverlap: 0.86, multiplier: 0.2 },
+  { minOverlap: 0.72, multiplier: 0.45 },
+  { minOverlap: 0.58, multiplier: 0.75 },
+];
+
+const GENERIC_SEMANTIC_THRESHOLDS: FinalSelectSemanticThreshold[] = [
+  { minSimilarity: 0.985, multiplier: 0.25 },
+  { minSimilarity: 0.96, multiplier: 0.45 },
+  { minSimilarity: 0.93, multiplier: 0.7 },
+];
+
+export function selectFinalAutoRecallResults(
+  results: RetrievalResult[],
+  options: AutoRecallFinalSelectionOptions = {}
+): RetrievalResult[] {
+  if (!Array.isArray(results) || results.length === 0) return [];
+
+  const finalLimit = Math.min(results.length, normalizeLimit(options.topK, results.length));
+  if (finalLimit <= 0) return [];
+  const shortlistLimit = Math.min(
+    results.length,
+    normalizeLimit(options.shortlistLimit, Math.max(finalLimit, finalLimit * 4))
+  );
+
+  const candidates: FinalSelectCandidate<RetrievalResult>[] = results.map((row) => {
+    const normalizedKey = normalizeRecallTextKey(row.entry.text);
+    return {
+      id: row.entry.id,
+      text: row.entry.text,
+      baseScore: Number.isFinite(row.score) ? row.score : 0,
+      ts: row.entry.timestamp,
+      softKey: normalizedKey || undefined,
+      normalizedKey: normalizedKey || undefined,
+      category: row.entry.category,
+      scope: row.entry.scope,
+      embedding: normalizeEmbedding(row.entry.vector),
+      raw: row,
+    };
+  });
+
+  return selectFinalTopKSetwise(candidates, {
+    finalLimit,
+    shortlistLimit,
+    now: options.now,
+    freshnessHalfLifeMs: DEFAULT_FINAL_SELECTION_FRESHNESS_HALF_LIFE_MS,
+    weights: {
+      relevance: 1,
+      freshness: 0.08,
+      categoryCoverage: 0.05,
+      scopeCoverage: 0.03,
+    },
+    penalties: {
+      sameKeyMultiplier: 0.08,
+      overlapThresholds: GENERIC_OVERLAP_THRESHOLDS,
+      semanticThresholds: GENERIC_SEMANTIC_THRESHOLDS,
+    },
+  }).map((row) => row.raw);
+}
+
+function normalizeLimit(value: unknown, fallback: number): number {
+  const resolved = Number.isFinite(value) ? Number(value) : fallback;
+  return Math.max(1, Math.floor(resolved));
+}
+
+function normalizeEmbedding(value: unknown): number[] | undefined {
+  if (value == null) return undefined;
+
+  let raw: unknown[] = [];
+  if (Array.isArray(value)) {
+    raw = value;
+  } else if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+    raw = Array.from(value as ArrayLike<unknown>);
+  } else if (typeof value === "object" && Symbol.iterator in value) {
+    try {
+      raw = Array.from(value as Iterable<unknown>);
+    } catch {
+      return undefined;
+    }
+  } else {
+    return undefined;
+  }
+
+  if (raw.length === 0) return undefined;
+
+  const embedding: number[] = [];
+  for (const item of raw) {
+    const num = Number(item);
+    if (!Number.isFinite(num)) return undefined;
+    embedding.push(num);
+  }
+
+  return embedding.length > 0 ? embedding : undefined;
+}

--- a/src/final-topk-setwise-selection.ts
+++ b/src/final-topk-setwise-selection.ts
@@ -1,0 +1,391 @@
+export interface FinalSelectCandidate<TRaw = unknown> {
+  id: string;
+  text: string;
+  baseScore: number;
+  raw: TRaw;
+  ts?: number;
+  softKey?: string;
+  normalizedKey?: string;
+  category?: string;
+  scope?: string;
+  sourceType?: string;
+  entityTags?: string[];
+  embedding?: number[];
+}
+
+export interface FinalSelectOverlapThreshold {
+  minOverlap: number;
+  multiplier: number;
+}
+
+export interface FinalSelectSemanticThreshold {
+  minSimilarity: number;
+  multiplier: number;
+}
+
+export interface FinalSelectWeights {
+  relevance: number;
+  freshness: number;
+  categoryCoverage: number;
+  scopeCoverage: number;
+}
+
+export interface FinalSelectPenalties {
+  sameKeyMultiplier: number;
+  overlapThresholds: FinalSelectOverlapThreshold[];
+  semanticThresholds: FinalSelectSemanticThreshold[];
+}
+
+export interface FinalSelectConfig {
+  shortlistLimit?: number;
+  finalLimit?: number;
+  now?: number;
+  freshnessHalfLifeMs?: number;
+  tokenMinLength?: number;
+  weights?: Partial<FinalSelectWeights>;
+  penalties?: Partial<FinalSelectPenalties>;
+}
+
+interface PreparedCandidate<TRaw = unknown> {
+  candidate: FinalSelectCandidate<TRaw>;
+  stableRank: number;
+  ts: number;
+  key: string;
+  overlapTokens: string[];
+  embedding?: number[];
+}
+
+const DAY_MS = 86_400_000;
+const EPSILON = 1e-12;
+
+const DEFAULT_WEIGHTS: FinalSelectWeights = {
+  relevance: 1,
+  freshness: 0,
+  categoryCoverage: 0,
+  scopeCoverage: 0,
+};
+
+const DEFAULT_PENALTIES: FinalSelectPenalties = {
+  sameKeyMultiplier: 0.08,
+  overlapThresholds: [],
+  semanticThresholds: [],
+};
+
+export function buildFinalSelectionShortlist<TRaw = unknown>(
+  candidates: FinalSelectCandidate<TRaw>[],
+  config: FinalSelectConfig = {}
+): FinalSelectCandidate<TRaw>[] {
+  if (!Array.isArray(candidates) || candidates.length === 0) return [];
+  const finalLimit = normalizeLimit(config.finalLimit, candidates.length);
+  const shortlistLimit = Math.min(
+    candidates.length,
+    normalizeLimit(config.shortlistLimit, Math.max(finalLimit, finalLimit * 4))
+  );
+  return candidates
+    .map((candidate, index) => ({ candidate, index }))
+    .sort((a, b) => compareForPresort(a.candidate, b.candidate, a.index, b.index))
+    .slice(0, shortlistLimit)
+    .map(({ candidate }) => candidate);
+}
+
+export function selectFinalTopKSetwise<TRaw = unknown>(
+  candidates: FinalSelectCandidate<TRaw>[],
+  config: FinalSelectConfig = {}
+): FinalSelectCandidate<TRaw>[] {
+  if (!Array.isArray(candidates) || candidates.length === 0) return [];
+
+  const finalLimit = Math.min(candidates.length, normalizeLimit(config.finalLimit, candidates.length));
+  if (finalLimit <= 0) return [];
+
+  const weights: FinalSelectWeights = {
+    ...DEFAULT_WEIGHTS,
+    ...(config.weights || {}),
+  };
+  const penalties: FinalSelectPenalties = {
+    ...DEFAULT_PENALTIES,
+    ...(config.penalties || {}),
+    overlapThresholds: normalizeThresholds(config.penalties?.overlapThresholds),
+    semanticThresholds: normalizeSemanticThresholds(config.penalties?.semanticThresholds),
+  };
+  const now = Number.isFinite(config.now) ? Number(config.now) : Date.now();
+  const tokenMinLength = normalizeLimit(config.tokenMinLength, 3);
+  const shortlist = buildFinalSelectionShortlist(candidates, {
+    ...config,
+    finalLimit,
+  });
+
+  const remaining: PreparedCandidate<TRaw>[] = shortlist.map((candidate, index) => {
+    const key = normalizeKey(candidate);
+    const overlapSeed = key || String(candidate.text || "");
+    return {
+      candidate,
+      stableRank: index,
+      ts: sanitizeTimestamp(candidate.ts, now),
+      key,
+      overlapTokens: tokenizeForOverlap(overlapSeed, tokenMinLength),
+      embedding: sanitizeEmbedding(candidate.embedding),
+    };
+  });
+
+  const selected: PreparedCandidate<TRaw>[] = [];
+  const selectedKeys = new Set<string>();
+  const selectedCategories = new Set<string>();
+  const selectedScopes = new Set<string>();
+  const selectedTokenSets: Set<string>[] = [];
+  const selectedEmbeddings: number[][] = [];
+
+  while (remaining.length > 0 && selected.length < finalLimit) {
+    let bestIndex = 0;
+    let bestScore = Number.NEGATIVE_INFINITY;
+
+    for (let i = 0; i < remaining.length; i += 1) {
+      const candidate = remaining[i];
+      const adjustedScore = computeAdjustedScore(candidate, {
+        now,
+        weights,
+        penalties,
+        selectedKeys,
+        selectedCategories,
+        selectedScopes,
+        selectedTokenSets,
+        selectedEmbeddings,
+        freshnessHalfLifeMs: Number(config.freshnessHalfLifeMs),
+      });
+
+      if (adjustedScore > bestScore + EPSILON) {
+        bestScore = adjustedScore;
+        bestIndex = i;
+        continue;
+      }
+      if (Math.abs(adjustedScore - bestScore) <= EPSILON) {
+        const currentBest = remaining[bestIndex];
+        if (candidate.stableRank < currentBest.stableRank) {
+          bestIndex = i;
+        }
+      }
+    }
+
+    const [chosen] = remaining.splice(bestIndex, 1);
+    selected.push(chosen);
+
+    if (chosen.key) selectedKeys.add(chosen.key);
+    if (chosen.candidate.category) selectedCategories.add(chosen.candidate.category);
+    if (chosen.candidate.scope) selectedScopes.add(chosen.candidate.scope);
+    if (chosen.overlapTokens.length > 0) selectedTokenSets.push(new Set(chosen.overlapTokens));
+    if (chosen.embedding && chosen.embedding.length > 0) selectedEmbeddings.push(chosen.embedding);
+  }
+
+  return selected.map((row) => row.candidate);
+}
+
+function computeAdjustedScore<TRaw>(
+  candidate: PreparedCandidate<TRaw>,
+  context: {
+    now: number;
+    freshnessHalfLifeMs: number;
+    weights: FinalSelectWeights;
+    penalties: FinalSelectPenalties;
+    selectedKeys: Set<string>;
+    selectedCategories: Set<string>;
+    selectedScopes: Set<string>;
+    selectedTokenSets: Set<string>[];
+    selectedEmbeddings: number[][];
+  }
+): number {
+  const baseScore = Number.isFinite(candidate.candidate.baseScore) ? candidate.candidate.baseScore : 0;
+  const freshnessScore = computeFreshnessScore(candidate.ts, context.now, context.freshnessHalfLifeMs);
+
+  let utility = (context.weights.relevance * baseScore)
+    + (context.weights.freshness * freshnessScore);
+
+  if (candidate.candidate.category && !context.selectedCategories.has(candidate.candidate.category)) {
+    utility += context.weights.categoryCoverage;
+  }
+  if (candidate.candidate.scope && !context.selectedScopes.has(candidate.candidate.scope)) {
+    utility += context.weights.scopeCoverage;
+  }
+
+  let multiplier = 1;
+  if (candidate.key && context.selectedKeys.has(candidate.key)) {
+    multiplier *= clampMultiplier(context.penalties.sameKeyMultiplier);
+  }
+
+  if (candidate.overlapTokens.length > 0 && context.selectedTokenSets.length > 0) {
+    const candidateSet = new Set(candidate.overlapTokens);
+    let maxOverlap = 0;
+    for (const selectedSet of context.selectedTokenSets) {
+      const overlap = jaccardSimilarity(candidateSet, selectedSet);
+      if (overlap > maxOverlap) maxOverlap = overlap;
+    }
+    for (const threshold of context.penalties.overlapThresholds) {
+      if (maxOverlap >= threshold.minOverlap) {
+        multiplier *= clampMultiplier(threshold.multiplier);
+        break;
+      }
+    }
+  }
+
+  if (candidate.embedding && context.selectedEmbeddings.length > 0) {
+    let maxSimilarity = -1;
+    for (const selectedEmbedding of context.selectedEmbeddings) {
+      const similarity = cosineSimilarity(candidate.embedding, selectedEmbedding);
+      if (similarity !== null && similarity > maxSimilarity) {
+        maxSimilarity = similarity;
+      }
+    }
+
+    if (maxSimilarity >= 0) {
+      for (const threshold of context.penalties.semanticThresholds) {
+        if (maxSimilarity >= threshold.minSimilarity) {
+          multiplier *= clampMultiplier(threshold.multiplier);
+          break;
+        }
+      }
+    }
+  }
+
+  return utility * multiplier;
+}
+
+function compareForPresort<TRaw>(
+  a: FinalSelectCandidate<TRaw>,
+  b: FinalSelectCandidate<TRaw>,
+  aIndex: number,
+  bIndex: number
+): number {
+  const aScore = Number.isFinite(a.baseScore) ? a.baseScore : 0;
+  const bScore = Number.isFinite(b.baseScore) ? b.baseScore : 0;
+  if (bScore !== aScore) return bScore - aScore;
+
+  const aTs = Number.isFinite(a.ts) ? Number(a.ts) : 0;
+  const bTs = Number.isFinite(b.ts) ? Number(b.ts) : 0;
+  if (bTs !== aTs) return bTs - aTs;
+
+  const idOrder = String(a.id || "").localeCompare(String(b.id || ""));
+  if (idOrder !== 0) return idOrder;
+
+  const textOrder = String(a.text || "").localeCompare(String(b.text || ""));
+  if (textOrder !== 0) return textOrder;
+
+  return aIndex - bIndex;
+}
+
+function sanitizeTimestamp(value: unknown, fallback: number): number {
+  const ts = Number(value);
+  if (!Number.isFinite(ts) || ts <= 0) return fallback;
+  return ts;
+}
+
+function computeFreshnessScore(ts: number, now: number, halfLifeMs: number): number {
+  if (!Number.isFinite(halfLifeMs) || halfLifeMs <= 0) return 0;
+  const ageMs = Math.max(0, now - ts);
+  return Math.exp(-ageMs / halfLifeMs);
+}
+
+function normalizeKey<TRaw>(candidate: FinalSelectCandidate<TRaw>): string {
+  const soft = String(candidate.softKey || "").trim();
+  if (soft) return soft;
+  const normalized = String(candidate.normalizedKey || "").trim();
+  if (normalized) return normalized;
+  return "";
+}
+
+function tokenizeForOverlap(value: string, tokenMinLength: number): string[] {
+  if (!value) return [];
+  return value
+    .toLowerCase()
+    .replace(/[_/\-\\]+/g, " ")
+    .replace(/[^\p{L}\p{N}\s]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .map((token) => token.trim())
+    .filter((token) => token.length >= tokenMinLength);
+}
+
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const token of a) {
+    if (b.has(token)) intersection += 1;
+  }
+  const union = new Set([...a, ...b]).size;
+  if (union === 0) return 0;
+  return intersection / union;
+}
+
+function normalizeLimit(value: unknown, fallback: number): number {
+  const resolved = Number.isFinite(value) ? Number(value) : fallback;
+  return Math.max(1, Math.floor(resolved));
+}
+
+function clampMultiplier(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}
+
+function normalizeThresholds(thresholds: unknown): FinalSelectOverlapThreshold[] {
+  if (!Array.isArray(thresholds) || thresholds.length === 0) return DEFAULT_PENALTIES.overlapThresholds;
+  return thresholds
+    .map((row) => {
+      const minOverlap = Number((row as FinalSelectOverlapThreshold).minOverlap);
+      const multiplier = Number((row as FinalSelectOverlapThreshold).multiplier);
+      if (!Number.isFinite(minOverlap) || minOverlap < 0 || minOverlap > 1) return null;
+      if (!Number.isFinite(multiplier)) return null;
+      return { minOverlap, multiplier: clampMultiplier(multiplier) };
+    })
+    .filter((row): row is FinalSelectOverlapThreshold => row !== null)
+    .sort((a, b) => b.minOverlap - a.minOverlap);
+}
+
+function normalizeSemanticThresholds(thresholds: unknown): FinalSelectSemanticThreshold[] {
+  if (!Array.isArray(thresholds) || thresholds.length === 0) return DEFAULT_PENALTIES.semanticThresholds;
+  return thresholds
+    .map((row) => {
+      const minSimilarity = Number((row as FinalSelectSemanticThreshold).minSimilarity);
+      const multiplier = Number((row as FinalSelectSemanticThreshold).multiplier);
+      if (!Number.isFinite(minSimilarity) || minSimilarity < -1 || minSimilarity > 1) return null;
+      if (!Number.isFinite(multiplier)) return null;
+      return { minSimilarity, multiplier: clampMultiplier(multiplier) };
+    })
+    .filter((row): row is FinalSelectSemanticThreshold => row !== null)
+    .sort((a, b) => b.minSimilarity - a.minSimilarity);
+}
+
+function sanitizeEmbedding(value: unknown): number[] | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+  const embedding: number[] = [];
+  for (const item of value) {
+    const num = Number(item);
+    if (!Number.isFinite(num)) return undefined;
+    embedding.push(num);
+  }
+  return embedding.length > 0 ? embedding : undefined;
+}
+
+function cosineSimilarity(a: number[], b: number[]): number | null {
+  if (!Array.isArray(a) || !Array.isArray(b)) return null;
+  if (a.length === 0 || b.length === 0 || a.length !== b.length) return null;
+
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < a.length; i += 1) {
+    const x = a[i];
+    const y = b[i];
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+    dot += x * y;
+    normA += x * x;
+    normB += y * y;
+  }
+
+  if (normA <= 0 || normB <= 0) return null;
+  const score = dot / (Math.sqrt(normA) * Math.sqrt(normB));
+  if (!Number.isFinite(score)) return null;
+  return Math.max(-1, Math.min(1, score));
+}
+
+export const DEFAULT_FINAL_SELECTION_FRESHNESS_HALF_LIFE_MS = 14 * DAY_MS;

--- a/src/reflection-recall-final-selection.ts
+++ b/src/reflection-recall-final-selection.ts
@@ -1,0 +1,60 @@
+import type { ReflectionGroup } from "./reflection-aggregation.js";
+import {
+  type FinalSelectCandidate,
+  type FinalSelectOverlapThreshold,
+  selectFinalTopKSetwise,
+} from "./final-topk-setwise-selection.js";
+
+interface ReflectionFinalSelectionOptions {
+  shortlistTarget?: number;
+  finalTarget?: number;
+  now?: number;
+}
+
+const REFLECTION_OVERLAP_THRESHOLDS: FinalSelectOverlapThreshold[] = [
+  { minOverlap: 0.85, multiplier: 0.12 },
+  { minOverlap: 0.70, multiplier: 0.35 },
+  { minOverlap: 0.55, multiplier: 0.7 },
+];
+
+export function selectFinalReflectionRecallGroups(
+  groups: ReflectionGroup[],
+  options: ReflectionFinalSelectionOptions = {}
+): ReflectionGroup[] {
+  if (!Array.isArray(groups) || groups.length === 0) return [];
+
+  const finalTarget = Math.min(groups.length, normalizeLimit(options.finalTarget, groups.length));
+  const shortlistTarget = Math.min(groups.length, normalizeLimit(options.shortlistTarget, groups.length));
+  if (finalTarget <= 0) return [];
+
+  const candidates: FinalSelectCandidate<ReflectionGroup>[] = groups.map((group) => ({
+    id: group.strictKey,
+    text: group.representative.text,
+    baseScore: Number.isFinite(group.finalScore) ? group.finalScore : 0,
+    ts: group.latestTs,
+    softKey: group.softKey || group.strictKey,
+    normalizedKey: group.strictKey,
+    raw: group,
+  }));
+
+  return selectFinalTopKSetwise(candidates, {
+    shortlistLimit: shortlistTarget,
+    finalLimit: finalTarget,
+    now: options.now,
+    weights: {
+      relevance: 1,
+      freshness: 0,
+      categoryCoverage: 0,
+      scopeCoverage: 0,
+    },
+    penalties: {
+      sameKeyMultiplier: 0.08,
+      overlapThresholds: REFLECTION_OVERLAP_THRESHOLDS,
+    },
+  }).map((row) => row.raw);
+}
+
+function normalizeLimit(value: unknown, fallback: number): number {
+  const resolved = Number.isFinite(value) ? Number(value) : fallback;
+  return Math.max(1, Math.floor(resolved));
+}

--- a/src/reflection-recall.ts
+++ b/src/reflection-recall.ts
@@ -6,7 +6,7 @@ import { getReflectionItemDecayDefaults, type ReflectionItemKind } from "./refle
 import { filterByMaxAge, keepMostRecentPerNormalizedKey } from "./recall-engine.js";
 import { normalizeReflectionSoftKey, normalizeReflectionStrictKey } from "./reflection-normalize.js";
 import { aggregateReflectionGroups, type ReflectionScoredItem } from "./reflection-aggregation.js";
-import { selectDiversityAwareReflectionGroups } from "./reflection-selection.js";
+import { selectFinalReflectionRecallGroups } from "./reflection-recall-final-selection.js";
 
 export interface ReflectionRecallOptions {
   agentId: string;
@@ -116,9 +116,10 @@ export function rankDynamicReflectionRecallFromEntries(
 
   const groups = aggregateReflectionGroups(scoredItems, now);
   if (groups.length === 0) return [];
-  const grouped = selectDiversityAwareReflectionGroups(groups, {
+  const grouped = selectFinalReflectionRecallGroups(groups, {
     shortlistTarget: groups.length,
     finalTarget: groups.length,
+    now,
   });
   const minScore = Number.isFinite(options.minScore) ? Number(options.minScore) : 0;
   const rows = grouped

--- a/test/config-session-strategy-migration.test.mjs
+++ b/test/config-session-strategy-migration.test.mjs
@@ -63,4 +63,17 @@ describe("sessionStrategy legacy compatibility mapping", () => {
     });
     assert.equal(parsed.embedding.chunking, false);
   });
+
+  it("defaults generic auto-recall selection mode to legacy", () => {
+    const parsed = parsePluginConfig(baseConfig());
+    assert.equal(parsed.autoRecallSelectionMode, "legacy");
+  });
+
+  it("parses explicit generic auto-recall selection mode override", () => {
+    const parsed = parsePluginConfig({
+      ...baseConfig(),
+      autoRecallSelectionMode: "setwise-v2",
+    });
+    assert.equal(parsed.autoRecallSelectionMode, "setwise-v2");
+  });
 });

--- a/test/memory-reflection.test.mjs
+++ b/test/memory-reflection.test.mjs
@@ -37,10 +37,12 @@ const {
 } = jiti("../src/reflection-store.ts");
 const { normalizeReflectionSoftKey } = jiti("../src/reflection-normalize.ts");
 const { rankDynamicReflectionRecallFromEntries } = jiti("../src/reflection-recall.ts");
+const { selectFinalAutoRecallResults } = jiti("../src/auto-recall-final-selection.ts");
 const {
   createDynamicRecallSessionState,
   clearDynamicRecallSessionState,
   orchestrateDynamicRecall,
+  normalizeRecallTextKey,
 } = jiti("../src/recall-engine.ts");
 const {
   REFLECTION_INVARIANT_DECAY_MIDPOINT_DAYS,
@@ -1075,6 +1077,358 @@ describe("memory reflection", () => {
     });
   });
 
+  describe("generic auto-recall final selection", () => {
+    function makeRetrievalResult({ id, text, score, category, scope, timestamp, vector = [] }) {
+      return {
+        entry: {
+          id,
+          text,
+          category,
+          scope,
+          timestamp,
+          vector,
+          importance: 0.8,
+          metadata: "{}",
+        },
+        score,
+        sources: {},
+      };
+    }
+
+    it("keeps strongest rank-1 while reducing duplicate saturation with light category/scope coverage", () => {
+      const now = Date.UTC(2026, 2, 8, 12, 0, 0);
+      const day = 24 * 60 * 60 * 1000;
+      const rows = [
+        makeRetrievalResult({
+          id: "dup-1",
+          text: "Verify DNS and mount health after service restart.",
+          score: 0.99,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+        }),
+        makeRetrievalResult({
+          id: "dup-2",
+          text: "Verify dns and mount health after service restart!",
+          score: 0.985,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+        }),
+        makeRetrievalResult({
+          id: "dup-3",
+          text: "verify dns mount health after service restart",
+          score: 0.98,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+        }),
+        makeRetrievalResult({
+          id: "decision-1",
+          text: "Record rollback command before changing service units.",
+          score: 0.95,
+          category: "decision",
+          scope: "global",
+          timestamp: now - 2 * day,
+        }),
+        makeRetrievalResult({
+          id: "pref-1",
+          text: "Prefer concise post-check summaries in final responses.",
+          score: 0.945,
+          category: "preference",
+          scope: "agent:main",
+          timestamp: now - 1 * day,
+        }),
+        makeRetrievalResult({
+          id: "entity-1",
+          text: "Service dependency map includes mosdns and rclone.",
+          score: 0.94,
+          category: "entity",
+          scope: "project:ops",
+          timestamp: now - 3 * day,
+        }),
+      ];
+
+      const selected = selectFinalAutoRecallResults(rows, { topK: 4, now });
+
+      assert.equal(selected.length, 4);
+      assert.equal(selected[0].entry.id, "dup-1");
+
+      const duplicateKey = normalizeRecallTextKey(rows[0].entry.text);
+      const duplicateCount = selected.filter((row) => normalizeRecallTextKey(row.entry.text) === duplicateKey).length;
+      assert.equal(duplicateCount, 1);
+      assert.ok(new Set(selected.map((row) => row.entry.category)).size >= 3);
+      assert.ok(new Set(selected.map((row) => row.entry.scope)).size >= 2);
+    });
+
+    it("is deterministic for the same candidate set regardless of input order", () => {
+      const now = Date.UTC(2026, 2, 8, 12, 0, 0);
+      const day = 24 * 60 * 60 * 1000;
+      const rows = [
+        makeRetrievalResult({
+          id: "dup-1",
+          text: "Keep DNS and mount post-checks in recovery flow.",
+          score: 0.97,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+        }),
+        makeRetrievalResult({
+          id: "dup-2",
+          text: "Keep dns and mount post-checks in recovery flow!",
+          score: 0.965,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+        }),
+        makeRetrievalResult({
+          id: "decision-1",
+          text: "Log rollback command and expected service state before edits.",
+          score: 0.94,
+          category: "decision",
+          scope: "global",
+          timestamp: now - 2 * day,
+        }),
+        makeRetrievalResult({
+          id: "pref-1",
+          text: "Respond with concise and factual status updates.",
+          score: 0.938,
+          category: "preference",
+          scope: "agent:main",
+          timestamp: now - 1 * day,
+        }),
+      ];
+
+      const forward = selectFinalAutoRecallResults(rows, { topK: 3, now });
+      const reversed = selectFinalAutoRecallResults([...rows].reverse(), { topK: 3, now });
+
+      assert.deepEqual(
+        forward.map((row) => row.entry.id),
+        reversed.map((row) => row.entry.id)
+      );
+    });
+
+    it("suppresses lexical-overlap paraphrases even when normalized keys differ", () => {
+      const now = Date.UTC(2026, 2, 8, 12, 0, 0);
+      const day = 24 * 60 * 60 * 1000;
+      const rows = [
+        makeRetrievalResult({
+          id: "dup-1",
+          text: "Keep DNS/mount post-check command list after service restart.",
+          score: 0.99,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+        }),
+        makeRetrievalResult({
+          id: "dup-2",
+          text: "Keep DNS mount post check command list after service restart",
+          score: 0.987,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+        }),
+        makeRetrievalResult({
+          id: "dup-3",
+          text: "Keep DNS-mount post check command list after service restart",
+          score: 0.984,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+        }),
+        makeRetrievalResult({
+          id: "decision-1",
+          text: "Write rollback command before editing service unit files.",
+          score: 0.955,
+          category: "decision",
+          scope: "global",
+          timestamp: now - 2 * day,
+        }),
+        makeRetrievalResult({
+          id: "pref-1",
+          text: "Prefer concise status updates after mandatory verification checks.",
+          score: 0.951,
+          category: "preference",
+          scope: "agent:main",
+          timestamp: now - 2 * day,
+        }),
+      ];
+
+      const selected = selectFinalAutoRecallResults(rows, { topK: 3, now });
+
+      assert.equal(selected.length, 3);
+      assert.equal(selected[0].entry.id, "dup-1");
+      assert.equal(selected.filter((row) => row.entry.id.startsWith("dup-")).length, 1);
+      assert.ok(selected.some((row) => row.entry.id === "decision-1"));
+      assert.ok(selected.some((row) => row.entry.id === "pref-1"));
+    });
+
+    it("suppresses semantic redundancy while preserving strongest top1", () => {
+      const now = Date.UTC(2026, 2, 8, 12, 0, 0);
+      const day = 24 * 60 * 60 * 1000;
+      const rows = [
+        makeRetrievalResult({
+          id: "sem-1",
+          text: "Use rollback checklist before restarting critical services.",
+          score: 0.992,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+          vector: [1, 0, 0, 0],
+        }),
+        makeRetrievalResult({
+          id: "sem-2",
+          text: "Maintain pre-restart safeguards for high-impact daemons.",
+          score: 0.989,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+          vector: [0.995, 0.005, 0, 0],
+        }),
+        makeRetrievalResult({
+          id: "sem-3",
+          text: "Record recovery expectations before applying config edits.",
+          score: 0.987,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+          vector: [0.996, 0.004, 0, 0],
+        }),
+        makeRetrievalResult({
+          id: "decision-1",
+          text: "Run post-check commands and store evidence timestamps.",
+          score: 0.956,
+          category: "decision",
+          scope: "global",
+          timestamp: now - 2 * day,
+          vector: [0, 1, 0, 0],
+        }),
+        makeRetrievalResult({
+          id: "pref-1",
+          text: "Keep responses concise and report only verified outcomes.",
+          score: 0.954,
+          category: "preference",
+          scope: "agent:main",
+          timestamp: now - 2 * day,
+          vector: [0, 0, 1, 0],
+        }),
+      ];
+
+      const selected = selectFinalAutoRecallResults(rows, { topK: 3, now });
+
+      assert.equal(selected.length, 3);
+      assert.equal(selected[0].entry.id, "sem-1");
+      assert.equal(selected.filter((row) => row.entry.id.startsWith("sem-")).length, 1);
+      assert.ok(selected.some((row) => row.entry.id === "decision-1"));
+      assert.ok(selected.some((row) => row.entry.id === "pref-1"));
+    });
+
+    it("keeps deterministic output under reversed order when semantic penalties are active", () => {
+      const now = Date.UTC(2026, 2, 8, 12, 0, 0);
+      const day = 24 * 60 * 60 * 1000;
+      const rows = [
+        makeRetrievalResult({
+          id: "sem-1",
+          text: "Store rollback checks before service restarts.",
+          score: 0.986,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+          vector: [1, 0, 0, 0],
+        }),
+        makeRetrievalResult({
+          id: "sem-2",
+          text: "Keep safety checklist in place ahead of daemon restarts.",
+          score: 0.983,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+          vector: [0.998, 0.002, 0, 0],
+        }),
+        makeRetrievalResult({
+          id: "decision-1",
+          text: "Record service state before changing systemd units.",
+          score: 0.95,
+          category: "decision",
+          scope: "global",
+          timestamp: now - 2 * day,
+          vector: [0, 1, 0, 0],
+        }),
+        makeRetrievalResult({
+          id: "pref-1",
+          text: "Keep final status reports concise and factual.",
+          score: 0.948,
+          category: "preference",
+          scope: "agent:main",
+          timestamp: now - 2 * day,
+          vector: [0, 0, 1, 0],
+        }),
+      ];
+
+      const forward = selectFinalAutoRecallResults(rows, { topK: 3, now });
+      const reversed = selectFinalAutoRecallResults([...rows].reverse(), { topK: 3, now });
+
+      assert.deepEqual(
+        forward.map((row) => row.entry.id),
+        reversed.map((row) => row.entry.id)
+      );
+    });
+
+    it("falls back safely to lexical-only behavior when vectors are missing or invalid", () => {
+      const now = Date.UTC(2026, 2, 8, 12, 0, 0);
+      const day = 24 * 60 * 60 * 1000;
+      const rows = [
+        makeRetrievalResult({
+          id: "dup-1",
+          text: "Keep DNS/mount checks mandatory after service edits.",
+          score: 0.99,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+          vector: [],
+        }),
+        makeRetrievalResult({
+          id: "dup-2",
+          text: "Keep DNS mount checks mandatory after service edits.",
+          score: 0.987,
+          category: "fact",
+          scope: "global",
+          timestamp: now - 1 * day,
+          vector: [Number.NaN, 1, 2],
+        }),
+        makeRetrievalResult({
+          id: "decision-1",
+          text: "Write rollback plan before changing service units.",
+          score: 0.955,
+          category: "decision",
+          scope: "global",
+          timestamp: now - 2 * day,
+          vector: undefined,
+        }),
+        makeRetrievalResult({
+          id: "pref-1",
+          text: "Report only verified outcomes in short status updates.",
+          score: 0.951,
+          category: "preference",
+          scope: "agent:main",
+          timestamp: now - 2 * day,
+          vector: new Float32Array([0, 1, 0, 0]),
+        }),
+      ];
+
+      const selected = selectFinalAutoRecallResults(rows, { topK: 3, now });
+      const reversed = selectFinalAutoRecallResults([...rows].reverse(), { topK: 3, now });
+
+      assert.equal(selected.length, 3);
+      assert.equal(selected[0].entry.id, "dup-1");
+      assert.equal(selected.filter((row) => row.entry.id.startsWith("dup-")).length, 1);
+      assert.deepEqual(
+        selected.map((row) => row.entry.id),
+        reversed.map((row) => row.entry.id)
+      );
+    });
+  });
+
   describe("dynamic reflection recall ranking", () => {
     it("filters stale rows by time window", () => {
       const now = Date.UTC(2026, 2, 8);
@@ -1303,6 +1657,9 @@ describe("memory reflection", () => {
         [...new Set(rows.map((row) => row.kind))].sort(),
         ["derived", "invariant"]
       );
+      for (const row of rows) {
+        assert.match(row.id, /^reflection:(derived|invariant)::/);
+      }
       assert.equal(new Set(rows.map((row) => row.id)).size, 2);
       assert.equal(new Set(rows.map((row) => normalizeReflectionSoftKey(row.text))).size, 1);
     });
@@ -1862,6 +2219,130 @@ describe("memory reflection", () => {
       assert.match(relevant.prependContext, /User prefers concise incident updates\./);
       assert.match(relevant.prependContext, /Decide to verify services after config edits\./);
       assert.match(inherited.prependContext, /Dynamic reflection rule 1/);
+    });
+  });
+
+  describe("generic auto-recall selection mode compatibility", () => {
+    let workspaceDir;
+    let originalRetrieve;
+    const now = Date.UTC(2026, 2, 8, 12, 0, 0);
+    const day = 24 * 60 * 60 * 1000;
+
+    beforeEach(() => {
+      workspaceDir = mkdtempSync(path.join(tmpdir(), "generic-auto-recall-selection-mode-test-"));
+      originalRetrieve = MemoryRetriever.prototype.retrieve;
+    });
+
+    afterEach(() => {
+      MemoryRetriever.prototype.retrieve = originalRetrieve;
+      rmSync(workspaceDir, { recursive: true, force: true });
+    });
+
+    function buildGenericRecallRows() {
+      return [
+        {
+          entry: {
+            id: "dup-1",
+            text: "Restart API service after config updates.",
+            category: "fact",
+            scope: "global",
+            timestamp: now - 1 * day,
+            vector: [],
+            importance: 0.8,
+            metadata: "{}",
+          },
+          score: 0.99,
+          sources: {},
+        },
+        {
+          entry: {
+            id: "dup-2",
+            text: "restart api service after config updates.",
+            category: "fact",
+            scope: "global",
+            timestamp: now - 2 * day,
+            vector: [],
+            importance: 0.8,
+            metadata: "{}",
+          },
+          score: 0.97,
+          sources: {},
+        },
+        {
+          entry: {
+            id: "alt-1",
+            text: "Run DNS and mount health checks after restart.",
+            category: "decision",
+            scope: "global",
+            timestamp: now - 1 * day,
+            vector: [],
+            importance: 0.8,
+            metadata: "{}",
+          },
+          score: 0.65,
+          sources: {},
+        },
+      ];
+    }
+
+    it("legacy mode bypasses set-wise selector and uses direct truncation", async () => {
+      MemoryRetriever.prototype.retrieve = async () => buildGenericRecallRows();
+
+      const harness = createPluginApiHarness({
+        resolveRoot: workspaceDir,
+        pluginConfig: {
+          embedding: { apiKey: "test-api-key" },
+          autoCapture: false,
+          autoRecall: true,
+          autoRecallTopK: 2,
+          autoRecallSelectionMode: "legacy",
+          autoRecallMinLength: 1,
+          selfImprovement: { enabled: false, beforeResetNote: false, ensureLearningFiles: false },
+        },
+      });
+      memoryLanceDBProPlugin.register(harness.api);
+
+      const hooks = harness.eventHandlers.get("before_agent_start") || [];
+      assert.equal(hooks.length, 1);
+      const output = await hooks[0].handler(
+        { prompt: "Need rollout memories now." },
+        { sessionId: "legacy-mode", sessionKey: "agent:main:session:legacy-mode", agentId: "main" }
+      );
+      assert.ok(output);
+      assert.match(output.prependContext, /<relevant-memories>/);
+      assert.match(output.prependContext, /Restart API service after config updates\./);
+      assert.match(output.prependContext, /restart api service after config updates\./);
+      assert.doesNotMatch(output.prependContext, /Run DNS and mount health checks after restart\./);
+    });
+
+    it("setwise-v2 mode uses set-wise selector for final top-k", async () => {
+      MemoryRetriever.prototype.retrieve = async () => buildGenericRecallRows();
+
+      const harness = createPluginApiHarness({
+        resolveRoot: workspaceDir,
+        pluginConfig: {
+          embedding: { apiKey: "test-api-key" },
+          autoCapture: false,
+          autoRecall: true,
+          autoRecallTopK: 2,
+          autoRecallSelectionMode: "setwise-v2",
+          autoRecallMinLength: 1,
+          selfImprovement: { enabled: false, beforeResetNote: false, ensureLearningFiles: false },
+        },
+      });
+      memoryLanceDBProPlugin.register(harness.api);
+
+      const hooks = harness.eventHandlers.get("before_agent_start") || [];
+      assert.equal(hooks.length, 1);
+      const output = await hooks[0].handler(
+        { prompt: "Need rollout memories now." },
+        { sessionId: "setwise-mode", sessionKey: "agent:main:session:setwise-mode", agentId: "main" }
+      );
+      assert.ok(output);
+      assert.match(output.prependContext, /<relevant-memories>/);
+      assert.match(output.prependContext, /Restart API service after config updates\./);
+      assert.match(output.prependContext, /Run DNS and mount health checks after restart\./);
+      assert.doesNotMatch(output.prependContext, /restart api service after config updates\./);
     });
   });
 });


### PR DESCRIPTION
## Summary
- replace generic auto-recall's final `MMR + direct truncation` behavior with a shared set-wise final-selection pipeline that is opt-in through `autoRecallSelectionMode=setwise-v2`
- keep compatibility by defaulting generic auto-recall to `autoRecallSelectionMode=legacy`
- route dynamic Reflection-Recall through the same shared final selector at the final cutoff seam while preserving `kind + strictKey` partitioning and deterministic ordering
- update README / README_CN / config docs so architecture, file reference, and configuration guidance match the current runtime wiring

## Why
- generic auto-recall previously depended on retriever ordering plus post-processing and direct truncation at the last step, so final diversity quality was largely limited to retriever-stage coarse MMR behavior
- that made the final top-k path too weak for lexical paraphrases and semantic near-duplicates, while also leaving no compatibility-controlled place to evolve product-level final selection semantics
- dynamic Reflection-Recall had already moved toward helper-based grouping/selection, but the repo still lacked one clearly documented shared final-selector layer and a clean generic compatibility story
- README / README_CN architecture and file reference sections no longer described the actual module boundaries after the reflection recall and final-selector refactors

## Data Flow
### Generic auto-recall path
1. `before_agent_start` in `index.ts` triggers generic auto-recall when `autoRecall=true`
2. `retriever.retrieve(...)` in `src/retriever.ts` still owns:
   - vector / BM25 retrieval
   - RRF fusion
   - rerank
   - recency / importance / length / time-decay weighting
   - noise filtering
   - coarse MMR diversity
3. `postProcessAutoRecallResults(...)` in `index.ts` still owns:
   - category allowlist filtering
   - reflection exclusion
   - age-window filtering
   - recent-per-normalized-key capping
4. the final seam is now explicit:
   - `autoRecallSelectionMode=legacy` -> direct truncation (`slice(0, topK)`) for compatibility
   - `autoRecallSelectionMode=setwise-v2` -> `selectFinalAutoRecallResults(...)`
5. `src/auto-recall-final-selection.ts` adapts generic retrieval rows into final-selection candidates
6. `src/final-topk-setwise-selection.ts` performs deterministic shortlist presort and set-wise final top-k selection
7. `src/recall-engine.ts` still owns repeated-injection/session suppression and tagged-block assembly for `<relevant-memories>`

### Dynamic Reflection-Recall path
1. `before_agent_start` in `index.ts` triggers reflection recall when `memoryReflection.recall.mode="dynamic"`
2. `rankDynamicReflectionRecallFromEntries(...)` in `src/reflection-recall.ts` loads eligible reflection items and computes per-item reflection scores
3. `aggregateReflectionGroups(...)` in `src/reflection-aggregation.ts` groups rows with `kind + strictKey` semantics and produces group-level scores
4. `selectFinalReflectionRecallGroups(...)` in `src/reflection-recall-final-selection.ts` adapts grouped reflection rows into the shared final-selector layer
5. `src/final-topk-setwise-selection.ts` applies deterministic final selection at the reflection cutoff seam
6. output remains the same public row shape for `<inherited-rules>` and reflection fixed/dynamic mode semantics stay separate from the generic selection-mode switch

## Scoring / Selection Model
### Generic legacy mode
Legacy mode now means:
- keep the retriever's ranked results, including coarse MMR diversity in `src/retriever.ts`
- then apply generic post-processing
- then apply direct final truncation (`slice(0, topK)`) for compatibility

This preserves prior product behavior instead of silently forcing the new selector on existing users.

### Generic `setwise-v2` final selection
The shared final selector introduces an explicit final shortlist-to-top-k model for generic auto-recall.

At a high level, it optimizes for:
- relevance from retrieval score
- freshness
- light category/scope coverage
- lexical near-duplicate suppression
- semantic near-duplicate suppression
- deterministic ordering

More concretely:
- shortlist presort is deterministic (`baseScore -> timestamp -> id/text fallback`)
- exact/normalized-key duplicates receive strong suppression
- lexical overlap thresholds penalize paraphrases even when normalized keys differ
- embedding-based semantic redundancy penalizes candidates that are too close to already-selected rows
- invalid or missing vectors degrade safely to lexical-only behavior instead of throwing

### Reflection final selection
For dynamic Reflection-Recall, this PR does **not** replace the reflection-specific ranking model.
It keeps:
- reflection per-item scoring
- reflection aggregation
- `kind + strictKey` partitioning

The shared selector is used only at the final top-k seam so reflection recall and generic recall can reuse the same deterministic final-selection layer without collapsing their ranking semantics into one model.

## What Changed
In plain language, this PR changes generic auto-recall from:
- retriever output
- post-processing
- direct final truncation

into:
- retriever output
- post-processing
- explicit mode-based final seam
  - `legacy` for compatibility
  - `setwise-v2` for stronger final diversity control

At the same time, it makes the reflection path's final cutoff use the same shared selector infrastructure while preserving reflection-specific grouping semantics.

Concretely:
- add `src/final-topk-setwise-selection.ts` as the shared final shortlist-to-top-k selector
- add `src/auto-recall-final-selection.ts` for generic candidate adaptation and mode-specific generic final-selection wiring
- add `src/reflection-recall-final-selection.ts` for reflection candidate adaptation into the shared selector
- update `index.ts` to branch generic auto-recall by `autoRecallSelectionMode` only after `postProcessAutoRecallResults(...)`
- update `src/reflection-recall.ts` to use the reflection final-selection adapter
- add `autoRecallSelectionMode` to `openclaw.plugin.json` with `legacy` default and `setwise-v2` opt-in
- update README / README_CN architecture, file reference, Session Strategy, Self-Improvement, memoryReflection, Markdown Mirror, and auto-recall sections so docs are configuration-first and match the actual runtime paths
- update changelog wording so the compatibility/default story is explicit

## Verification
- `node --test test/memory-reflection.test.mjs test/config-session-strategy-migration.test.mjs`
- `npm test`
- final local verification after upstream merge: `npm test`

New / updated tests cover:
- generic exact-duplicate reduction with strongest top1 preserved
- deterministic generic output under reversed input order
- lexical-overlap paraphrase suppression even when normalized keys differ
- embedding-based semantic redundancy suppression with top1 preservation
- lexical-only fallback when vectors are missing or invalid
- config parsing for generic `autoRecallSelectionMode`
- compatibility branching:
  - `legacy` bypasses set-wise final selection and keeps direct truncation semantics
  - `setwise-v2` uses the shared final selector
- reflection recall still preserves `kind + strictKey` separation and deterministic output
- reflection / generic coexistence still keeps `<relevant-memories>` and `<inherited-rules>` independent

## Risks / Compatibility
- generic auto-recall defaults to `legacy`, so existing deployments do not silently change behavior
- `setwise-v2` is explicitly opt-in and can be enabled when reviewers/users want the stronger final diversity filtering path
- retriever-stage public behavior is unchanged; this PR does not remove or rewrite retriever MMR logic
- Reflection-Recall `fixed | dynamic` semantics remain unchanged and are not renamed into the generic compatibility switch
- repo-local planning docs were intentionally excluded from the shipped diff
