### PR TITLE
fix: support Windows extension API lookup paths

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { homedir, tmpdir } from "node:os";
-import { join, dirname, basename } from "node:path";
+import { join, dirname, basename, win32 } from "node:path";
 import { readFile, readdir, writeFile, mkdir, appendFile, unlink, stat } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
@@ -311,26 +311,58 @@ function toImportSpecifier(value: string): string {
   if (!trimmed) return "";
   if (trimmed.startsWith("file://")) return trimmed;
   if (trimmed.startsWith("/")) return pathToFileURL(trimmed).href;
+  if (/^[a-zA-Z]:[\\/]/.test(trimmed)) {
+    return pathToFileURL(`/${trimmed.replace(/\\/g, "/")}`).href;
+  }
   return trimmed;
 }
-function getExtensionApiImportSpecifiers(): string[] {
-  const envPath = process.env.OPENCLAW_EXTENSION_API_PATH?.trim();
+
+function getExtensionApiFallbackPaths(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  if (platform === "win32") {
+    const appData = env.APPDATA?.trim() || win32.join(homedir(), "AppData", "Roaming");
+    return [
+      win32.join(appData, "npm", "node_modules", "openclaw", "dist", "extensionAPI.js"),
+    ];
+  }
+
+  return [
+    "/usr/lib/node_modules/openclaw/dist/extensionAPI.js",
+    "/usr/local/lib/node_modules/openclaw/dist/extensionAPI.js",
+  ];
+}
+
+function getExtensionApiImportSpecifiers(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  resolveInstalledSpecifier: () => string = () => requireFromHere.resolve("openclaw/dist/extensionAPI.js"),
+): string[] {
+  const envPath = env.OPENCLAW_EXTENSION_API_PATH?.trim();
   const specifiers: string[] = [];
 
   if (envPath) specifiers.push(toImportSpecifier(envPath));
   specifiers.push("openclaw/dist/extensionAPI.js");
 
   try {
-    specifiers.push(toImportSpecifier(requireFromHere.resolve("openclaw/dist/extensionAPI.js")));
+    specifiers.push(toImportSpecifier(resolveInstalledSpecifier()));
   } catch {
     // ignore resolve failures and continue fallback probing
   }
 
-  specifiers.push(toImportSpecifier("/usr/lib/node_modules/openclaw/dist/extensionAPI.js"));
-  specifiers.push(toImportSpecifier("/usr/local/lib/node_modules/openclaw/dist/extensionAPI.js"));
+  for (const fallbackPath of getExtensionApiFallbackPaths(platform, env)) {
+    specifiers.push(toImportSpecifier(fallbackPath));
+  }
 
   return [...new Set(specifiers.filter(Boolean))];
 }
+
+export const __testOnly = {
+  toImportSpecifier,
+  getExtensionApiFallbackPaths,
+  getExtensionApiImportSpecifiers,
+};
 
 async function loadEmbeddedPiRunner(): Promise<EmbeddedPiRunner> {
   if (!embeddedPiRunnerPromise) {

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -5,6 +5,7 @@ import http from "node:http";
 import Module from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import jitiFactory from "jiti";
 
@@ -88,6 +89,32 @@ assert.equal(
   pkg.dependencies["apache-arrow"],
   "18.1.0",
   "package.json should declare apache-arrow directly so OpenClaw plugin installs do not miss the LanceDB runtime dependency",
+);
+
+const windowsExtensionApiPath = "C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\extensionAPI.js";
+assert.equal(
+  plugin.__testOnly.toImportSpecifier(windowsExtensionApiPath),
+  pathToFileURL("/C:/Users/alice/AppData/Roaming/npm/node_modules/openclaw/dist/extensionAPI.js").href,
+  "Windows absolute extension API paths should be converted into file:// import specifiers",
+);
+
+const windowsSpecifiers = plugin.__testOnly.getExtensionApiImportSpecifiers(
+  "win32",
+  {
+    OPENCLAW_EXTENSION_API_PATH: windowsExtensionApiPath,
+    APPDATA: "C:\\Users\\alice\\AppData\\Roaming",
+  },
+  () => {
+    throw new Error("resolve disabled in regression test");
+  },
+);
+assert.ok(
+  windowsSpecifiers.includes(pathToFileURL("/C:/Users/alice/AppData/Roaming/npm/node_modules/openclaw/dist/extensionAPI.js").href),
+  "Windows fallback probing should include the global npm extensionAPI.js path",
+);
+assert.ok(
+  !windowsSpecifiers.some((specifier) => specifier.includes("/usr/lib/node_modules/openclaw")),
+  "Windows fallback probing should not include Unix-only global npm paths",
 );
 
 const workDir = mkdtempSync(path.join(tmpdir(), "memory-plugin-regression-"));


### PR DESCRIPTION
## Summary
- convert Windows drive-letter paths to `file://` import specifiers correctly on all platforms
- probe `%APPDATA%\npm\node_modules\openclaw\dist\extensionAPI.js` on Windows instead of Unix-only global npm paths
- add regression coverage for Windows path conversion and fallback probing in `plugin-manifest-regression`

Fixes #197.

## Validation
- `node test/plugin-manifest-regression.mjs`
- `npm test`