### PR TITLE
fix(reflection): write artifacts to the source agent workspace

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1330,16 +1330,26 @@ type AgentWorkspaceMap = Record<string, string>;
 function resolveAgentWorkspaceMap(api: OpenClawPluginApi): AgentWorkspaceMap {
   const map: AgentWorkspaceMap = {};
 
-  // Try api.config first (runtime config)
-  const agents = Array.isArray((api as any).config?.agents?.list)
-    ? (api as any).config.agents.list
-    : [];
+  const assignFromConfigRoot = (root: any) => {
+    const defaultWorkspace = typeof root?.agents?.defaults?.workspace === "string"
+      ? root.agents.defaults.workspace
+      : undefined;
+    const agents = Array.isArray(root?.agents?.list)
+      ? root.agents.list
+      : [];
 
-  for (const agent of agents) {
-    if (agent?.id && typeof agent.workspace === "string") {
-      map[String(agent.id)] = agent.workspace;
+    for (const agent of agents) {
+      if (!agent?.id) continue;
+      const explicitWorkspace = typeof agent.workspace === "string" ? agent.workspace : undefined;
+      const resolvedWorkspace = explicitWorkspace || defaultWorkspace;
+      if (resolvedWorkspace) {
+        map[String(agent.id)] = resolvedWorkspace;
+      }
     }
-  }
+  };
+
+  // Try api.config first (runtime config)
+  assignFromConfigRoot((api as any).config || {});
 
   // Fallback: read from openclaw.json (respect OPENCLAW_HOME if set)
   if (Object.keys(map).length === 0) {
@@ -1348,14 +1358,7 @@ function resolveAgentWorkspaceMap(api: OpenClawPluginApi): AgentWorkspaceMap {
       const configPath = join(openclawHome, "openclaw.json");
       const raw = readFileSync(configPath, "utf8");
       const parsed = JSON.parse(raw);
-      const list = parsed?.agents?.list;
-      if (Array.isArray(list)) {
-        for (const agent of list) {
-          if (agent?.id && typeof agent.workspace === "string") {
-            map[String(agent.id)] = agent.workspace;
-          }
-        }
-      }
+      assignFromConfigRoot(parsed || {});
     } catch {
       /* silent */
     }
@@ -2191,7 +2194,9 @@ const memoryLanceDBProPlugin = {
           const currentSessionId = typeof sessionEntry.sessionId === "string" ? sessionEntry.sessionId : "unknown";
           let currentSessionFile = typeof sessionEntry.sessionFile === "string" ? sessionEntry.sessionFile : undefined;
           const sourceAgentId = parseAgentIdFromSessionKey(sessionKey) || "main";
-          const effectiveWorkspaceDir = agentWorkspaceMap[sourceAgentId] || workspaceDir;
+          const sourceWorkspaceDir = agentWorkspaceMap[sourceAgentId] || workspaceDir;
+          const reflectionRunAgentId = resolveReflectionRunAgentId(cfg, sourceAgentId);
+          const reflectionWorkspaceDir = agentWorkspaceMap[reflectionRunAgentId] || sourceWorkspaceDir;
           const commandSource = typeof context.commandSource === "string" ? context.commandSource : "";
           const triggerKey = `${String(event?.action || "unknown")}|${sessionKey || "(none)"}|${currentSessionFile || currentSessionId || "unknown"}`;
           if (isDuplicateReflectionTrigger(triggerKey)) {
@@ -2208,7 +2213,7 @@ const memoryLanceDBProPlugin = {
             const searchDirs = resolveReflectionSessionSearchDirs({
               context,
               cfg,
-              workspaceDir,
+              workspaceDir: sourceWorkspaceDir,
               currentSessionFile,
               sourceAgentId,
             });
@@ -2231,7 +2236,7 @@ const memoryLanceDBProPlugin = {
             const searchDirs = resolveReflectionSessionSearchDirs({
               context,
               cfg,
-              workspaceDir,
+              workspaceDir: sourceWorkspaceDir,
               currentSessionFile,
               sourceAgentId,
             });
@@ -2255,7 +2260,6 @@ const memoryLanceDBProPlugin = {
           const timeIso = now.toISOString().split("T")[1].replace("Z", "");
           const timeHms = timeIso.split(".")[0];
           const timeCompact = timeIso.replace(/[:.]/g, "");
-          const reflectionRunAgentId = resolveReflectionRunAgentId(cfg, sourceAgentId);
           const targetScope = scopeManager.getDefaultScope(sourceAgentId);
           const toolErrorSignals = sessionKey
             ? (reflectionErrorStateBySession.get(sessionKey)?.entries ?? []).slice(-reflectionErrorReminderMaxEntries)
@@ -2269,7 +2273,7 @@ const memoryLanceDBProPlugin = {
             maxInputChars: reflectionMaxInputChars,
             cfg,
             agentId: reflectionRunAgentId,
-            workspaceDir: effectiveWorkspaceDir,
+            workspaceDir: reflectionWorkspaceDir,
             timeoutMs: reflectionTimeoutMs,
             thinkLevel: reflectionThinkLevel,
             toolErrorSignals,
@@ -2337,7 +2341,7 @@ const memoryLanceDBProPlugin = {
           ].join("\n");
           const reflectionBody = `${header}${reflectionText.trim()}\n`;
 
-          const outDir = join(effectiveWorkspaceDir, "memory", "reflections", dateStr);
+          const outDir = join(sourceWorkspaceDir, "memory", "reflections", dateStr);
           await mkdir(outDir, { recursive: true });
           const agentToken = sanitizeFileToken(sourceAgentId, "agent");
           const sessionToken = sanitizeFileToken(currentSessionId || "unknown", "session");
@@ -2347,7 +2351,7 @@ const memoryLanceDBProPlugin = {
             const suffix = attempt === 0 ? "" : `-${Math.random().toString(36).slice(2, 8)}`;
             const fileName = `${timeCompact}-${agentToken}-${sessionToken}${suffix}.md`;
             const candidateRelPath = join("memory", "reflections", dateStr, fileName);
-            const candidateOutPath = join(effectiveWorkspaceDir, candidateRelPath);
+            const candidateOutPath = join(sourceWorkspaceDir, candidateRelPath);
             try {
               await writeFile(candidateOutPath, reflectionBody, { encoding: "utf-8", flag: "wx" });
               relPath = candidateRelPath;
@@ -2366,7 +2370,7 @@ const memoryLanceDBProPlugin = {
           if (config.selfImprovement?.enabled !== false && reflectionGovernanceCandidates.length > 0) {
             for (const candidate of reflectionGovernanceCandidates) {
               await appendSelfImprovementEntry({
-                baseDir: effectiveWorkspaceDir,
+                baseDir: sourceWorkspaceDir,
                 type: "learning",
                 summary: candidate.summary,
                 details: candidate.details,
@@ -2455,7 +2459,7 @@ const memoryLanceDBProPlugin = {
             }
           }
 
-          const dailyPath = join(effectiveWorkspaceDir, "memory", `${dateStr}.md`);
+          const dailyPath = join(sourceWorkspaceDir, "memory", `${dateStr}.md`);
           await ensureDailyLogFile(dailyPath, dateStr);
           await appendFile(dailyPath, `- [${timeHms} UTC] Reflection generated: \`${relPath}\`\n`, "utf-8");
 


### PR DESCRIPTION
## Summary

This fixes a workspace routing bug in the reflection pipeline.

When `sessionStrategy = "memoryReflection"` is enabled, reflection artifacts were written using the hook context `workspaceDir` instead of the workspace that belongs to the `sourceAgentId` parsed from the session key.

As a result, a reflection generated for agents such as `feishu-her` could be stored under the main workspace, for example:

- `workspace/memory/reflections/...`
- `workspace/memory/YYYY-MM-DD.md`
- `workspace/.learnings/...`

instead of the agent-specific workspace such as `workspace-feishu/...`.

## Root cause

[runMemoryReflection()](cci:1://file:///mnt/user/DataCache/openclaw/.openclaw/plugins/memory-lancedb-pro/index.ts:2176:6-2470:8) correctly derived `sourceAgentId` from `sessionKey`, but still used the event/context `workspaceDir` for:

- reflection markdown output
- daily memory log append
- self-improvement learning append

This mixed agent identity with the wrong filesystem target.

## Changes

- resolve `agentWorkspaceMap` once during plugin registration
- derive `effectiveWorkspaceDir` from `sourceAgentId`
- use `effectiveWorkspaceDir` instead of the hook context workspace for:
  - reflection output directory
  - reflection file write path
  - `.learnings` append base dir
  - daily memory log path
- keep the existing context workspace as fallback if the agent workspace is unavailable

## Behavior after this change

Reflection artifacts now follow the workspace of the source agent.

For example, `feishu-her` reflections are written to:

- `workspace-feishu/memory/reflections/...`
- `workspace-feishu/memory/YYYY-MM-DD.md`

instead of leaking into the main workspace.

## Notes

This is a minimal fix and does not change reflection content generation, retrieval, or storage semantics beyond correcting the filesystem target.