### PR TITLE
fix: skip autoRecall for heartbeat/NO_REPLY turns

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "scripts": {
-    "test": "node test/embedder-error-hints.test.mjs && node test/migrate-legacy-schema.test.mjs && node --test test/config-session-strategy-migration.test.mjs && node test/update-consistency-lancedb.test.mjs && node test/cli-smoke.mjs && node test/functional-e2e.mjs && node test/retriever-rerank-regression.mjs && node test/smart-memory-lifecycle.mjs && node test/smart-extractor-branches.mjs && node test/plugin-manifest-regression.mjs",
+    "test": "node test/embedder-error-hints.test.mjs && node test/migrate-legacy-schema.test.mjs && node --test test/config-session-strategy-migration.test.mjs && node test/update-consistency-lancedb.test.mjs && node test/cli-smoke.mjs && node test/functional-e2e.mjs && node test/retriever-rerank-regression.mjs && node test/smart-memory-lifecycle.mjs && node test/smart-extractor-branches.mjs && node test/plugin-manifest-regression.mjs && node --test test/adaptive-retrieval-skip-heartbeat.test.mjs",
     "test:openclaw-host": "node test/openclaw-host-functional.mjs"
   },
   "devDependencies": {

--- a/src/adaptive-retrieval.ts
+++ b/src/adaptive-retrieval.ts
@@ -20,6 +20,8 @@ const SKIP_PATTERNS = [
   /^[\p{Emoji}\s]+$/u,
   // Heartbeat/system (match anywhere, not just at start, to handle prefixed formats)
   /HEARTBEAT/i,
+  /^(no[_-]?reply|noreply)\s*[.!]?$/i,
+  /^(heartbeat(_ok|_fail|_err|_error)?|heartbeat\s*(ok|fail|error)|health[_ -]?check|system[_ -]?check|status[_ -]?check)\s*[.!]?$/i,
   /^\[System/i,
   // Single-word utility pings
   /^(ping|pong|test|debug)\s*[.!?]?$/i,
@@ -56,6 +58,10 @@ function normalizeQuery(query: string): string {
 
   // 3. Strip OpenClaw timestamp prefix [Mon 2026-03-02 04:21 GMT+8].
   s = s.trim().replace(/^\[[A-Za-z]{3}\s\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}\s[^\]]+\]\s*/, "");
+
+  // 4. Strip heartbeat/healthcheck wrappers.
+  s = s.trim().replace(/^\[(heartbeat|health[-_ ]?check|system[-_ ]?check)[^\]]*\]\s*/i, "");
+  s = s.trim().replace(/^(heartbeat|health[-_ ]?check|system[-_ ]?check)\s*[:\-]\s*/i, "");
 
   const result = s.trim();
   return result;

--- a/test/adaptive-retrieval-skip-heartbeat.test.mjs
+++ b/test/adaptive-retrieval-skip-heartbeat.test.mjs
@@ -1,0 +1,27 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+
+const { shouldSkipRetrieval } = jiti("../src/adaptive-retrieval.ts");
+
+describe("shouldSkipRetrieval heartbeat/NO_REPLY", () => {
+  const cases = [
+    "NO_REPLY",
+    "no_reply",
+    "no-reply",
+    "HEARTBEAT_OK",
+    "heartbeat ok",
+    "heartbeat: NO_REPLY",
+    "[heartbeat] NO_REPLY",
+    "health_check",
+    "system-check",
+  ];
+
+  for (const input of cases) {
+    it(`skips retrieval for ${input}`, () => {
+      assert.equal(shouldSkipRetrieval(input), true);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
Heartbeat / `NO_REPLY` turns were still triggering `autoRecall` injection, causing compaction-related latency spikes (minutes-long delays).

## Changes
- **`src/adaptive-retrieval.ts`**:
  - Added `NO_REPLY`, `HEARTBEAT_OK`, `health_check`, `system_check` and variants to `SKIP_PATTERNS`
  - Added heartbeat/healthcheck wrapper stripping in `normalizeQuery()` (e.g. `[heartbeat] ...`, `heartbeat: ...`)
- **`test/adaptive-retrieval-skip-heartbeat.test.mjs`**: 9 test cases covering all heartbeat variants
- **`package.json`**: added new test to `npm test` pipeline

## Root cause
`shouldSkipRetrieval()` already had `/HEARTBEAT/i` but missed:
- `NO_REPLY` (common heartbeat prompt)
- `HEARTBEAT_OK` / `heartbeat ok` variants
- `health_check` / `system_check` patterns
- Prefixed formats like `[heartbeat] NO_REPLY` or `heartbeat: NO_REPLY`

## Test plan
- [x] All 9 new heartbeat skip tests pass
- [ ] Verify existing tests still pass (note: `smart-extractor-branches.mjs` has a pre-existing failure unrelated to this change)

Closes #137