### PR TITLE
fix: add Windows path support in getExtensionApiImportSpecifiers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -311,6 +311,8 @@ function toImportSpecifier(value: string): string {
   if (!trimmed) return "";
   if (trimmed.startsWith("file://")) return trimmed;
   if (trimmed.startsWith("/")) return pathToFileURL(trimmed).href;
+  // Handle Windows absolute paths (e.g., C:\Users\...)
+  if (/^[a-zA-Z]:[/\\]/.test(trimmed)) return pathToFileURL(trimmed).href;
   return trimmed;
 }
 function getExtensionApiImportSpecifiers(): string[] {
@@ -326,8 +328,17 @@ function getExtensionApiImportSpecifiers(): string[] {
     // ignore resolve failures and continue fallback probing
   }
 
-  specifiers.push(toImportSpecifier("/usr/lib/node_modules/openclaw/dist/extensionAPI.js"));
-  specifiers.push(toImportSpecifier("/usr/local/lib/node_modules/openclaw/dist/extensionAPI.js"));
+  // Platform-aware fallback paths
+  const home = homedir();
+  if (process.platform === "win32") {
+    // Windows: %APPDATA%\npm\node_modules\openclaw\dist\extensionAPI.js
+    const winPath = join(process.env.APPDATA || join(home, "AppData", "Roaming"), "npm", "node_modules", "openclaw", "dist", "extensionAPI.js");
+    specifiers.push(toImportSpecifier(winPath));
+  } else {
+    // Unix fallback paths
+    specifiers.push(toImportSpecifier("/usr/lib/node_modules/openclaw/dist/extensionAPI.js"));
+    specifiers.push(toImportSpecifier("/usr/local/lib/node_modules/openclaw/dist/extensionAPI.js"));
+  }
 
   return [...new Set(specifiers.filter(Boolean))];
 }


### PR DESCRIPTION
## Summary

Adds Windows path support to the plugin's import specifier resolution.

## Changes

1. **toImportSpecifier()**: Added Windows absolute path detection (C:\Users\...)
2. **getExtensionApiImportSpecifiers()**: Added platform-aware fallback paths:
   - Windows: uses %APPDATA%\npm\node_modules\openclaw\dist\extensionAPI.js
   - Unix: keeps existing /usr/lib/node_modules/... and /usr/local/lib/node_modules/...

## Testing

Tested on Windows 11 with Node.js v24.13.0 and memory-lancedb-pro 1.1.0-beta.8.

`
SUCCESS: runEmbeddedPiAgent exists: function
[plugins] memory-reflection: integrated hooks registered
`

## Related

Fixes #197