### PR TITLE
fix(cli): flush pending writes after import by calling store.close()

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -495,6 +495,11 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
           }
         }
 
+        // Close store to flush pending writes
+        if (context.store.close) {
+          await context.store.close();
+        }
+
         console.log(`Import completed: ${imported} imported, ${skipped} skipped`);
       } catch (error) {
         console.error("Import failed:", error);

--- a/src/store.ts
+++ b/src/store.ts
@@ -984,6 +984,20 @@ export class MemoryStore {
     return this._lastFtsError;
   }
 
+  /** Close the database connection and flush pending writes. */
+  async close(): Promise<void> {
+    if (this.table) {
+      try {
+        await this.table.optimize();
+        await this.table.close();
+      } catch {
+        // Ignore close errors
+      }
+      this.table = undefined;
+      this.initPromise = null;
+    }
+  }
+
   /** Get FTS index health status */
   getFtsStatus(): { available: boolean; lastError: string | null } {
     return {


### PR DESCRIPTION
## Problem

The `memory-pro import` command reports success but data is not persisted to the database.

```bash
$ openclaw memory-pro import memories.json
Import completed: 1 imported, 0 skipped

$ openclaw memory-pro list --limit 5
# Shows no new records
```

## Root Cause

LanceDB writes are asynchronous. When the Node.js process exits after the import command completes, pending writes may not have been flushed to disk.

## Solution

This PR adds:

1. **`MemoryStore.close()` method** - Calls `table.optimize()` to flush writes, then `table.close()` to release resources

2. **CLI import cleanup** - Calls `store.close()` before the import command exits

## Testing

```bash
$ openclaw memory-pro import test.json
Import completed: 1 imported, 0 skipped

$ openclaw memory-pro list --limit 5
# New record now appears ✓
```

Verified with LanceDB 0.26.2 on macOS.