### PR TITLE
fix: declare apache-arrow as a direct runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@lancedb/lancedb": "^0.26.2",
     "@sinclair/typebox": "0.34.48",
+    "apache-arrow": "18.1.0",
     "openai": "^6.21.0"
   },
   "openclaw": {

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -84,6 +84,11 @@ assert.equal(
   pkg.version,
   "openclaw.plugin.json version should stay aligned with package.json",
 );
+assert.equal(
+  pkg.dependencies["apache-arrow"],
+  "18.1.0",
+  "package.json should declare apache-arrow directly so OpenClaw plugin installs do not miss the LanceDB runtime dependency",
+);
 
 const workDir = mkdtempSync(path.join(tmpdir(), "memory-plugin-regression-"));
 const services = [];


### PR DESCRIPTION
## Summary

Declare `apache-arrow` as a direct runtime dependency of `memory-lancedb-pro`.

## Why

`@lancedb/lancedb` requires `apache-arrow` at runtime, but currently exposes it via `peerDependencies`.
That works in some regular npm environments, but it can be missed by isolated plugin installation flows.

One reproducible case is OpenClaw's plugin installer, which installs plugin dependencies with:

```bash
npm install --omit=dev --omit=peer --ignore-scripts
```

In that environment, `apache-arrow` is not installed, and the plugin later fails when LanceDB is loaded:

```text
memory-lancedb-pro: failed to load LanceDB
Cannot find module 'apache-arrow'
```

Declaring `apache-arrow` directly fixes both:
- regular npm installation
- isolated OpenClaw plugin installation

## Changes

- add `apache-arrow@18.1.0` to `dependencies`
- add a regression assertion so the package keeps declaring it directly
- refresh `package-lock.json`

## Verification

Ran in a clean container:

```bash
npm ci
node test/plugin-manifest-regression.mjs
node --test test/sync-plugin-version.test.mjs
```

All passed.
