### PR TITLE
feat: add native support for Azure OpenAI embeddings

### DIFF
--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -302,9 +302,14 @@ export class Embedder {
     this._autoChunk = config.chunking !== false;
 
     // Create a client pool — one OpenAI client per key
+    const isAzure = config.baseURL?.includes('.openai.azure.com');
     this.clients = resolvedKeys.map(key => new OpenAI({
       apiKey: key,
       ...(config.baseURL ? { baseURL: config.baseURL } : {}),
+      ...(isAzure ? {
+        defaultHeaders: { 'api-key': key },
+        defaultQuery: { 'api-version': '2024-02-01' }
+      } : {})
     }));
 
     if (this.clients.length > 1) {


### PR DESCRIPTION
This PR adds native support for Azure OpenAI endpoints. When the `baseURL` contains `.openai.azure.com`, it automatically injects the required `api-key` header and `api-version` query parameter into the underlying OpenAI client. This allows users to configure Azure OpenAI directly without needing an intermediate proxy like LiteLLM or OneAPI.

### How to configure
Users can simply use the standard `openai-compatible` provider and paste their Azure deployment URL:

```json
"embedding": {
  "provider": "openai-compatible",
  "baseURL": "https://<YOUR_RESOURCE>.openai.azure.com/openai/deployments/<YOUR_DEPLOYMENT>",
  "apiKey": "<YOUR_AZURE_API_KEY>",
  "model": "text-embedding-3-large",
  "dimensions": 3072
}
```
