### PR TITLE
fix: use input_type instead of task for NVIDIA NIM embeddings

### DIFF
--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -453,7 +453,14 @@ export class Embedder {
       encoding_format: "float",
     };
 
-    if (task) payload.task = task;
+    if (task) {
+      // NVIDIA NIM uses input_type; other providers (Jina etc.) use task
+      if (this._baseURL && /nvidia\.com/i.test(this._baseURL)) {
+        payload.input_type = task;
+      } else {
+        payload.task = task;
+      }
+    }
     if (this._normalized !== undefined) payload.normalized = this._normalized;
 
     // Some OpenAI-compatible providers support requesting a specific vector size.


### PR DESCRIPTION
## Summary

- NVIDIA NIM API now strictly validates request bodies and rejects unknown fields
- The `task` parameter causes a 400 error on NVIDIA endpoints
- Fix routes by provider: NVIDIA endpoints get `input_type`, others get `task`

## Root Cause

`buildPayload()` in `embedder.ts` was sending both `task` and `input_type` to all providers. NVIDIA rejects `task` as unknown.

## Test plan

- Verified with nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1
- Non-NVIDIA providers still receive task parameter as before