### PR TITLE
fix: rollback MemoryStore.update when add fails after delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "scripts": {
-    "test": "node test/embedder-error-hints.test.mjs && node test/migrate-legacy-schema.test.mjs && node --test test/config-session-strategy-migration.test.mjs && node test/cli-smoke.mjs && node test/functional-e2e.mjs && node test/retriever-rerank-regression.mjs && node test/smart-memory-lifecycle.mjs && node test/smart-extractor-branches.mjs && node test/plugin-manifest-regression.mjs",
+    "test": "node test/embedder-error-hints.test.mjs && node test/migrate-legacy-schema.test.mjs && node --test test/config-session-strategy-migration.test.mjs && node test/update-consistency-lancedb.test.mjs && node test/cli-smoke.mjs && node test/functional-e2e.mjs && node test/retriever-rerank-regression.mjs && node test/smart-memory-lifecycle.mjs && node test/smart-extractor-branches.mjs && node test/plugin-manifest-regression.mjs",
     "test:openclaw-host": "node test/openclaw-host-functional.mjs"
   },
   "devDependencies": {

--- a/src/store.ts
+++ b/src/store.ts
@@ -180,6 +180,7 @@ export class MemoryStore {
   private table: LanceDB.Table | null = null;
   private initPromise: Promise<void> | null = null;
   private ftsIndexCreated = false;
+  private updateQueue: Promise<void> = Promise.resolve();
 
   constructor(private readonly config: StoreConfig) {}
 
@@ -762,109 +763,138 @@ export class MemoryStore {
   ): Promise<MemoryEntry | null> {
     await this.ensureInitialized();
 
-    // Support both full UUID and short prefix (8+ hex chars), same as delete()
-    const uuidRegex =
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    const prefixRegex = /^[0-9a-f]{8,}$/i;
-    const isFullId = uuidRegex.test(id);
-    const isPrefix = !isFullId && prefixRegex.test(id);
+    return this.runSerializedUpdate(async () => {
+      // Support both full UUID and short prefix (8+ hex chars), same as delete()
+      const uuidRegex =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      const prefixRegex = /^[0-9a-f]{8,}$/i;
+      const isFullId = uuidRegex.test(id);
+      const isPrefix = !isFullId && prefixRegex.test(id);
 
-    if (!isFullId && !isPrefix) {
-      throw new Error(`Invalid memory ID format: ${id}`);
-    }
-
-    let rows: any[];
-    if (isFullId) {
-      const safeId = escapeSqlLiteral(id);
-      rows = await this.table!.query()
-        .where(`id = '${safeId}'`)
-        .limit(1)
-        .toArray();
-    } else {
-      // Prefix match
-      const all = await this.table!.query()
-        .select([
-          "id",
-          "text",
-          "vector",
-          "category",
-          "scope",
-          "importance",
-          "timestamp",
-          "metadata",
-        ])
-        .limit(1000)
-        .toArray();
-      rows = all.filter((r: any) => (r.id as string).startsWith(id));
-      if (rows.length > 1) {
-        throw new Error(
-          `Ambiguous prefix "${id}" matches ${rows.length} memories. Use a longer prefix or full ID.`,
-        );
+      if (!isFullId && !isPrefix) {
+        throw new Error(`Invalid memory ID format: ${id}`);
       }
-    }
 
-    if (rows.length === 0) return null;
+      let rows: any[];
+      if (isFullId) {
+        const safeId = escapeSqlLiteral(id);
+        rows = await this.table!.query()
+          .where(`id = '${safeId}'`)
+          .limit(1)
+          .toArray();
+      } else {
+        // Prefix match
+        const all = await this.table!.query()
+          .select([
+            "id",
+            "text",
+            "vector",
+            "category",
+            "scope",
+            "importance",
+            "timestamp",
+            "metadata",
+          ])
+          .limit(1000)
+          .toArray();
+        rows = all.filter((r: any) => (r.id as string).startsWith(id));
+        if (rows.length > 1) {
+          throw new Error(
+            `Ambiguous prefix "${id}" matches ${rows.length} memories. Use a longer prefix or full ID.`,
+          );
+        }
+      }
 
-    const row = rows[0];
-    const rowScope = (row.scope as string | undefined) ?? "global";
+      if (rows.length === 0) return null;
 
-    // Check scope permissions
-    if (
-      scopeFilter &&
-      scopeFilter.length > 0 &&
-      !scopeFilter.includes(rowScope)
-    ) {
-      throw new Error(`Memory ${id} is outside accessible scopes`);
-    }
+      const row = rows[0];
+      const rowScope = (row.scope as string | undefined) ?? "global";
 
-    const original: MemoryEntry = {
-      id: row.id as string,
-      text: row.text as string,
-      vector: Array.from(row.vector as Iterable<number>),
-      category: row.category as MemoryEntry["category"],
-      scope: rowScope,
-      importance: Number(row.importance),
-      timestamp: Number(row.timestamp),
-      metadata: (row.metadata as string) || "{}",
-    };
+      // Check scope permissions
+      if (
+        scopeFilter &&
+        scopeFilter.length > 0 &&
+        !scopeFilter.includes(rowScope)
+      ) {
+        throw new Error(`Memory ${id} is outside accessible scopes`);
+      }
 
-    // Build updated entry, preserving original timestamp
-    const updated: MemoryEntry = {
-      ...original,
-      text: updates.text ?? original.text,
-      vector: updates.vector ?? original.vector,
-      category: updates.category ?? original.category,
-      scope: rowScope,
-      importance: updates.importance ?? original.importance,
-      timestamp: original.timestamp, // preserve original
-      metadata: updates.metadata ?? original.metadata,
-    };
+      const original: MemoryEntry = {
+        id: row.id as string,
+        text: row.text as string,
+        vector: Array.from(row.vector as Iterable<number>),
+        category: row.category as MemoryEntry["category"],
+        scope: rowScope,
+        importance: Number(row.importance),
+        timestamp: Number(row.timestamp),
+        metadata: (row.metadata as string) || "{}",
+      };
 
-    // LanceDB doesn't support in-place update; delete + re-add.
-    // If the add fails after delete, attempt best-effort rollback to avoid
-    // silently losing the original record.
-    const resolvedId = escapeSqlLiteral(row.id as string);
-    await this.table!.delete(`id = '${resolvedId}'`);
-    try {
-      await this.table!.add([updated]);
-    } catch (addError) {
+      // Build updated entry, preserving original timestamp
+      const updated: MemoryEntry = {
+        ...original,
+        text: updates.text ?? original.text,
+        vector: updates.vector ?? original.vector,
+        category: updates.category ?? original.category,
+        scope: rowScope,
+        importance: updates.importance ?? original.importance,
+        timestamp: original.timestamp, // preserve original
+        metadata: updates.metadata ?? original.metadata,
+      };
+
+      // LanceDB doesn't support in-place update; delete + re-add.
+      // Serialize updates per store instance to avoid stale rollback races.
+      // If the add fails after delete, attempt best-effort recovery without
+      // overwriting a newer concurrent successful update.
+      const rollbackCandidate =
+        (await this.getById(original.id).catch(() => null)) ?? original;
+      const resolvedId = escapeSqlLiteral(row.id as string);
+      await this.table!.delete(`id = '${resolvedId}'`);
       try {
-        await this.table!.add([original]);
-      } catch (rollbackError) {
+        await this.table!.add([updated]);
+      } catch (addError) {
+        const current = await this.getById(original.id).catch(() => null);
+        if (current) {
+          throw new Error(
+            `Failed to update memory ${id}: write failed after delete, but an existing record was preserved. ` +
+            `Write error: ${addError instanceof Error ? addError.message : String(addError)}`,
+          );
+        }
+
+        try {
+          await this.table!.add([rollbackCandidate]);
+        } catch (rollbackError) {
+          throw new Error(
+            `Failed to update memory ${id}: write failed after delete, and rollback also failed. ` +
+            `Write error: ${addError instanceof Error ? addError.message : String(addError)}. ` +
+            `Rollback error: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+          );
+        }
+
         throw new Error(
-          `Failed to update memory ${id}: write failed after delete, and rollback also failed. ` +
-          `Write error: ${addError instanceof Error ? addError.message : String(addError)}. ` +
-          `Rollback error: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+          `Failed to update memory ${id}: write failed after delete, latest available record restored. ` +
+          `Write error: ${addError instanceof Error ? addError.message : String(addError)}`,
         );
       }
 
-      throw new Error(
-        `Failed to update memory ${id}: write failed after delete, original record restored. ` +
-        `Write error: ${addError instanceof Error ? addError.message : String(addError)}`,
-      );
-    }
+      return updated;
+    });
+  }
 
-    return updated;
+  private async runSerializedUpdate<T>(action: () => Promise<T>): Promise<T> {
+    const previous = this.updateQueue;
+    let release: (() => void) | undefined;
+    const lock = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.updateQueue = previous.then(() => lock);
+
+    await previous;
+    try {
+      return await action();
+    } finally {
+      release?.();
+    }
   }
 
   async patchMetadata(

--- a/test/update-consistency-lancedb.test.mjs
+++ b/test/update-consistency-lancedb.test.mjs
@@ -72,7 +72,7 @@ describe("MemoryStore update rollback (real LanceDB backend)", () => {
 
     await assert.rejects(
       store.update(entry.id, { text: "updated memory", vector: [1, 1, 1, 1] }),
-      /original record restored/,
+      /latest available record restored/,
     );
 
     restore();
@@ -81,7 +81,7 @@ describe("MemoryStore update rollback (real LanceDB backend)", () => {
     assert.equal((await store.list(["global"]))[0]?.text, "original memory");
   });
 
-  it("avoids data loss under concurrent updates when the later add fails", async () => {
+  it("preserves the latest committed value under concurrent update failure", async () => {
     const { store, entry } = await createStoreWithEntry();
 
     const secondDeleteQueued = deferred();
@@ -133,13 +133,13 @@ describe("MemoryStore update rollback (real LanceDB backend)", () => {
     secondDeleteGate.resolve();
     secondAddGate.resolve();
 
-    await assert.rejects(second, /original record restored/);
+    await assert.rejects(second, /latest available record restored/);
 
     restoreDelete();
     restoreAdd();
 
-    assert.equal((await store.getById(entry.id))?.text, "original memory");
-    assert.equal((await store.list(["global"]))[0]?.text, "original memory");
+    assert.equal((await store.getById(entry.id))?.text, "update from A");
+    assert.equal((await store.list(["global"]))[0]?.text, "update from A");
   });
 
   it("access-tracker style metadata update preserves the row on write failure", async () => {


### PR DESCRIPTION
## Summary

Cherry-pick of #96 rebased onto `master` (original PR targeted `main`).

Prevents silent memory loss in `MemoryStore.update()` when the post-delete `add()` fails.

## What changed

- Preserve the original record before delete
- Serialize concurrent updates per store instance to avoid stale rollback races
- Attempt best-effort rollback if `add(updated)` fails after delete, without overwriting a newer concurrent successful update
- Return descriptive errors when rollback succeeds or fails
- Added `test/update-consistency-lancedb.test.mjs` to the default `npm test` pipeline

## Original PR

Closes #96 — cherry-picked from @robinspt's work with merge conflict resolution for `master`.

## Test plan

- [x] `store.ts` rollback logic cherry-picked cleanly
- [x] `test/update-consistency-lancedb.test.mjs` included in `npm test`
- [ ] CI passes (note: `smart-extractor-branches.mjs` already fails on current `master`, unrelated)