### PR TITLE
feat: include memory ID in store/update response text

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -664,7 +664,7 @@ export function registerMemoryStoreTool(
             content: [
               {
                 type: "text",
-                text: `Stored: "${text.slice(0, 100)}${text.length > 100 ? "..." : ""}" in scope '${targetScope}'`,
+                text: `Stored: "${text.slice(0, 100)}${text.length > 100 ? "..." : ""}" (ID: ${entry.id}) in scope '${targetScope}'`,
               },
             ],
             details: {
@@ -996,7 +996,7 @@ export function registerMemoryUpdateTool(
             content: [
               {
                 type: "text",
-                text: `Updated memory ${updated.id.slice(0, 8)}...: "${updated.text.slice(0, 80)}${updated.text.length > 80 ? "..." : ""}"`,
+                text: `Updated memory (ID: ${updated.id}): "${updated.text.slice(0, 80)}${updated.text.length > 80 ? "..." : ""}"`,
               },
             ],
             details: {


### PR DESCRIPTION
## Summary
- Include the full memory ID in the response text of `memory_store` and `memory_update` tools
- Prevents AI hallucination by providing verifiable confirmation of successful storage
- Enables users and AI to reference specific memory entries by ID

## Changes
- **`memory_store`**: Added `(ID: <uuid>)` to response text
  - Before: `Stored: "..." in scope 'agent:main'`
  - After: `Stored: "..." (ID: 8f82f232-...) in scope 'agent:main'`
- **`memory_update`**: Show full ID instead of truncated 8-char prefix
  - Before: `Updated memory 8f82f232...: "..."`
  - After: `Updated memory (ID: 8f82f232-abc1-4def-...): "..."`

## Test plan
- [ ] Verify `memory_store` response includes full UUID in text field
- [ ] Verify `memory_update` response includes full UUID in text field
- [ ] Confirm `details.id` field remains unchanged

Closes #139