### PR TITLE
docs(memory): sync reflection injection stage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Shared infrastructure: `store.ts`, `embedder.ts`, `scopes.ts`, `tools.ts`,
 
 | File | Purpose |
 |------|---------|
-| `index.ts` | Plugin entry point. Registers with OpenClaw Plugin API, parses config, mounts `before_agent_start` / `agent_end` hooks, routes generic auto-recall through `legacy | setwise-v2`, and coordinates reflection injection flows |
+| `index.ts` | Plugin entry point. Registers with OpenClaw Plugin API, parses config, mounts lifecycle hooks (`before_agent_start` / `before_prompt_build` / `agent_end`), routes generic auto-recall through `legacy | setwise-v2`, and coordinates reflection injection flows |
 | `openclaw.plugin.json` | Plugin metadata + full JSON Schema config declaration (with `uiHints`) |
 | `package.json` | NPM package info. Depends on `@lancedb/lancedb`, `openai`, `@sinclair/typebox` |
 | `cli.ts` | CLI commands: `memory list/search/stats/delete/delete-bulk/export/import/reembed/migrate` |
@@ -258,9 +258,9 @@ Recommended starter config:
 ```
 
 Quick behavior guide:
-- `before_agent_start` can inject `<inherited-rules>`
+- `before_prompt_build` can inject `<inherited-rules>`
 - `/new` / `/reset` can build the reflection note
-- `before_prompt_build` only injects `<error-detected>` reminders
+- `before_prompt_build` can also inject `<error-detected>` reminders
 - dynamic recall keeps `kind + strictKey` separation for invariant/derived rows
 
 ### 10. Markdown Mirror (`mdMirror`)

--- a/README_CN.md
+++ b/README_CN.md
@@ -91,7 +91,7 @@ OpenClaw 内置的 `memory-lancedb` 插件仅提供基本的向量搜索。**mem
 
 | 文件 | 用途 |
 |------|------|
-| `index.ts` | 插件入口。注册到 OpenClaw Plugin API，解析配置，挂载 `before_agent_start` / `agent_end` 钩子，负责 generic auto-recall 的 `legacy | setwise-v2` 分流，并编排 reflection 注入流程 |
+| `index.ts` | 插件入口。注册到 OpenClaw Plugin API，解析配置，挂载生命周期钩子（`before_agent_start` / `before_prompt_build` / `agent_end`），负责 generic auto-recall 的 `legacy | setwise-v2` 分流，并编排 reflection 注入流程 |
 | `openclaw.plugin.json` | 插件元数据 + 完整 JSON Schema 配置声明（含 `uiHints`） |
 | `package.json` | NPM 包信息，依赖 `@lancedb/lancedb`、`openai`、`@sinclair/typebox` |
 | `cli.ts` | CLI 命令实现：`memory list/search/stats/delete/delete-bulk/export/import/reembed/migrate` |
@@ -258,9 +258,9 @@ Query → BM25 FTS ─────┘
 ```
 
 快速行为说明：
-- `before_agent_start` 可注入 `<inherited-rules>`
+- `before_prompt_build` 可注入 `<inherited-rules>`
 - `/new` / `/reset` 可生成 reflection note
-- `before_prompt_build` 只注入 `<error-detected>` 提醒
+- `before_prompt_build` 还可注入 `<error-detected>` 提醒
 - dynamic recall 会保持 `kind + strictKey` 分区，不会把 invariant / derived 混在一起
 
 ### 10. Markdown 镜像（`mdMirror`）


### PR DESCRIPTION
## Summary
- correct the README and README_CN hook descriptions for reflection injection
- align the quick behavior guide with the current prompt-build-stage inherited-rules flow

## Why
- the current runtime behavior injects `<inherited-rules>` in `before_prompt_build`
- the README text still describes the older `before_agent_start` path, which can mislead reviewers and operators when checking the reflection pipeline

## Changes
- update `README.md`
  - describe `index.ts` as mounting `before_prompt_build` alongside the other lifecycle hooks
  - correct the quick behavior guide so `<inherited-rules>` and `<error-detected>` both reflect prompt-build-stage behavior
- update `README_CN.md` with the same corrections

## Verification
- compared the README wording against the current implementation and retained only the two documentation corrections in the final diff
- confirmed the fork diff against `upstream/main` contains only `README.md` and `README_CN.md`

## Risks / Compatibility
- docs-only change
- no runtime or config behavior changes
