### PR TITLE
fix(recall): correct generic auto-recall legacy naming to mmr

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The built-in `memory-lancedb` plugin in OpenClaw provides basic vector search. *
 │ (index.ts local step)  │               └──────┬────────────────────┘
 └────────┬───────────────┘                      │
          │                               ┌──────▼───────────────────────┐
-         │ legacy | setwise-v2           │ reflection-recall-final-     │
+         │ mmr | setwise-v2              │ reflection-recall-final-     │
 ┌────────▼────────────────────┐           │ selection.ts                 │
 │ auto-recall-final-          │           └──────┬───────────────────────┘
 │ selection.ts                │                  │
@@ -91,7 +91,7 @@ Shared infrastructure: `store.ts`, `embedder.ts`, `scopes.ts`, `tools.ts`,
 
 | File | Purpose |
 |------|---------|
-| `index.ts` | Plugin entry point. Registers with OpenClaw Plugin API, parses config, mounts lifecycle hooks (`before_agent_start` / `before_prompt_build` / `agent_end`), routes generic auto-recall through `legacy | setwise-v2`, and coordinates reflection injection flows |
+| `index.ts` | Plugin entry point. Registers with OpenClaw Plugin API, parses config, mounts lifecycle hooks (`before_agent_start` / `before_prompt_build` / `agent_end`), routes generic auto-recall through `mmr | setwise-v2`, and coordinates reflection injection flows |
 | `openclaw.plugin.json` | Plugin metadata + full JSON Schema config declaration (with `uiHints`) |
 | `package.json` | NPM package info. Depends on `@lancedb/lancedb`, `openai`, `@sinclair/typebox` |
 | `cli.ts` | CLI commands: `memory list/search/stats/delete/delete-bulk/export/import/reembed/migrate` |
@@ -99,7 +99,7 @@ Shared infrastructure: `store.ts`, `embedder.ts`, `scopes.ts`, `tools.ts`,
 | `src/embedder.ts` | Embedding abstraction. Compatible with any OpenAI-API provider (OpenAI, Gemini, Jina, Ollama, etc.). Supports task-aware embedding (`taskQuery`/`taskPassage`) |
 | `src/retriever.ts` | Hybrid retrieval engine. Vector + BM25 → RRF fusion → rerank → recency / importance / length / decay weighting → noise filter → coarse MMR diversity. |
 | `src/recall-engine.ts` | Shared recall helpers: prompt gating, session repeated-injection suppression, tagged-block assembly, max-age filtering, and recent-per-key capping |
-| `src/auto-recall-final-selection.ts` | Generic auto-recall adapter. Maps `RetrievalResult` rows into final-selection candidates and applies generic `legacy | setwise-v2` behavior at the final cutoff seam |
+| `src/auto-recall-final-selection.ts` | Generic auto-recall adapter. Maps `RetrievalResult` rows into final-selection candidates and applies generic `mmr | setwise-v2` behavior at the final cutoff seam |
 | `src/final-topk-setwise-selection.ts` | Shared final top-k selector. Owns shortlist presort, deterministic set-wise selection, lexical-overlap suppression, and optional embedding-based semantic redundancy suppression |
 | `src/reflection-recall.ts` | Dynamic Reflection-Recall ranking for `<inherited-rules>`. Filters/caps reflection items, computes scores, preserves `kind + strictKey` partitioning, and maps selected groups back to recall rows |
 | `src/reflection-aggregation.ts` | Reflection group aggregation. Combines scored reflection items into strict-key groups with representative selection and final group scoring |
@@ -316,12 +316,13 @@ When embedding calls fail, the plugin provides **actionable error messages** ins
   - Skips memory-management prompts (e.g. delete/forget/cleanup memory entries) to reduce noise
 - **Auto-Recall** (`before_agent_start` hook): Injects `<relevant-memories>` context
   - Default top-k: `autoRecallTopK=3`
-  - Generic final-selection mode: `autoRecallSelectionMode` (`legacy` by default; `setwise-v2` to enable set-wise final selector)
+  - Generic final-selection mode: `autoRecallSelectionMode` (`mmr` by default; `setwise-v2` to enable set-wise final selector)
   - Default category allowlist: `preference`, `fact`, `decision`, `entity`, `other`
   - `autoRecallExcludeReflection=true` by default, so `<relevant-memories>` stays separate from `<inherited-rules>`
   - Supports age window (`autoRecallMaxAgeDays`) and recent-per-key cap (`autoRecallMaxEntriesPerKey`)
-  - `legacy`: post-processed rows use direct truncation (`slice(0, topK)`) for compatibility
-  - `setwise-v2`: final top-k uses shared set-wise selection (base score + freshness + light category/scope coverage + lexical overlap suppression + embedding-based semantic near-duplicate suppression), with deterministic output order and safe lexical-only fallback when vectors are missing
+  - `mmr`: post-processed rows use direct truncation (`slice(0, topK)`); this is simpler and closer to current retriever order, usually with stronger per-item relevance/score stability, but diversity/coverage is weaker
+  - `setwise-v2`: final top-k uses shared set-wise selection (base score + freshness + light category/scope coverage + lexical overlap suppression + embedding-based semantic near-duplicate suppression), so diversity/coverage in the final top-k is usually better, but average per-item score/relevance can be lower than `mmr`
+  - Choose according to your preference: prioritize rank stability/relevance with `mmr`, or prioritize diversity/coverage with `setwise-v2`.
   - This mode is generic auto-recall only. Reflection-Recall mode remains `fixed | dynamic`.
 
 ### Prevent memories from showing up in replies
@@ -521,7 +522,7 @@ openclaw config get plugins.slots.memory
   "autoRecall": false,
   "autoRecallMinLength": 8,
   "autoRecallTopK": 3,
-  "autoRecallSelectionMode": "legacy",
+  "autoRecallSelectionMode": "mmr",
   "autoRecallCategories": ["preference", "fact", "decision", "entity", "other"],
   "autoRecallExcludeReflection": true,
   "autoRecallMaxAgeDays": 30,
@@ -612,7 +613,7 @@ A practical starting point for Chinese chat workloads:
   "autoCapture": true,
   "autoRecall": true,
   "autoRecallMinLength": 8,
-  "autoRecallSelectionMode": "legacy",
+  "autoRecallSelectionMode": "mmr",
   "autoRecallExcludeReflection": true,
   "retrieval": {
     "candidatePoolSize": 20,

--- a/README_CN.md
+++ b/README_CN.md
@@ -73,7 +73,7 @@ OpenClaw 内置的 `memory-lancedb` 插件仅提供基本的向量搜索。**mem
 │ （index.ts 本地步骤）  │               └──────┬────────────────────┘
 └────────┬───────────────┘                      │
          │                               ┌──────▼───────────────────────┐
-         │ legacy | setwise-v2           │ reflection-recall-final-     │
+         │ mmr | setwise-v2              │ reflection-recall-final-     │
 ┌────────▼────────────────────┐           │ selection.ts                 │
 │ auto-recall-final-          │           └──────┬───────────────────────┘
 │ selection.ts                │                  │
@@ -91,7 +91,7 @@ OpenClaw 内置的 `memory-lancedb` 插件仅提供基本的向量搜索。**mem
 
 | 文件 | 用途 |
 |------|------|
-| `index.ts` | 插件入口。注册到 OpenClaw Plugin API，解析配置，挂载生命周期钩子（`before_agent_start` / `before_prompt_build` / `agent_end`），负责 generic auto-recall 的 `legacy | setwise-v2` 分流，并编排 reflection 注入流程 |
+| `index.ts` | 插件入口。注册到 OpenClaw Plugin API，解析配置，挂载生命周期钩子（`before_agent_start` / `before_prompt_build` / `agent_end`），负责 generic auto-recall 的 `mmr | setwise-v2` 分流，并编排 reflection 注入流程 |
 | `openclaw.plugin.json` | 插件元数据 + 完整 JSON Schema 配置声明（含 `uiHints`） |
 | `package.json` | NPM 包信息，依赖 `@lancedb/lancedb`、`openai`、`@sinclair/typebox` |
 | `cli.ts` | CLI 命令实现：`memory list/search/stats/delete/delete-bulk/export/import/reembed/migrate` |
@@ -99,7 +99,7 @@ OpenClaw 内置的 `memory-lancedb` 插件仅提供基本的向量搜索。**mem
 | `src/embedder.ts` | Embedding 抽象层。兼容 OpenAI API 的任意 Provider（OpenAI、Gemini、Jina、Ollama 等），支持 task-aware embedding（`taskQuery`/`taskPassage`） |
 | `src/retriever.ts` | 混合检索引擎。Vector + BM25 → RRF 融合 → rerank → 时效 / 重要性 / 长度 / 衰减加权 → 噪声过滤 → 粗粒度 MMR 去重。 |
 | `src/recall-engine.ts` | 共享 recall 辅助层：prompt 触发判断、session 重复注入抑制、tag block 组装、max-age 过滤、按 key 保留最近 N 条 |
-| `src/auto-recall-final-selection.ts` | generic auto-recall 适配层。把 `RetrievalResult` 映射为最终选择候选，并在最终截断点应用 generic 的 `legacy | setwise-v2` 行为 |
+| `src/auto-recall-final-selection.ts` | generic auto-recall 适配层。把 `RetrievalResult` 映射为最终选择候选，并在最终截断点应用 generic 的 `mmr | setwise-v2` 行为 |
 | `src/final-topk-setwise-selection.ts` | 共享最终 top-k 选择器。负责 shortlist presort、确定性的 set-wise 选择、词法重叠抑制，以及可选的 embedding 语义冗余抑制 |
 | `src/reflection-recall.ts` | `<inherited-rules>` 的动态 Reflection-Recall 排序链路。负责 reflection item 过滤/截断、分数计算、保持 `kind + strictKey` 分区，并将选中的 group 映射回 recall rows |
 | `src/reflection-aggregation.ts` | Reflection group 聚合层。把打分后的 reflection item 聚合为 strict-key group，选择代表文本并计算 group final score |
@@ -316,12 +316,13 @@ Query → BM25 FTS ─────┘
   - 触发词支持 **简体中文 + 繁體中文**（例如：记住/記住、偏好/喜好/喜歡、决定/決定 等）
 - **Auto-Recall**（`before_agent_start` hook）: 注入 `<relevant-memories>` 上下文
   - 默认 top-k：`autoRecallTopK=3`
-  - Generic 最终选择模式：`autoRecallSelectionMode`（默认 `legacy`；设置 `setwise-v2` 可启用 set-wise 最终选择器）
+  - Generic 最终选择模式：`autoRecallSelectionMode`（默认 `mmr`；设置 `setwise-v2` 可启用 set-wise 最终选择器）
   - 默认类别白名单：`preference`、`fact`、`decision`、`entity`、`other`
   - 默认 `autoRecallExcludeReflection=true`，让 `<relevant-memories>` 与 `<inherited-rules>` 分离
   - 支持时间窗（`autoRecallMaxAgeDays`）和按归一化 key 的最近 N 条限制（`autoRecallMaxEntriesPerKey`）
-  - `legacy`：保留 retriever 当前的排序结果（包括内部的粗粒度 MMR 去重），再对 post-process 后的结果直接截断（`slice(0, topK)`），保持兼容行为
-  - `setwise-v2`：最终 top-k 使用共享 set-wise selector（基础分 + 新鲜度 + 轻量 category/scope 覆盖 + 词法重叠抑制 + 基于 embedding 的语义近重复抑制）；当向量缺失时会安全回退到仅词法抑制，并保持确定性顺序
+  - `mmr`：对 post-process 后的结果直接截断（`slice(0, topK)`）；实现更简单、更贴近当前 retriever 顺序，通常单条相关性/分数稳定性更好，但多样性与覆盖度较弱
+  - `setwise-v2`：最终 top-k 使用共享 set-wise selector（基础分 + 新鲜度 + 轻量 category/scope 覆盖 + 词法重叠抑制 + 基于 embedding 的语义近重复抑制）；最终 top-k 的多样性/覆盖度通常更好，但平均单条分数/相关性可能低于 `mmr`
+  - 请按偏好选择：偏向相关性稳定可选 `mmr`，偏向多样覆盖可选 `setwise-v2`。
   - 该模式只作用于 generic auto-recall；Reflection-Recall 的 `fixed | dynamic` 语义不变。
 
 ### 不想在对话中"显示长期记忆"？
@@ -521,7 +522,7 @@ openclaw config get plugins.slots.memory
   "autoRecall": false,
   "autoRecallMinLength": 8,
   "autoRecallTopK": 3,
-  "autoRecallSelectionMode": "legacy",
+  "autoRecallSelectionMode": "mmr",
   "autoRecallCategories": ["preference", "fact", "decision", "entity", "other"],
   "autoRecallExcludeReflection": true,
   "autoRecallMaxAgeDays": 30,
@@ -612,7 +613,7 @@ openclaw config get plugins.slots.memory
   "autoCapture": true,
   "autoRecall": true,
   "autoRecallMinLength": 8,
-  "autoRecallSelectionMode": "legacy",
+  "autoRecallSelectionMode": "mmr",
   "autoRecallExcludeReflection": true,
   "retrieval": {
     "candidatePoolSize": 20,

--- a/index.ts
+++ b/index.ts
@@ -144,7 +144,7 @@ type SessionStrategy = "memoryReflection" | "systemSessionMemory" | "none";
 type ReflectionInjectMode = "inheritance-only" | "inheritance+derived";
 type ReflectionRecallMode = "fixed" | "dynamic";
 type ReflectionRecallKind = "invariant" | "derived";
-type AutoRecallSelectionMode = "legacy" | "setwise-v2";
+type AutoRecallSelectionMode = "mmr" | "setwise-v2";
 type MemoryCategory = "preference" | "fact" | "decision" | "entity" | "other" | "reflection";
 
 // ============================================================================
@@ -262,7 +262,7 @@ const DEFAULT_REFLECTION_SESSION_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_REFLECTION_MAX_TRACKED_SESSIONS = 200;
 const DEFAULT_REFLECTION_ERROR_SCAN_MAX_CHARS = 8_000;
 const DEFAULT_AUTO_RECALL_TOP_K = 3;
-const DEFAULT_AUTO_RECALL_SELECTION_MODE: AutoRecallSelectionMode = "legacy";
+const DEFAULT_AUTO_RECALL_SELECTION_MODE: AutoRecallSelectionMode = "mmr";
 const DEFAULT_AUTO_RECALL_EXCLUDE_REFLECTION = true;
 const DEFAULT_AUTO_RECALL_MAX_AGE_DAYS = 30;
 const DEFAULT_AUTO_RECALL_MAX_ENTRIES_PER_KEY = 10;
@@ -2764,6 +2764,8 @@ export function parsePluginConfig(value: unknown): PluginConfig {
   const autoRecallSelectionMode: AutoRecallSelectionMode =
     cfg.autoRecallSelectionMode === "setwise-v2"
       ? "setwise-v2"
+      : cfg.autoRecallSelectionMode === "mmr" || cfg.autoRecallSelectionMode === "legacy"
+        ? "mmr"
       : DEFAULT_AUTO_RECALL_SELECTION_MODE;
 
   return {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -114,11 +114,12 @@
       "autoRecallSelectionMode": {
         "type": "string",
         "enum": [
+          "mmr",
           "legacy",
           "setwise-v2"
         ],
-        "default": "legacy",
-        "description": "Generic Auto-Recall final top-k mode. legacy keeps post-processed direct truncation compatibility; setwise-v2 uses set-wise final selection."
+        "default": "mmr",
+        "description": "Generic Auto-Recall final top-k mode. mmr keeps direct truncation after post-processing as the canonical mode; legacy is accepted as a backward-compatible alias to mmr; setwise-v2 enables set-wise final selection with higher diversity/coverage but potentially lower average per-item relevance."
       },
       "autoRecallCategories": {
         "type": "array",
@@ -582,7 +583,7 @@
     },
     "autoRecallSelectionMode": {
       "label": "Auto-Recall Selection Mode",
-      "help": "Generic final top-k mode: legacy uses direct truncation after post-processing; setwise-v2 enables set-wise final selection.",
+      "help": "Generic final top-k mode: mmr is the canonical direct-truncation mode; legacy remains a backward-compatible alias to mmr; setwise-v2 enables a more diverse final selector with possible average relevance tradeoffs.",
       "advanced": true
     },
     "autoRecallCategories": {

--- a/test/config-session-strategy-migration.test.mjs
+++ b/test/config-session-strategy-migration.test.mjs
@@ -64,12 +64,28 @@ describe("sessionStrategy legacy compatibility mapping", () => {
     assert.equal(parsed.embedding.chunking, false);
   });
 
-  it("defaults generic auto-recall selection mode to legacy", () => {
+  it("defaults generic auto-recall selection mode to mmr", () => {
     const parsed = parsePluginConfig(baseConfig());
-    assert.equal(parsed.autoRecallSelectionMode, "legacy");
+    assert.equal(parsed.autoRecallSelectionMode, "mmr");
   });
 
-  it("parses explicit generic auto-recall selection mode override", () => {
+  it("accepts explicit generic auto-recall selection mode mmr", () => {
+    const parsed = parsePluginConfig({
+      ...baseConfig(),
+      autoRecallSelectionMode: "mmr",
+    });
+    assert.equal(parsed.autoRecallSelectionMode, "mmr");
+  });
+
+  it("normalizes legacy generic auto-recall selection mode to mmr", () => {
+    const parsed = parsePluginConfig({
+      ...baseConfig(),
+      autoRecallSelectionMode: "legacy",
+    });
+    assert.equal(parsed.autoRecallSelectionMode, "mmr");
+  });
+
+  it("parses explicit generic auto-recall selection mode setwise-v2", () => {
     const parsed = parsePluginConfig({
       ...baseConfig(),
       autoRecallSelectionMode: "setwise-v2",

--- a/test/memory-reflection.test.mjs
+++ b/test/memory-reflection.test.mjs
@@ -2357,7 +2357,37 @@ describe("memory reflection", () => {
       ];
     }
 
-    it("legacy mode bypasses set-wise selector and uses direct truncation", async () => {
+    it("mmr mode bypasses set-wise selector and uses direct truncation", async () => {
+      MemoryRetriever.prototype.retrieve = async () => buildGenericRecallRows();
+
+      const harness = createPluginApiHarness({
+        resolveRoot: workspaceDir,
+        pluginConfig: {
+          embedding: { apiKey: "test-api-key" },
+          autoCapture: false,
+          autoRecall: true,
+          autoRecallTopK: 2,
+          autoRecallSelectionMode: "mmr",
+          autoRecallMinLength: 1,
+          selfImprovement: { enabled: false, beforeResetNote: false, ensureLearningFiles: false },
+        },
+      });
+      memoryLanceDBProPlugin.register(harness.api);
+
+      const hooks = harness.eventHandlers.get("before_agent_start") || [];
+      assert.equal(hooks.length, 1);
+      const output = await hooks[0].handler(
+        { prompt: "Need rollout memories now." },
+        { sessionId: "mmr-mode", sessionKey: "agent:main:session:mmr-mode", agentId: "main" }
+      );
+      assert.ok(output);
+      assert.match(output.prependContext, /<relevant-memories>/);
+      assert.match(output.prependContext, /Restart API service after config updates\./);
+      assert.match(output.prependContext, /restart api service after config updates\./);
+      assert.doesNotMatch(output.prependContext, /Run DNS and mount health checks after restart\./);
+    });
+
+    it("legacy alias follows the same direct-truncation path as mmr", async () => {
       MemoryRetriever.prototype.retrieve = async () => buildGenericRecallRows();
 
       const harness = createPluginApiHarness({
@@ -2378,7 +2408,7 @@ describe("memory reflection", () => {
       assert.equal(hooks.length, 1);
       const output = await hooks[0].handler(
         { prompt: "Need rollout memories now." },
-        { sessionId: "legacy-mode", sessionKey: "agent:main:session:legacy-mode", agentId: "main" }
+        { sessionId: "legacy-alias-mode", sessionKey: "agent:main:session:legacy-alias-mode", agentId: "main" }
       );
       assert.ok(output);
       assert.match(output.prependContext, /<relevant-memories>/);


### PR DESCRIPTION
## Summary
- rename the canonical generic auto-recall mode from `legacy` to `mmr`
- keep `legacy` as a backward-compatible alias to `mmr`
- align docs, config schema, and tests with the corrected naming

## Why
- `legacy` inaccurately describes the primary generic auto-recall path
- this path is not just a compatibility fallback: `mmr` also has practical advantages in use, including simpler behavior, closer alignment with the current retriever order, and stronger per-item relevance/score stability
- labeling that path as `legacy` hides those tradeoffs and makes the product contract harder to understand
- this change corrects the naming without changing the runtime contract

## Changes
- default `autoRecallSelectionMode` is now `mmr`
- `legacy` is still accepted and normalized to `mmr`
- updated `README.md`, `README_CN.md`, `openclaw.plugin.json`, and related tests
- added short guidance for choosing between `mmr` and `setwise-v2`

## Verification
- `node test/config-session-strategy-migration.test.mjs`
- `node --test test/memory-reflection.test.mjs`
- `npm test`

## Compatibility
- existing `autoRecallSelectionMode: "legacy"` configs continue to work
- Reflection-Recall modes remain unchanged (`fixed | dynamic`)