### PR TITLE
feat: add DashScope (Alibaba Cloud) rerank provider

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -85,7 +85,7 @@ interface PluginConfig {
     rerankApiKey?: string;
     rerankModel?: string;
     rerankEndpoint?: string;
-    rerankProvider?: "jina" | "siliconflow" | "voyage" | "pinecone";
+    rerankProvider?: "jina" | "siliconflow" | "voyage" | "pinecone" | "dashscope";
     recencyHalfLifeDays?: number;
     recencyWeight?: number;
     filterNoise?: boolean;

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -186,10 +186,11 @@
               "jina",
               "siliconflow",
               "voyage",
-              "pinecone"
+              "pinecone",
+              "dashscope"
             ],
             "default": "jina",
-            "description": "Reranker provider format. Determines request/response shape and auth header."
+            "description": "Reranker provider format. Determines request/response shape and auth header. DashScope uses gte-rerank-v2 with endpoint https://dashscope.aliyuncs.com/api/v1/services/rerank/text-rerank/text-rerank."
           },
           "candidatePoolSize": {
             "type": "integer",
@@ -608,7 +609,7 @@
     },
     "retrieval.rerankProvider": {
       "label": "Reranker Provider",
-      "help": "Provider format: jina (default), siliconflow, voyage, or pinecone",
+      "help": "Provider format: jina (default), siliconflow, voyage, pinecone, or dashscope",
       "advanced": true
     },
     "retrieval.candidatePoolSize": {

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -43,7 +43,7 @@ export interface RetrievalConfig {
    *  - "siliconflow": same format as jina (alias, for clarity)
    *  - "voyage": Authorization: Bearer, string[] documents, data[].relevance_score
    *  - "pinecone": Api-Key header, {text}[] documents, data[].score */
-  rerankProvider?: "jina" | "siliconflow" | "voyage" | "pinecone";
+  rerankProvider?: "jina" | "siliconflow" | "voyage" | "pinecone" | "dashscope";
   /**
    * Length normalization: penalize long entries that dominate via sheer keyword
    * density. Formula: score *= 1 / (1 + log2(charLen / anchor)).
@@ -139,7 +139,7 @@ function clamp01WithFloor(value: number, floor: number): number {
 // Rerank Provider Adapters
 // ============================================================================
 
-type RerankProvider = "jina" | "siliconflow" | "voyage" | "pinecone";
+type RerankProvider = "jina" | "siliconflow" | "voyage" | "pinecone" | "dashscope";
 
 interface RerankItem {
   index: number;
@@ -156,6 +156,22 @@ function buildRerankRequest(
   topN: number,
 ): { headers: Record<string, string>; body: Record<string, unknown> } {
   switch (provider) {
+    case "dashscope":
+      // DashScope wraps query+documents under `input` and does not use top_n.
+      // Endpoint: https://dashscope.aliyuncs.com/api/v1/services/rerank/text-rerank/text-rerank
+      return {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: {
+          model,
+          input: {
+            query,
+            documents,
+          },
+        },
+      };
     case "pinecone":
       return {
         headers: {
@@ -234,6 +250,15 @@ function parseRerankResponse(
   };
 
   switch (provider) {
+    case "dashscope": {
+      // DashScope: { output: { results: [{ index, relevance_score }] } }
+      const output = data.output as Record<string, unknown> | undefined;
+      if (output) {
+        return parseItems(output.results, ["relevance_score", "score"]);
+      }
+      // Fallback: try top-level results in case API format changes
+      return parseItems(data.results, ["relevance_score", "score"]);
+    }
     case "pinecone": {
       // Pinecone: usually { data: [{ index, score, ... }] }
       // Also tolerate results[] with score/relevance_score for robustness.


### PR DESCRIPTION
## Summary

Add `"dashscope"` as a new rerank provider to support Alibaba Cloud's DashScope `gte-rerank-v2` model.

DashScope's rerank API differs from existing providers:

| Aspect | Jina/SiliconFlow | DashScope |
|--------|-----------------|-----------|
| Request body | `{ query, documents }` | `{ input: { query, documents } }` |
| Response | `{ results: [...] }` | `{ output: { results: [...] } }` |
| Endpoint | `/v1/rerank` | `/api/v1/services/rerank/text-rerank/text-rerank` |

## Changes

- **`src/retriever.ts`**: Add `"dashscope"` case to `buildRerankRequest()` (wraps under `input`) and `parseRerankResponse()` (unwraps from `output.results[]`). Extend `RerankProvider` type.
- **`index.ts`**: Extend `rerankProvider` union type in config interface.
- **`openclaw.plugin.json`**: Add `"dashscope"` to schema enum, update description and help text.

## Configuration Example

```json
{
  "retrieval": {
    "rerank": "cross-encoder",
    "rerankProvider": "dashscope",
    "rerankModel": "gte-rerank-v2",
    "rerankEndpoint": "https://dashscope.aliyuncs.com/api/v1/services/rerank/text-rerank/text-rerank",
    "rerankApiKey": "<dashscope-api-key>"
  }
}
```

## Test

Verified end-to-end with DashScope `gte-rerank-v2`:

```
Request:  { model: "gte-rerank-v2", input: { query: "...", documents: [...] } }
Response: { output: { results: [{ index: 0, relevance_score: 0.934 }, ...] } }
```

Adapter correctly builds the request and parses the response.