### PR TITLE
fix: improve voyage embedding provider compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ Works with **any OpenAI-compatible embedding API**:
 | --- | --- | --- | --- |
 | **Jina** (recommended) | `jina-embeddings-v5-text-small` | `https://api.jina.ai/v1` | 1024 |
 | **OpenAI** | `text-embedding-3-small` | `https://api.openai.com/v1` | 1536 |
+| **Voyage** | `voyage-4-lite` / `voyage-4` | `https://api.voyageai.com/v1` | 1024 / 1024 |
 | **Google Gemini** | `gemini-embedding-001` | `https://generativelanguage.googleapis.com/v1beta/openai/` | 3072 |
 | **Ollama** (local) | `nomic-embed-text` | `http://localhost:11434/v1` | provider-specific |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -471,6 +471,7 @@ git clone https://github.com/CortexReach/memory-lancedb-pro-skill.git ~/.opencla
 | --- | --- | --- | --- |
 | **Jina**（推荐） | `jina-embeddings-v5-text-small` | `https://api.jina.ai/v1` | 1024 |
 | **OpenAI** | `text-embedding-3-small` | `https://api.openai.com/v1` | 1536 |
+| **Voyage** | `voyage-4-lite` / `voyage-4` | `https://api.voyageai.com/v1` | 1024 / 1024 |
 | **Google Gemini** | `gemini-embedding-001` | `https://generativelanguage.googleapis.com/v1beta/openai/` | 3072 |
 | **Ollama**（本地） | `nomic-embed-text` | `http://localhost:11434/v1` | 取决于模型 |
 

--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -101,6 +101,32 @@ export interface EmbeddingConfig {
   chunking?: boolean;
 }
 
+type EmbeddingProviderProfile =
+  | "openai"
+  | "jina"
+  | "voyage-compatible"
+  | "generic-openai-compatible";
+
+interface EmbeddingCapabilities {
+  /** Whether to send encoding_format: "float" */
+  encoding_format: boolean;
+  /** Whether to send normalized (Jina-style) */
+  normalized: boolean;
+  /**
+   * Field name to use for the task/input-type hint, or null if unsupported.
+   * e.g. "task" for Jina, "input_type" for Voyage, null for OpenAI/generic.
+   * If a taskValueMap is provided, task values are translated before sending.
+   */
+  taskField: string | null;
+  /** Optional value translation map for taskField (e.g. Voyage needs "retrieval.query" → "query") */
+  taskValueMap?: Record<string, string>;
+  /**
+   * Field name to use for the requested output dimension, or null if unsupported.
+   * e.g. "dimensions" for OpenAI, "output_dimension" for Voyage, null if not supported.
+   */
+  dimensionsField: string | null;
+}
+
 // Known embedding model dimensions
 const EMBEDDING_DIMENSIONS: Record<string, number> = {
   "text-embedding-3-small": 1536,
@@ -116,6 +142,16 @@ const EMBEDDING_DIMENSIONS: Record<string, number> = {
   // Jina v5
   "jina-embeddings-v5-text-small": 1024,
   "jina-embeddings-v5-text-nano": 768,
+
+  // Voyage recommended models
+  "voyage-4": 1024,
+  "voyage-4-lite": 1024,
+  "voyage-4-large": 1024,
+
+  // Voyage legacy models
+  "voyage-3": 1024,
+  "voyage-3-lite": 512,
+  "voyage-3-large": 1024,
 };
 
 // ============================================================================
@@ -159,12 +195,15 @@ function getErrorCode(error: unknown): string | undefined {
 }
 
 function getProviderLabel(baseURL: string | undefined, model: string): string {
+  const profile = detectEmbeddingProviderProfile(baseURL, model);
   const base = baseURL || "";
 
+  if (/localhost:11434|127\.0\.0\.1:11434|\/ollama\b/i.test(base)) return "Ollama";
+
   if (base) {
-    if (/api\.jina\.ai/i.test(base)) return "Jina";
-    if (/localhost:11434|127\.0\.0\.1:11434|\/ollama\b/i.test(base)) return "Ollama";
-    if (/api\.openai\.com/i.test(base)) return "OpenAI";
+    if (profile === "jina" && /api\.jina\.ai/i.test(base)) return "Jina";
+    if (profile === "voyage-compatible" && /api\.voyageai\.com/i.test(base)) return "Voyage";
+    if (profile === "openai" && /api\.openai\.com/i.test(base)) return "OpenAI";
 
     try {
       return new URL(base).host;
@@ -173,9 +212,71 @@ function getProviderLabel(baseURL: string | undefined, model: string): string {
     }
   }
 
-  if (/^jina-/i.test(model)) return "Jina";
+  switch (profile) {
+    case "jina":
+      return "Jina";
+    case "voyage-compatible":
+      return "Voyage";
+    case "openai":
+      return "OpenAI";
+    default:
+      return "embedding provider";
+  }
+}
 
-  return "embedding provider";
+function detectEmbeddingProviderProfile(
+  baseURL: string | undefined,
+  model: string,
+): EmbeddingProviderProfile {
+  const base = baseURL || "";
+
+  if (/api\.openai\.com/i.test(base)) return "openai";
+  if (/api\.jina\.ai/i.test(base) || /^jina-/i.test(model)) return "jina";
+  if (/api\.voyageai\.com/i.test(base) || /^voyage\b/i.test(model)) {
+    return "voyage-compatible";
+  }
+
+  return "generic-openai-compatible";
+}
+
+function getEmbeddingCapabilities(profile: EmbeddingProviderProfile): EmbeddingCapabilities {
+  switch (profile) {
+    case "openai":
+      return {
+        encoding_format: true,
+        normalized: false,
+        taskField: null,
+        dimensionsField: "dimensions",
+      };
+    case "jina":
+      return {
+        encoding_format: true,
+        normalized: true,
+        taskField: "task",
+        dimensionsField: "dimensions",
+      };
+    case "voyage-compatible":
+      return {
+        encoding_format: false,
+        normalized: false,
+        taskField: "input_type",
+        taskValueMap: {
+          "retrieval.query": "query",
+          "retrieval.passage": "document",
+          "query": "query",
+          "document": "document",
+        },
+        dimensionsField: "output_dimension",
+      };
+    case "generic-openai-compatible":
+    default:
+      return {
+        encoding_format: true,
+        normalized: false,
+        taskField: null,
+        dimensionsField: "dimensions",
+      };
+  }
 }
 
 function isAuthError(error: unknown): boolean {
@@ -226,7 +327,10 @@ export function formatEmbeddingProviderError(
 
   if (isAuthError(error)) {
     let hint = `Check embedding.apiKey and endpoint for ${provider}.`;
-    if (provider === "Jina") {
+    // Use profile rather than provider label so Jina-specific hint also fires
+    // when model is jina-* but baseURL is a proxy (not api.jina.ai).
+    const profile = detectEmbeddingProviderProfile(opts.baseURL, opts.model);
+    if (profile === "jina") {
       hint +=
         " If your Jina key expired or lost access, replace the key or switch to a local OpenAI-compatible endpoint such as Ollama (for example baseURL http://127.0.0.1:11434/v1, with a matching model and embedding.dimensions).";
     } else if (provider === "Ollama") {
@@ -281,6 +385,7 @@ export class Embedder {
   private readonly _taskQuery?: string;
   private readonly _taskPassage?: string;
   private readonly _normalized?: boolean;
+  private readonly _capabilities: EmbeddingCapabilities;
 
   /** Optional requested dimensions to pass through to the embedding provider (OpenAI-compatible). */
   private readonly _requestDimensions?: number;
@@ -300,6 +405,20 @@ export class Embedder {
     this._requestDimensions = config.dimensions;
     // Enable auto-chunking by default for better handling of long documents
     this._autoChunk = config.chunking !== false;
+    const profile = detectEmbeddingProviderProfile(this._baseURL, this._model);
+    this._capabilities = getEmbeddingCapabilities(profile);
+
+    // Warn if configured fields will be silently ignored by this provider profile
+    if (config.normalized !== undefined && !this._capabilities.normalized) {
+      console.debug(
+        `[memory-lancedb-pro] embedding.normalized is set but provider profile "${profile}" does not support it — value will be ignored`
+      );
+    }
+    if ((config.taskQuery || config.taskPassage) && !this._capabilities.taskField) {
+      console.debug(
+        `[memory-lancedb-pro] embedding.taskQuery/taskPassage is set but provider profile "${profile}" does not support task hints — values will be ignored`
+      );
+    }
 
     // Create a client pool — one OpenAI client per key
     this.clients = resolvedKeys.map(key => new OpenAI({
@@ -449,18 +568,28 @@ export class Embedder {
     const payload: any = {
       model: this.model,
       input,
-      // Force float output to avoid SDK default base64 decoding path.
-      encoding_format: "float",
     };
 
-    if (task) payload.task = task;
-    if (this._normalized !== undefined) payload.normalized = this._normalized;
+    if (this._capabilities.encoding_format) {
+      // Force float output where providers explicitly support OpenAI-style formatting.
+      payload.encoding_format = "float";
+    }
 
-    // Some OpenAI-compatible providers support requesting a specific vector size.
-    // We only pass it through when explicitly configured to avoid breaking providers
-    // that reject unknown fields.
-    if (this._requestDimensions && this._requestDimensions > 0) {
-      payload.dimensions = this._requestDimensions;
+    if (this._capabilities.normalized && this._normalized !== undefined) {
+      payload.normalized = this._normalized;
+    }
+
+    // Task hint: field name and optional value translation are provider-defined.
+    if (this._capabilities.taskField && task) {
+      const cap = this._capabilities;
+      const value = cap.taskValueMap?.[task] ?? task;
+      payload[cap.taskField] = value;
+    }
+
+    // Output dimension: field name is provider-defined.
+    // Only sent when explicitly configured to avoid breaking providers that reject unknown fields.
+    if (this._capabilities.dimensionsField && this._requestDimensions && this._requestDimensions > 0) {
+      payload[this._capabilities.dimensionsField] = this._requestDimensions;
     }
 
     return payload;
@@ -494,7 +623,7 @@ export class Embedder {
         try {
           console.log(`Document exceeded context limit (${errorMsg}), attempting chunking...`);
           const chunkResult = smartChunk(text, this._model);
-          
+
           if (chunkResult.chunks.length === 0) {
             throw new Error(`Failed to chunk document: ${errorMsg}`);
           }
@@ -525,11 +654,11 @@ export class Embedder {
           );
 
           const finalEmbedding = avgEmbedding.map(v => v / chunkEmbeddings.length);
-          
+
           // Cache the result for the original text (using its hash)
           this._cache.set(text, task, finalEmbedding);
           console.log(`Successfully embedded long document as ${chunkEmbeddings.length} averaged chunks`);
-          
+
           return finalEmbedding;
         } catch (chunkError) {
           // If chunking fails, throw the original error
@@ -605,7 +734,7 @@ export class Embedder {
       if (isContextError && this._autoChunk) {
         try {
           console.log(`Batch embedding failed with context error, attempting chunking...`);
-          
+
           const chunkResults = await Promise.all(
             validTexts.map(async (text, idx) => {
               const chunkResult = smartChunk(text, this._model);

--- a/test/embedder-error-hints.test.mjs
+++ b/test/embedder-error-hints.test.mjs
@@ -4,7 +4,7 @@ import http from "node:http";
 import jitiFactory from "jiti";
 
 const jiti = jitiFactory(import.meta.url, { interopDefault: true });
-const { Embedder, formatEmbeddingProviderError } = jiti("../src/embedder.ts");
+const { Embedder, formatEmbeddingProviderError, getVectorDimensions } = jiti("../src/embedder.ts");
 
 async function withJsonServer(status, body, fn) {
   const server = http.createServer((req, res) => {
@@ -29,6 +29,66 @@ async function withJsonServer(status, body, fn) {
   }
 }
 
+function createEmbeddingResponse(dimensions, value = 0.1) {
+  return {
+    data: [
+      {
+        object: "embedding",
+        index: 0,
+        embedding: new Array(dimensions).fill(value),
+      },
+    ],
+  };
+}
+
+async function withEmbeddingCaptureServer(handler, fn) {
+  const server = http.createServer(async (req, res) => {
+    if (req.url !== "/v1/embeddings" || req.method !== "POST") {
+      res.writeHead(404);
+      res.end("not found");
+      return;
+    }
+
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const body = Buffer.concat(chunks).toString("utf8");
+    const payload = JSON.parse(body);
+    const response = await handler(payload, req);
+    res.writeHead(response.status ?? 200, { "content-type": "application/json" });
+    res.end(JSON.stringify(response.body));
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  const baseURL = `http://127.0.0.1:${port}/v1`;
+
+  try {
+    await fn({ baseURL, port });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+function installMockEmbeddingClient(embedder, onCreate) {
+  embedder.clients = [
+    {
+      embeddings: {
+        create: async (payload) => onCreate(payload),
+      },
+    },
+  ];
+}
+
+/** Capture console.debug calls emitted synchronously during fn(). */
+function captureDebug(fn) {
+  const messages = [];
+  const orig = console.debug;
+  console.debug = (...args) => messages.push(args.join(" "));
+  try { fn(); } finally { console.debug = orig; }
+  return messages;
+}
+
 async function expectReject(promiseFactory, pattern) {
   try {
     await promiseFactory();
@@ -41,6 +101,133 @@ async function expectReject(promiseFactory, pattern) {
 }
 
 async function run() {
+  assert.equal(getVectorDimensions("voyage-4-lite"), 1024);
+  assert.equal(getVectorDimensions("voyage-3-large"), 1024);
+
+  const voyageEmbedder = new Embedder({
+    provider: "openai-compatible",
+    apiKey: "test-key",
+    model: "voyage-3-lite",
+    baseURL: "https://api.voyageai.com/v1",
+    dimensions: 1024,
+  });
+  installMockEmbeddingClient(voyageEmbedder, async (payload) => {
+    assert.notEqual(payload.encoding_format, "float");
+    assert.equal(payload.dimensions, undefined);
+    return createEmbeddingResponse(1024);
+  });
+  await voyageEmbedder.embedPassage("hello");
+
+  const jinaEmbedder = new Embedder({
+    provider: "openai-compatible",
+    apiKey: "test-key",
+    model: "jina-embeddings-v5-text-small",
+    baseURL: "https://api.jina.ai/v1",
+    dimensions: 1024,
+    taskPassage: "retrieval.passage",
+    normalized: true,
+  });
+  installMockEmbeddingClient(jinaEmbedder, async (payload) => {
+    assert.equal(payload.task, "retrieval.passage");
+    assert.equal(payload.normalized, true);
+    assert.equal(payload.dimensions, 1024);
+    return createEmbeddingResponse(1024);
+  });
+  await jinaEmbedder.embedPassage("hello");
+
+  const genericEmbedder = new Embedder({
+    provider: "openai-compatible",
+    apiKey: "test-key",
+    model: "custom-embed-model",
+    baseURL: "https://embeddings.example.invalid/v1",
+    dimensions: 384,
+  });
+  installMockEmbeddingClient(genericEmbedder, async (payload) => {
+    assert.equal(payload.encoding_format, "float");
+    assert.equal(payload.dimensions, 384);
+    return createEmbeddingResponse(384);
+  });
+  await genericEmbedder.embedPassage("hello");
+
+  // voyage-4 should be detected as voyage-compatible via model name prefix,
+  // even when baseURL is NOT api.voyageai.com (e.g. behind a proxy).
+  const voyageProxyEmbedder = new Embedder({
+    provider: "openai-compatible",
+    apiKey: "test-key",
+    model: "voyage-4",
+    baseURL: "https://proxy.example.invalid/v1",
+    dimensions: 1024,
+  });
+  installMockEmbeddingClient(voyageProxyEmbedder, async (payload) => {
+    assert.notEqual(payload.encoding_format, "float", "voyage-4 should not send encoding_format");
+    assert.equal(payload.dimensions, undefined, "voyage-4 should not send dimensions");
+    return createEmbeddingResponse(1024);
+  });
+  await voyageProxyEmbedder.embedPassage("hello");
+
+  // Voyage: taskPassage "retrieval.passage" → input_type "document"
+  //         taskQuery  "retrieval.query"   → input_type "query"
+  const voyageTaskEmbedder = new Embedder({
+    provider: "openai-compatible",
+    apiKey: "test-key",
+    model: "voyage-3-lite",
+    baseURL: "https://api.voyageai.com/v1",
+    dimensions: 1024,
+    taskPassage: "retrieval.passage",
+    taskQuery: "retrieval.query",
+  });
+  installMockEmbeddingClient(voyageTaskEmbedder, async (payload) => {
+    assert.equal(payload.input_type, "document", "voyage taskPassage should map to input_type=document");
+    assert.equal(payload.task, undefined, "voyage should not send task field");
+    return createEmbeddingResponse(1024);
+  });
+  await voyageTaskEmbedder.embedPassage("hello");
+
+  installMockEmbeddingClient(voyageTaskEmbedder, async (payload) => {
+    assert.equal(payload.input_type, "query", "voyage taskQuery should map to input_type=query");
+    return createEmbeddingResponse(1024);
+  });
+  await voyageTaskEmbedder.embedQuery("hello");
+
+  // Voyage: configured dimensions should be sent as output_dimension, not dimensions.
+  // voyage-4-lite is a recommended Voyage model that supports output_dimension.
+  const voyageDimEmbedder = new Embedder({
+    provider: "openai-compatible",
+    apiKey: "test-key",
+    model: "voyage-4-lite",
+    baseURL: "https://api.voyageai.com/v1",
+    dimensions: 512,
+  });
+  installMockEmbeddingClient(voyageDimEmbedder, async (payload) => {
+    assert.equal(payload.output_dimension, 512, "voyage should send output_dimension");
+    assert.equal(payload.dimensions, undefined, "voyage should not send dimensions");
+    return createEmbeddingResponse(512);
+  });
+  await voyageDimEmbedder.embedPassage("hello");
+
+  // End-to-end HTTP payload verification for generic-openai-compatible profile.
+  // Unlike the mock tests above, this spins up a real HTTP server and verifies
+  // the actual request body sent by the OpenAI SDK.
+  await withEmbeddingCaptureServer(
+    (payload) => {
+      assert.equal(payload.encoding_format, "float", "generic profile should send encoding_format");
+      assert.equal(payload.dimensions, 384, "generic profile should send dimensions");
+      assert.equal(payload.task, undefined, "generic profile should not send task");
+      assert.equal(payload.normalized, undefined, "generic profile should not send normalized");
+      return { body: createEmbeddingResponse(384) };
+    },
+    async ({ baseURL }) => {
+      const embedder = new Embedder({
+        provider: "openai-compatible",
+        apiKey: "test-key",
+        model: "custom-embed-model",
+        baseURL,
+        dimensions: 384,
+      });
+      await embedder.embedPassage("hello world");
+    },
+  );
+
   await withJsonServer(
     403,
     { error: { message: "Invalid API key", code: "invalid_api_key" } },
@@ -62,6 +249,50 @@ async function run() {
       assert.doesNotMatch(msg, /Check .* for Jina\./i, msg);
     },
   );
+
+  // Constructor warning: normalized set on OpenAI profile → debug warning fires
+  {
+    const msgs = captureDebug(() => new Embedder({
+      provider: "openai-compatible", apiKey: "test-key",
+      model: "text-embedding-3-small", dimensions: 1536, normalized: true,
+    }));
+    assert.ok(msgs.some((m) => /normalized/i.test(m)),
+      `Expected warning about normalized, got: ${msgs.join(" | ")}`);
+  }
+
+  // Constructor warning: taskQuery set on generic profile → debug warning fires
+  {
+    const msgs = captureDebug(() => new Embedder({
+      provider: "openai-compatible", apiKey: "test-key",
+      model: "custom-embed-model", baseURL: "https://embeddings.example.invalid/v1",
+      dimensions: 384, taskQuery: "retrieval.query",
+    }));
+    assert.ok(msgs.some((m) => /taskQuery/i.test(m)),
+      `Expected warning about taskQuery, got: ${msgs.join(" | ")}`);
+  }
+
+  // Constructor no false positive: normalized on Jina profile is valid → no warning
+  {
+    const msgs = captureDebug(() => new Embedder({
+      provider: "openai-compatible", apiKey: "test-key",
+      model: "jina-embeddings-v5-text-small", baseURL: "https://api.jina.ai/v1",
+      dimensions: 1024, normalized: true,
+    }));
+    assert.ok(!msgs.some((m) => /normalized/i.test(m)),
+      `Unexpected warning for Jina profile: ${msgs.join(" | ")}`);
+  }
+
+  // Jina proxy: jina-* model at a proxy URL still gets the Jina-specific auth hint
+  const jinaProxyAuth = formatEmbeddingProviderError(
+    Object.assign(new Error("401 Unauthorized"), { status: 401 }),
+    {
+      baseURL: "https://proxy.example.invalid/v1",
+      model: "jina-embeddings-v5-text-small",
+    },
+  );
+  assert.match(jinaProxyAuth, /authentication failed/i, jinaProxyAuth);
+  assert.match(jinaProxyAuth, /Jina key expired/i, jinaProxyAuth);
+  assert.match(jinaProxyAuth, /Ollama/i, jinaProxyAuth);
 
   const jinaAuth = formatEmbeddingProviderError(
     Object.assign(new Error("403 Invalid API key"), {
@@ -99,6 +330,15 @@ async function run() {
     },
   );
   assert.match(formattedBatch, /^Failed to generate batch embeddings from /, formattedBatch);
+
+  const formattedVoyage = formatEmbeddingProviderError(
+    new Error("unsupported request field"),
+    {
+      baseURL: "https://api.voyageai.com/v1",
+      model: "voyage-3-lite",
+    },
+  );
+  assert.match(formattedVoyage, /^Failed to generate embedding from Voyage:/, formattedVoyage);
 
   console.log("OK: embedder auth/network error hints verified");
 }


### PR DESCRIPTION
## Problem

Voyage AI (and Voyage-style providers such as proxies backed by Voyage models) expose an OpenAI-compatible embeddings endpoint but **reject** standard OpenAI request fields and use **different field names** for task hints and output dimensions:

| Field | OpenAI / Generic | Voyage AI |
|-------|-----------------|-----------|
| Format hint | `encoding_format: "float"` | ❌ rejected (`400 Bad Request`) |
| Output dimensions | `dimensions` | `output_dimension` (Matryoshka models only) |
| Task hint | `task` | `input_type` (`"query"` / `"document"`) |

Without handling these differences, all embedding calls to Voyage endpoints failed with `400 Bad Request: Unknown request body key: encoding_format`, and task/dimension configuration was silently dropped.

## Root Cause

`buildPayload` unconditionally appended `encoding_format`, `dimensions`, and `task` to every request, with no mechanism to suppress or rename fields based on the provider.

Additionally, Voyage's `input_type` accepts only `"query"` and `"document"`, but the rest of the codebase uses the broader OpenAI-style values `"retrieval.query"` and `"retrieval.passage"`.

## Solution

Introduce a **provider profile + generic capabilities** layer detected once at `Embedder` construction time, replacing per-provider conditionals in `buildPayload`.

### New types

```ts
type EmbeddingProviderProfile =
  | "openai"
  | "jina"
  | "voyage-compatible"
  | "generic-openai-compatible";

interface EmbeddingCapabilities {
  /** Whether to send encoding_format: "float" */
  encoding_format: boolean;
  /** Whether to send normalized (Jina-style) */
  normalized: boolean;
  /**
   * Field name for the task hint, or null if unsupported.
   * e.g. "task" for Jina, "input_type" for Voyage, null for OpenAI/generic.
   */
  taskField: string | null;
  /** Optional value translation map (e.g. Voyage: "retrieval.query" → "query") */
  taskValueMap?: Record<string, string>;
  /**
   * Field name for the requested output dimension, or null if unsupported.
   * e.g. "dimensions" for OpenAI, "output_dimension" for Voyage.
   */
  dimensionsField: string | null;
}
```

### Detection logic (`detectEmbeddingProviderProfile`)

| Signal | Profile |
|--------|---------|
| baseURL contains `api.openai.com` | `openai` |
| baseURL contains `api.jina.ai` OR model starts with `jina-` | `jina` |
| baseURL contains `api.voyageai.com` OR model starts with `voyage` | `voyage-compatible` |
| anything else | `generic-openai-compatible` |

> The `voyage-` model-prefix heuristic handles deployments behind a custom proxy where the endpoint URL is generic. This is documented with a caveat about potential misclassification.

### Capability matrix

| Profile | `encoding_format` | task field | task value map | dimensions field |
|---------|:-----------------:|:----------:|:--------------:|:----------------:|
| `openai` | ✅ | — | — | `dimensions` |
| `jina` | ✅ | `task` | — (pass-through) | `dimensions` |
| `voyage-compatible` | ❌ | `input_type` | `retrieval.query→query`<br>`retrieval.passage→document` | `output_dimension` |
| `generic-openai-compatible` | ✅ | — | — | `dimensions` |

### Data-driven `buildPayload`

`buildPayload` is now fully data-driven — no provider conditionals:

```ts
// Task hint: field name and optional value translation are provider-defined.
if (this._capabilities.taskField && task) {
  const cap = this._capabilities;
  const value = cap.taskValueMap?.[task] ?? task;
  payload[cap.taskField] = value;
}

// Output dimension: field name is provider-defined.
if (this._capabilities.dimensionsField && this._requestDimensions > 0) {
  payload[this._capabilities.dimensionsField] = this._requestDimensions;
}
```

### `getProviderLabel` tightened

Now cross-checks both the detected profile and the baseURL to avoid misleading error messages on custom endpoints that happen to have Jina-style model names.

## Files Changed

- **`src/embedder.ts`** — new types, profile detection, capability lookup, data-driven `buildPayload`, tightened `getProviderLabel`
- **`test/embedder-error-hints.test.mjs`** — regression tests covering Voyage, Jina, generic, and proxy-backed Voyage; real HTTP round-trip for generic profile; plus new Voyage-specific tests for `input_type` translation and `output_dimension`

## Testing

```bash
node test/embedder-error-hints.test.mjs   # payload regression tests
npm test                                  # full suite
```

All existing tests continue to pass. New/updated tests cover:

1. **Voyage direct** (`api.voyageai.com`) — `encoding_format` absent, `dimensions` absent
2. **Voyage via proxy** (`voyage-code-3` model behind generic proxy URL) — same suppression via model-prefix heuristic
3. **Voyage `input_type` translation** — `taskPassage: "retrieval.passage"` → `input_type: "document"`, `taskQuery: "retrieval.query"` → `input_type: "query"`; raw `task` field must not appear
4. **Voyage `output_dimension`** — `dimensions: 512` config → `output_dimension: 512` in payload; `dimensions` must not appear
5. **Jina** — `task`, `normalized`, `dimensions` all present
6. **Generic OpenAI-compatible** — `encoding_format` and `dimensions` present (real HTTP server round-trip)