### PR TITLE
feat: add memory_purge_scope tool for batch scope cleanup

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1199,6 +1199,107 @@ export function registerMemoryListTool(
 }
 
 // ============================================================================
+// Purge Scope Tool
+// ============================================================================
+
+export function registerMemoryPurgeScopeTool(
+  api: OpenClawPluginApi,
+  context: ToolContext,
+) {
+  api.registerTool(
+    (toolCtx) => {
+      const agentId = resolveAgentId((toolCtx as any)?.agentId, context.agentId) ?? "main";
+      return {
+        name: "memory_purge_scope",
+        label: "Memory Purge Scope",
+        description:
+          "Permanently delete ALL memories in a specific scope. This is a DESTRUCTIVE and IRREVERSIBLE operation. " +
+          "You must set confirm=true to execute. Use with extreme caution — typically for user/agent cleanup.",
+        parameters: Type.Object({
+          scope: Type.String({
+            description: "The scope to purge (e.g. 'agent:ent_user-xxx_default')",
+          }),
+          confirm: Type.Boolean({
+            description: "Must be true to execute. Safety guard against accidental purge.",
+          }),
+        }),
+        async execute(_toolCallId, params) {
+          const { scope, confirm } = params as {
+            scope: string;
+            confirm: boolean;
+          };
+
+          if (!confirm) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: "Purge aborted: confirm must be true to execute this destructive operation.",
+                },
+              ],
+              details: { error: "not_confirmed" },
+            };
+          }
+
+          if (!scope || !scope.trim()) {
+            return {
+              content: [
+                { type: "text", text: "Purge aborted: scope must be a non-empty string." },
+              ],
+              details: { error: "invalid_scope" },
+            };
+          }
+
+          // Access control: only allow purging scopes this agent can access
+          if (!context.scopeManager.isAccessible(scope, agentId)) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Access denied: scope "${scope}" is not accessible by agent "${agentId}".`,
+                },
+              ],
+              details: {
+                error: "scope_access_denied",
+                requestedScope: scope,
+                agentId,
+              },
+            };
+          }
+
+          try {
+            const deletedCount = await context.store.bulkDelete([scope]);
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Purged scope "${scope}": ${deletedCount} memor${deletedCount === 1 ? "y" : "ies"} deleted.`,
+                },
+              ],
+              details: {
+                scope,
+                deletedCount,
+              },
+            };
+          } catch (error) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Failed to purge scope "${scope}": ${error instanceof Error ? error.message : String(error)}`,
+                },
+              ],
+              details: { error: "purge_failed", message: String(error) },
+            };
+          }
+        },
+      };
+    },
+    { name: "memory_purge_scope" },
+  );
+}
+
+// ============================================================================
 // Tool Registration Helper
 // ============================================================================
 
@@ -1220,6 +1321,7 @@ export function registerAllMemoryTools(
   if (options.enableManagementTools) {
     registerMemoryStatsTool(api, context);
     registerMemoryListTool(api, context);
+    registerMemoryPurgeScopeTool(api, context);
   }
   if (options.enableSelfImprovementTools !== false) {
     registerSelfImprovementLogTool(api, context);


### PR DESCRIPTION
## Problem

Currently there is no way to delete all memories within a specific scope at once. Users who want to clean up stale or test data from a particular scope must delete entries one by one using `memory_delete`, which is tedious and error-prone.

This becomes especially painful when:
- An agent accumulates outdated memories in a scope and needs a fresh start
- - Administrators need to clean up test/debug scopes
- - A scope becomes polluted with low-quality auto-captured memories
## Solution

Add a new `memory_purge_scope` tool that deletes all memories within a given scope in a single operation.

### Safety Features
- **Scope accessibility check**: Validates the agent has access to the target scope via `scopeManager.isAccessible()` before deletion
- - **Explicit confirmation**: Requires `confirm: true` parameter to prevent accidental purges
- - **Clear feedback**: Returns the count of deleted memories
### Tool Signature
```
memory_purge_scope(scope: string, confirm: boolean)
```

### Example Usage
```
memory_purge_scope({ scope: "agent:my-agent", confirm: true })
// → "Successfully purged scope 'agent:my-agent': 42 memories deleted."
```

## Implementation

- Added `registerMemoryPurgeScopeTool()` in `src/tools.ts`
- - Uses existing `store.bulkDelete([scope])` under the hood
- - Registered alongside other tools in the plugin entry point
## Testing

Verified in production — agents can clean up their own scopes but cannot purge scopes they don't have access to.