### PR TITLE
fix(retriever): make vectorWeight/bm25Weight actually affect fusion scoring

### DIFF
--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -535,17 +535,15 @@ export class MemoryRetriever {
       // BM25 hit acts as a bonus (keyword match confirms relevance).
       const vectorScore = vectorResult ? vectorResult.score : 0;
       const bm25Score = bm25Result ? bm25Result.score : 0;
-      const bm25Hit = bm25Result ? 1 : 0;
-
-      // Base = vector score; BM25 hit boosts by up to 15%
-      // BM25-only results use their raw BM25 score so exact keyword matches
-      // (e.g. searching "JINA_API_KEY") still surface. The previous floor of 0.5
-      // was too generous and allowed ghost entries to survive hardMinScore (0.35).
+      // Weighted fusion: vectorWeight/bm25Weight directly control score blending.
+      // BM25 high-score floor (>= 0.75) preserves exact keyword matches
+      // (e.g. API keys, ticket numbers) that may have low vector similarity.
+      const weightedFusion = (vectorScore * this.config.vectorWeight)
+                           + (bm25Score * this.config.bm25Weight);
       const fusedScore = vectorResult
         ? clamp01(
           Math.max(
-            vectorScore + (bm25Hit * 0.15 * vectorScore),
-            (vectorScore * this.config.vectorWeight) + (bm25Score * this.config.bm25Weight),
+            weightedFusion,
             bm25Score >= 0.75 ? bm25Score * 0.92 : 0,
           ),
           0.1,

--- a/test/retriever-rerank-regression.mjs
+++ b/test/retriever-rerank-regression.mjs
@@ -130,3 +130,149 @@ const lexicalResults = await lexicalRetriever.retrieve({
 
 assert.equal(lexicalResults.length, 1, "strong lexical hit should survive hybrid fusion thresholds");
 assert.equal(lexicalResults[0].entry.id, lexicalEntry.id);
+
+// ============================================================================
+// Weight effectiveness tests (Issue #130 Layer 3)
+// ============================================================================
+
+const weightTestEntry = {
+  id: "weight-test-1",
+  text: "User prefers dark mode for all applications.",
+  vector: [0.6, 0.8],
+  category: "preference",
+  scope: "global",
+  importance: 0.8,
+  timestamp: Date.now(),
+  metadata: "{}",
+};
+
+const weightTestStore = {
+  hasFtsSupport: true,
+  async vectorSearch() {
+    return [{ entry: weightTestEntry, score: 0.6 }];
+  },
+  async bm25Search() {
+    return [{ entry: weightTestEntry, score: 0.5 }];
+  },
+  async hasId(id) {
+    return id === weightTestEntry.id;
+  },
+};
+
+const weightTestEmbedder = {
+  async embedQuery() {
+    return [0.6, 0.8];
+  },
+};
+
+// Test: vectorWeight=0.9, bm25Weight=0.1
+const vectorHeavyRetriever = createRetriever(weightTestStore, weightTestEmbedder, {
+  ...DEFAULT_RETRIEVAL_CONFIG,
+  filterNoise: false,
+  rerank: "none",
+  vectorWeight: 0.9,
+  bm25Weight: 0.1,
+  minScore: 0.0,
+  hardMinScore: 0.0,
+});
+
+// Test: vectorWeight=0.1, bm25Weight=0.9
+const bm25HeavyRetriever = createRetriever(weightTestStore, weightTestEmbedder, {
+  ...DEFAULT_RETRIEVAL_CONFIG,
+  filterNoise: false,
+  rerank: "none",
+  vectorWeight: 0.1,
+  bm25Weight: 0.9,
+  minScore: 0.0,
+  hardMinScore: 0.0,
+});
+
+const vectorHeavyResults = await vectorHeavyRetriever.retrieve({
+  query: "dark mode",
+  limit: 5,
+});
+
+const bm25HeavyResults = await bm25HeavyRetriever.retrieve({
+  query: "dark mode",
+  limit: 5,
+});
+
+assert.equal(vectorHeavyResults.length, 1, "vectorHeavy: should return 1 result");
+assert.equal(bm25HeavyResults.length, 1, "bm25Heavy: should return 1 result");
+
+// Core assertion: different weights must produce different fused scores
+const vectorHeavyFused = vectorHeavyResults[0].sources.fused?.score;
+const bm25HeavyFused = bm25HeavyResults[0].sources.fused?.score;
+
+assert.ok(vectorHeavyFused !== undefined, "vectorHeavy: fused score must exist");
+assert.ok(bm25HeavyFused !== undefined, "bm25Heavy: fused score must exist");
+assert.notEqual(
+  vectorHeavyFused,
+  bm25HeavyFused,
+  "different weight configs must produce different fused scores",
+);
+
+// vectorScore(0.6) > bm25Score(0.5), so vector-heavy config should score higher
+// vectorHeavy: 0.6*0.9 + 0.5*0.1 = 0.59
+// bm25Heavy:   0.6*0.1 + 0.5*0.9 = 0.51
+assert.ok(
+  vectorHeavyFused > bm25HeavyFused,
+  `vector-heavy config (${vectorHeavyFused}) should score higher than bm25-heavy (${bm25HeavyFused}) when vectorScore > bm25Score`,
+);
+
+console.log("OK: weight effectiveness test passed");
+
+// Test: BM25 high-score floor (>= 0.75) must hold regardless of weight config
+const floorTestEntry = {
+  id: "floor-test-1",
+  text: "JINA_API_KEY=sk-test-12345",
+  vector: [0.1, 0.9],
+  category: "credential",
+  scope: "global",
+  importance: 1.0,
+  timestamp: Date.now(),
+  metadata: "{}",
+};
+
+const floorTestStore = {
+  hasFtsSupport: true,
+  async vectorSearch() {
+    return [{ entry: floorTestEntry, score: 0.3 }];
+  },
+  async bm25Search() {
+    return [{ entry: floorTestEntry, score: 0.85 }];
+  },
+  async hasId(id) {
+    return id === floorTestEntry.id;
+  },
+};
+
+const floorTestRetriever = createRetriever(floorTestStore, weightTestEmbedder, {
+  ...DEFAULT_RETRIEVAL_CONFIG,
+  filterNoise: false,
+  rerank: "none",
+  vectorWeight: 0.9,
+  bm25Weight: 0.1,
+  minScore: 0.0,
+  hardMinScore: 0.0,
+});
+
+const floorResults = await floorTestRetriever.retrieve({
+  query: "JINA_API_KEY",
+  limit: 5,
+});
+
+assert.equal(floorResults.length, 1, "floor test: should return 1 result");
+
+const floorFused = floorResults[0].sources.fused?.score;
+assert.ok(floorFused !== undefined, "floor test: fused score must exist");
+
+// BM25 floor: 0.85 * 0.92 = 0.782
+// Weighted: 0.3 * 0.9 + 0.85 * 0.1 = 0.355
+// Math.max(0.355, 0.782) = 0.782 — floor should win
+assert.ok(
+  floorFused >= 0.85 * 0.92 - 0.001,
+  `BM25 high-score floor must hold: got ${floorFused}, expected >= ${0.85 * 0.92}`,
+);
+
+console.log("OK: BM25 high-score floor test passed");


### PR DESCRIPTION
## Summary

- **Remove redundant `vectorScore + 15% bonus` branch** from the 3-way `Math.max` in `fuseResults()` — this branch dominated in most cases, making `vectorWeight`/`bm25Weight` config parameters effectively useless
- **Make weighted fusion the primary formula**: `vectorScore * vectorWeight + bm25Score * bm25Weight` now directly controls score blending
- **Preserve BM25 high-score floor** (`>= 0.75 → score * 0.92`) to protect exact keyword matches (API keys, ticket numbers) with low vector similarity

Addresses Layer 3 of #130.

## Why

Users configure `vectorWeight`/`bm25Weight` expecting to tune the balance between vector and lexical retrieval. Before this fix, the old formula A (`vectorScore + bm25Hit * 0.15 * vectorScore`) won `Math.max` in most scenarios, making weight tuning ineffective:

```
Old: Math.max(vectorScore + 15% bonus, weightedFusion, bm25Floor) → bonus wins
New: Math.max(weightedFusion, bm25Floor) → weights take effect
```

## Numerical verification

| Scenario | vectorScore | bm25Score | Old | New | hardMinScore | Pass? |
|----------|------------|-----------|-----|-----|-------------|-------|
| Rerank regression | 0.5439 | 0.7834 | 0.721 | 0.721 | 0.62 | ✅ |
| Lexical (乌龙茶) | 0.5007 | 0.78 | 0.718 | 0.718 | 0.62 | ✅ |
| High vector only | 0.9 | 0.0 | 0.9 | 0.63 | 0.35 | ✅ |
| Balanced | 0.6 | 0.5 | 0.69 | 0.57 | 0.35 | ✅ |

## Test plan

- [x] **Weight effectiveness** — two retrievers with different weight configs produce different fused scores
- [x] **BM25 high-score floor** — `bm25Score >= 0.75` always floors at `bm25Score * 0.92` regardless of weights
- [x] **Existing regression** — all existing assertions in `retriever-rerank-regression.mjs` pass unchanged
- [x] All tests pass (`npm test` green, including `smart-extractor-branches.mjs` now that #164 is merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)