### PR TITLE
fix(memory): harden recall injection prompt timing and skip gates

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2088,82 +2088,90 @@ const memoryLanceDBProPlugin = {
         }
       }, { priority: 15 });
 
-      api.on("before_agent_start", async (event, ctx) => {
-        const sessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : "";
-        if (isInternalReflectionSessionKey(sessionKey)) return;
-        if (reflectionInjectMode !== "inheritance-only" && reflectionInjectMode !== "inheritance+derived") return;
-        try {
-          pruneReflectionSessionState();
-          const agentId = typeof ctx.agentId === "string" && ctx.agentId.trim() ? ctx.agentId.trim() : "main";
-          const scopes = scopeManager.getAccessibleScopes(agentId);
-          if (reflectionRecallMode === "fixed") {
-            const slices = await loadAgentReflectionSlices(agentId, scopes);
-            if (slices.invariants.length === 0) return;
-            const body = slices.invariants.slice(0, 6).map((line, i) => `${i + 1}. ${line}`).join("\n");
-            return {
-              prependContext: [
-                "<inherited-rules>",
-                "Stable rules inherited from memory-lancedb-pro reflections. Treat as long-term behavioral constraints unless user overrides.",
-                body,
-                "</inherited-rules>",
-              ].join("\n"),
-            };
-          }
-
-          const sessionId = ctx?.sessionId || "default";
-          const topK = Math.max(1, reflectionRecallTopK);
-          const listLimit = Math.min(800, Math.max(topK * 40, 240));
-          const result = await orchestrateDynamicRecall({
-            channelName: "reflection-recall",
-            prompt: event.prompt,
-            minPromptLength: reflectionRecallMinPromptLength,
-            minRepeated: reflectionRecallMinRepeated,
-            topK,
-            sessionId,
-            state: reflectionDynamicRecallState,
-            outputTag: "inherited-rules",
-            headerLines: [
-              "Dynamic rules selected by Reflection-Recall. Treat as long-term behavioral constraints unless user overrides.",
-            ],
-            logger: api.logger,
-            loadCandidates: async () => {
-              const entries = await store.list(scopes, "reflection", listLimit, 0);
-              return rankDynamicReflectionRecallFromEntries(entries, {
-                agentId,
-                includeKinds: reflectionRecallIncludeKinds,
-                topK,
-                maxAgeMs: daysToMs(reflectionRecallMaxAgeDays),
-                maxEntriesPerKey: reflectionRecallMaxEntriesPerKey,
-                minScore: reflectionRecallMinScore,
-              });
-            },
-            formatLine: (row, index) =>
-              `${index + 1}. ${sanitizeForContext(row.text)} (${(row.score * 100).toFixed(0)}%)`,
-          });
-          if (!result) return;
-          return { prependContext: result.prependContext };
-        } catch (err) {
-          api.logger.warn(`memory-reflection: reflection-recall injection failed: ${String(err)}`);
+      const buildReflectionRecallPrependContext = async (
+        event: { prompt?: string } | undefined,
+        ctx: { sessionId?: string; sessionKey?: string; agentId?: string },
+      ): Promise<string | undefined> => {
+        const agentId = typeof ctx.agentId === "string" && ctx.agentId.trim() ? ctx.agentId.trim() : "main";
+        const scopes = scopeManager.getAccessibleScopes(agentId);
+        if (reflectionRecallMode === "fixed") {
+          const slices = await loadAgentReflectionSlices(agentId, scopes);
+          if (slices.invariants.length === 0) return undefined;
+          const body = slices.invariants.slice(0, 6).map((line, i) => `${i + 1}. ${line}`).join("\n");
+          return [
+            "<inherited-rules>",
+            "Stable rules inherited from memory-lancedb-pro reflections. Treat as long-term behavioral constraints unless user overrides.",
+            body,
+            "</inherited-rules>",
+          ].join("\n");
         }
-      }, { priority: 12 });
 
-      api.on("before_prompt_build", async (_event, ctx) => {
+        const sessionId = ctx?.sessionId || ctx?.sessionKey || "default";
+        const topK = Math.max(1, reflectionRecallTopK);
+        const listLimit = Math.min(800, Math.max(topK * 40, 240));
+        const result = await orchestrateDynamicRecall({
+          channelName: "reflection-recall",
+          prompt: event?.prompt,
+          minPromptLength: reflectionRecallMinPromptLength,
+          minRepeated: reflectionRecallMinRepeated,
+          topK,
+          sessionId,
+          state: reflectionDynamicRecallState,
+          outputTag: "inherited-rules",
+          headerLines: [
+            "Dynamic rules selected by Reflection-Recall. Treat as long-term behavioral constraints unless user overrides.",
+          ],
+          logger: api.logger,
+          loadCandidates: async () => {
+            const entries = await store.list(scopes, "reflection", listLimit, 0);
+            return rankDynamicReflectionRecallFromEntries(entries, {
+              agentId,
+              includeKinds: reflectionRecallIncludeKinds,
+              topK,
+              maxAgeMs: daysToMs(reflectionRecallMaxAgeDays),
+              maxEntriesPerKey: reflectionRecallMaxEntriesPerKey,
+              minScore: reflectionRecallMinScore,
+            });
+          },
+          formatLine: (row, index) =>
+            `${index + 1}. ${sanitizeForContext(row.text)} (${(row.score * 100).toFixed(0)}%)`,
+        });
+        return result?.prependContext;
+      };
+
+      api.on("before_prompt_build", async (event, ctx) => {
         const sessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : "";
         if (isInternalReflectionSessionKey(sessionKey)) return;
         pruneReflectionSessionState();
 
-        if (!sessionKey) return;
-        const pending = getPendingReflectionErrorSignalsForPrompt(sessionKey, reflectionErrorReminderMaxEntries);
-        if (pending.length === 0) return;
-        return {
-          prependContext: [
-            "<error-detected>",
-            "A tool error was detected. Consider logging this to `.learnings/ERRORS.md` if it is non-trivial or likely to recur.",
-            "Recent error signals:",
-            ...pending.map((e, i) => `${i + 1}. [${e.toolName}] ${e.summary}`),
-            "</error-detected>",
-          ].join("\n"),
-        };
+        const contextBlocks: string[] = [];
+
+        if (reflectionInjectMode === "inheritance-only" || reflectionInjectMode === "inheritance+derived") {
+          try {
+            const inheritedRules = await buildReflectionRecallPrependContext(event, ctx);
+            if (inheritedRules) {
+              contextBlocks.push(inheritedRules);
+            }
+          } catch (err) {
+            api.logger.warn(`memory-reflection: reflection-recall injection failed: ${String(err)}`);
+          }
+        }
+
+        if (sessionKey) {
+          const pending = getPendingReflectionErrorSignalsForPrompt(sessionKey, reflectionErrorReminderMaxEntries);
+          if (pending.length > 0) {
+            contextBlocks.push([
+              "<error-detected>",
+              "A tool error was detected. Consider logging this to `.learnings/ERRORS.md` if it is non-trivial or likely to recur.",
+              "Recent error signals:",
+              ...pending.map((e, i) => `${i + 1}. [${e.toolName}] ${e.summary}`),
+              "</error-detected>",
+            ].join("\n"));
+          }
+        }
+
+        if (contextBlocks.length === 0) return;
+        return { prependContext: contextBlocks.join("\n\n") };
       }, { priority: 15 });
 
       api.on("session_end", (_event, ctx) => {
@@ -2508,7 +2516,7 @@ const memoryLanceDBProPlugin = {
           api.logger.warn(`memory-reflection: before_reset fallback failed: ${String(err)}`);
         }
       }, { priority: 12 });
-      api.logger.info("memory-reflection: integrated hooks registered (command:new, command:reset, after_tool_call, before_agent_start, before_prompt_build)");
+      api.logger.info("memory-reflection: integrated hooks registered (command:new, command:reset, after_tool_call, before_prompt_build[inherited-rules,error-detected])");
     }
 
     if (config.sessionStrategy === "systemSessionMemory") {

--- a/src/adaptive-retrieval.ts
+++ b/src/adaptive-retrieval.ts
@@ -5,6 +5,14 @@
  * Saves embedding API calls and reduces noise injection.
  */
 
+// Control/system prompts that should never trigger retrieval
+const CONTROL_PROMPT_SKIP_PATTERNS = [
+  // Session-start/control boilerplate wrappers
+  /A new session was started via \/new or \/reset/i,
+  /Execute your Session Startup sequence now/i,
+  /(^|\n)\s*\/note\b/i,
+];
+
 // Queries that are clearly NOT memory-retrieval candidates
 const SKIP_PATTERNS = [
   // Greetings & pleasantries
@@ -69,6 +77,9 @@ function normalizeQuery(query: string): string {
  */
 export function shouldSkipRetrieval(query: string, minLength?: number): boolean {
   const trimmed = normalizeQuery(query);
+
+  // Control/system wrappers should always skip retrieval.
+  if (CONTROL_PROMPT_SKIP_PATTERNS.some(p => p.test(trimmed))) return true;
 
   // Force retrieve if query has memory-related intent (checked FIRST,
   // before length check, so short CJK queries like "你记得吗" aren't skipped)

--- a/test/helpers/openclaw-extension-api-stub.mjs
+++ b/test/helpers/openclaw-extension-api-stub.mjs
@@ -28,7 +28,7 @@ export async function runEmbeddedPiAgent() {
           "- memory-reflection",
           "",
           "## Invariants",
-          "- Keep inherited-rules in before_agent_start only.",
+          "- Keep inherited-rules in before_prompt_build only.",
           "",
           "## Derived",
           "- Fresh derived line from this run.",

--- a/test/memory-reflection.test.mjs
+++ b/test/memory-reflection.test.mjs
@@ -42,6 +42,7 @@ const {
   clearDynamicRecallSessionState,
   orchestrateDynamicRecall,
 } = jiti("../src/recall-engine.ts");
+const { shouldSkipRetrieval } = jiti("../src/adaptive-retrieval.ts");
 const {
   REFLECTION_INVARIANT_DECAY_MIDPOINT_DAYS,
   REFLECTION_INVARIANT_DECAY_K,
@@ -181,6 +182,28 @@ describe("memory reflection", () => {
       assert.match(conversation, /assistant: Acknowledged\. I will keep responses concise and factual\./);
       assert.doesNotMatch(conversation, /old reset snapshot/);
       assert.doesNotMatch(conversation, /^user:\s*\/new/m);
+    });
+  });
+
+  describe("adaptive retrieval control prompt skip gate", () => {
+    it("skips session-start boilerplate containing /new or /reset", () => {
+      const prompt = "A new session was started via /new or /reset. Keep this in mind.";
+      assert.equal(shouldSkipRetrieval(prompt), true);
+    });
+
+    it("skips startup boilerplate containing session startup sequence text", () => {
+      const prompt = "Execute your Session Startup sequence now before continuing.";
+      assert.equal(shouldSkipRetrieval(prompt), true);
+    });
+
+    it("skips /note handoff/control prompts", () => {
+      const prompt = "Control wrapper line\n/note self-improvement (before reset): preserve incident timeline.";
+      assert.equal(shouldSkipRetrieval(prompt), true);
+    });
+
+    it("does not skip a normal user task prompt", () => {
+      const prompt = "Please draft a rollback checklist for mosdns and rclone incidents.";
+      assert.equal(shouldSkipRetrieval(prompt), false);
     });
   });
 
@@ -1626,10 +1649,10 @@ describe("memory reflection", () => {
       rmSync(workspaceDir, { recursive: true, force: true });
     });
 
-    it("keeps inherited-rules in before_agent_start and builds note with fresh open-loops + historical derived-focus", async () => {
-      const beforeAgentStartHooks = harness.eventHandlers.get("before_agent_start") || [];
-      assert.equal(beforeAgentStartHooks.length, 1);
-      const inheritedResult = await beforeAgentStartHooks[0].handler({}, {
+    it("injects inherited-rules in before_prompt_build and builds note with fresh open-loops + historical derived-focus", async () => {
+      const beforePromptHooks = harness.eventHandlers.get("before_prompt_build") || [];
+      assert.equal(beforePromptHooks.length, 1);
+      const inheritedResult = await beforePromptHooks[0].handler({}, {
         sessionKey: "agent:main:session:s1",
         agentId: "main",
       });
@@ -1668,7 +1691,7 @@ describe("memory reflection", () => {
       assert.doesNotMatch(messages[0], /Historical stale follow-up should be filtered\./);
     });
 
-    it("keeps error-detected in before_prompt_build without derived-focus", async () => {
+    it("keeps error-detected in before_prompt_build and coexists with inherited-rules", async () => {
       const afterToolHooks = harness.eventHandlers.get("after_tool_call") || [];
       const beforePromptHooks = harness.eventHandlers.get("before_prompt_build") || [];
       assert.equal(afterToolHooks.length, 1);
@@ -1683,6 +1706,7 @@ describe("memory reflection", () => {
         sessionKey: "agent:main:session:s1",
         agentId: "main",
       });
+      assert.match(promptResult.prependContext, /<inherited-rules>/);
       assert.match(promptResult.prependContext, /<error-detected>/);
       assert.match(promptResult.prependContext, /\[shell\]/);
       assert.doesNotMatch(promptResult.prependContext, /<derived-focus>/);
@@ -1829,27 +1853,32 @@ describe("memory reflection", () => {
       });
       memoryLanceDBProPlugin.register(fixedHarness.api);
 
-      const hooks = fixedHarness.eventHandlers.get("before_agent_start") || [];
-      const outputs = await Promise.all(hooks.map((hook) => hook.handler(
+      const autoRecallHooks = fixedHarness.eventHandlers.get("before_agent_start") || [];
+      assert.equal(autoRecallHooks.length, 1);
+      const promptHooks = fixedHarness.eventHandlers.get("before_prompt_build") || [];
+      assert.equal(promptHooks.length, 1);
+      const inherited = await promptHooks[0].handler(
         { prompt: "Please recall relevant constraints for this task." },
         { sessionId: "fixed-s1", sessionKey: "agent:main:session:fixed-s1", agentId: "main" }
-      )));
-      const inherited = outputs.find((result) => result?.prependContext?.includes("<inherited-rules>"));
+      );
       assert.ok(inherited);
       assert.match(inherited.prependContext, /Dynamic reflection rule 1|Stable rules inherited from memory-lancedb-pro reflections\./);
     });
 
     it("keeps dynamic reflection top-k independent from relevant-memories top-k and excludes reflection rows from auto-recall", async () => {
-      const hooks = harness.eventHandlers.get("before_agent_start") || [];
-      assert.equal(hooks.length, 2);
+      const beforeAgentStartHooks = harness.eventHandlers.get("before_agent_start") || [];
+      const beforePromptHooks = harness.eventHandlers.get("before_prompt_build") || [];
+      assert.equal(beforeAgentStartHooks.length, 1);
+      assert.equal(beforePromptHooks.length, 1);
 
-      const outputs = await Promise.all(hooks.map((hook) => hook.handler(
+      const relevant = await beforeAgentStartHooks[0].handler(
         { prompt: "Need a concise plan and recall prior decisions for this deploy?" },
         { sessionId: "s-dyn", sessionKey: "agent:main:session:s-dyn", agentId: "main" }
-      )));
-
-      const relevant = outputs.find((result) => result?.prependContext?.includes("<relevant-memories>"));
-      const inherited = outputs.find((result) => result?.prependContext?.includes("<inherited-rules>"));
+      );
+      const inherited = await beforePromptHooks[0].handler(
+        { prompt: "Need a concise plan and recall prior decisions for this deploy?" },
+        { sessionId: "s-dyn", sessionKey: "agent:main:session:s-dyn", agentId: "main" }
+      );
       assert.ok(relevant);
       assert.ok(inherited);
 
@@ -1862,6 +1891,49 @@ describe("memory reflection", () => {
       assert.match(relevant.prependContext, /User prefers concise incident updates\./);
       assert.match(relevant.prependContext, /Decide to verify services after config edits\./);
       assert.match(inherited.prependContext, /Dynamic reflection rule 1/);
+    });
+
+    it("lets ordinary follow-up prompts receive inherited-rules via before_prompt_build", async () => {
+      const beforePromptHooks = harness.eventHandlers.get("before_prompt_build") || [];
+      assert.equal(beforePromptHooks.length, 1);
+
+      const followUp = await beforePromptHooks[0].handler(
+        { prompt: "继续按这个方案改，并给我步骤" },
+        { sessionId: "s-follow-up", sessionKey: "agent:main:session:s-follow-up", agentId: "main" }
+      );
+
+      assert.ok(followUp);
+      assert.match(followUp.prependContext, /<inherited-rules>/);
+      assert.match(followUp.prependContext, /Dynamic reflection rule 1/);
+    });
+
+    it("uses the shared skip gate to suppress both auto-recall and reflection recall on control prompts", async () => {
+      const beforeAgentStartHooks = harness.eventHandlers.get("before_agent_start") || [];
+      const beforePromptHooks = harness.eventHandlers.get("before_prompt_build") || [];
+      assert.equal(beforeAgentStartHooks.length, 1);
+      assert.equal(beforePromptHooks.length, 1);
+
+      const controlPrompts = [
+        "/new",
+        "/reset",
+        "A new session was started via /new or /reset. Keep this in mind.",
+        "Execute your Session Startup sequence now before continuing.",
+        "Control wrapper line\n/note self-improvement (before reset): preserve incident timeline.",
+      ];
+
+      for (const prompt of controlPrompts) {
+        const relevant = await beforeAgentStartHooks[0].handler(
+          { prompt },
+          { sessionId: `auto-${prompt.length}`, sessionKey: `agent:main:session:auto-${prompt.length}`, agentId: "main" }
+        );
+        const inherited = await beforePromptHooks[0].handler(
+          { prompt },
+          { sessionId: `reflect-${prompt.length}`, sessionKey: `agent:main:session:reflect-${prompt.length}`, agentId: "main" }
+        );
+
+        assert.equal(relevant, undefined, `expected auto-recall to skip control prompt: ${prompt}`);
+        assert.equal(inherited, undefined, `expected reflection recall to skip control prompt: ${prompt}`);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- harden recall injection around control prompts and ordinary follow-up turns
- move `<inherited-rules>` injection to `before_prompt_build`
- add regression coverage proving generic auto-recall and reflection recall share the same skip behavior for control prompts

## Why
Issue #101 is about fresh-session continuity failure. While investigating that continuity surface, we found two adjacent causes that can also make the assistant feel inconsistent after restart / reset:
- system/control wrappers could still pollute memory recall injection
- dynamic `<inherited-rules>` injection happened too early, so ordinary follow-up turns could miss the rules that should apply at prompt-build time

This PR does **not** implement first-turn weak-signal relaxation. Instead, it is a companion hardening patch for the same continuity/problem space.

## What Changed
### 1. Exclude control/system wrappers from retrieval
- add explicit skip patterns for session-start boilerplate (`/new` / `/reset` wrappers)
- skip `Execute your Session Startup sequence now`
- skip wrapped `/note` handoff/control prompts

### 2. Move dynamic inherited-rules injection to prompt-build time
- build reflection recall context in `before_prompt_build`
- let ordinary follow-up turns receive `<inherited-rules>` when applicable
- keep `<error-detected>` reminders in the same prompt-build stage so both blocks can coexist

### 3. Add regression tests
- control prompt skip coverage
- follow-up prompt coverage for `before_prompt_build`
- shared skip-gate coverage across both `relevant-memories` and `inherited-rules`

## Verification
- `node --test test/memory-reflection.test.mjs`
- `npm test`

## Risks / Compatibility
- no config schema changes
- no first-turn weak-signal relaxation is included here
- behavior changes are limited to recall gating / injection timing and associated tests

## Included upstream-delta sources
This branch packages the intent of these downstream commits into one reviewable payload:
- `d20aa360faff94179338157e370486c6bf26f83a`
- `f7604fe2277cca9abbffbd0cf6de0bd00a2d9a6e`
- `bd1df1d5ad5d267d1743022b883b48ac1b327c5a`

## Related
- Related to #101
