### PR TITLE
 feat: add memory normalizer pipeline

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -4,12 +4,15 @@
 
 import type { Command } from "commander";
 import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { describeKnowledgeUnit, extractAtomicMemory } from "./src/atomic-memory.js";
+import { buildGovernanceReport, classifyArchiveNoiseCandidate, governanceEntryLabel, type GovernanceReport, type GovernanceReportEntry } from "./src/governance-report.js";
+import type { NormalizationAuditRecord } from "./src/normalization-types.js";
 import { loadLanceDB, type MemoryEntry, type MemoryStore } from "./src/store.js";
 import { createRetriever, type MemoryRetriever } from "./src/retriever.js";
 import type { MemoryScopeManager } from "./src/scopes.js";
 import type { MemoryMigrator } from "./src/migrate.js";
-import { createMemoryUpgrader } from "./src/memory-upgrader.js";
-import type { LlmClient } from "./src/llm-client.js";
 
 // ============================================================================
 // Types
@@ -21,7 +24,136 @@ interface CLIContext {
   scopeManager: MemoryScopeManager;
   migrator: MemoryMigrator;
   embedder?: import("./src/embedder.js").Embedder;
-  llmClient?: LlmClient;
+}
+
+interface SearchObservationExpectation {
+  category?: string;
+  unitType?: string;
+  sourceKind?: string;
+  topAtomic?: boolean;
+  textIncludes?: string[];
+  maxArchiveNoiseInTopK?: number;
+  minTopScore?: number;
+}
+
+interface SearchObservationCase {
+  id?: string;
+  description?: string;
+  query: string;
+  expected?: SearchObservationExpectation;
+}
+
+interface SearchObservationTopHit {
+  id: string;
+  text: string;
+  category: string;
+  scope: string;
+  score: number;
+  atomic?: NonNullable<ReturnType<typeof extractAtomicMemory>>;
+  archiveNoiseReasons: string[];
+}
+
+interface SearchObservationCaseResult {
+  id: string;
+  description?: string;
+  query: string;
+  pass: boolean | null;
+  failures: string[];
+  noiseInTopK: number;
+  topHit: SearchObservationTopHit | null;
+  topResults: Array<{
+    id: string;
+    category: string;
+    score: number;
+    archiveNoise: boolean;
+    atomic: boolean;
+  }>;
+}
+
+interface SearchObservationReport {
+  summary: {
+    totalCases: number;
+    expectationCases: number;
+    passedCases: number;
+    failedCases: number;
+    noResultCases: number;
+    topAtomicCount: number;
+    topArchiveNoiseCount: number;
+    casesWithArchiveNoiseInTopK: number;
+  };
+  cases: SearchObservationCaseResult[];
+}
+
+interface GovernanceReviewPacketItem {
+  queue: "verify" | "archive";
+  proposedAction: "metadata-verify" | "archive-review";
+  riskLevel: "low" | "medium";
+  id: string;
+  category: string;
+  scope: string;
+  importance: number;
+  text: string;
+  reasons: string[];
+  atomic?: NonNullable<ReturnType<typeof extractAtomicMemory>>;
+}
+
+interface GovernanceReviewPacket {
+  summary: {
+    mode: "all" | "verify" | "archive";
+    verifyCount: number;
+    archiveCount: number;
+    totalReviewItems: number;
+  };
+  queues: {
+    verify: GovernanceReviewPacketItem[];
+    archive: GovernanceReviewPacketItem[];
+  };
+}
+
+interface ReviewPacketQueueComparison {
+  beforeCount: number;
+  afterCount: number;
+  overlapCount: number;
+  addedCount: number;
+  removedCount: number;
+  overlapRatio: number;
+  retainedIds: string[];
+  addedIds: string[];
+  removedIds: string[];
+}
+
+interface GovernanceReviewPacketComparison {
+  summary: {
+    beforeFile: string;
+    afterFile: string;
+  };
+  queues: {
+    verify: ReviewPacketQueueComparison;
+    archive: ReviewPacketQueueComparison;
+  };
+}
+
+interface NormalizationAuditSummary {
+  logPath: string;
+  totalRecords: number;
+  sourceCounts: Record<string, number>;
+  fallbackCounts: Record<string, number>;
+  candidateRoleCounts: Record<string, number>;
+  candidateCategoryCounts: Record<string, number>;
+  candidateUnitTypeCounts: Record<string, number>;
+  entryModeCounts: Record<string, number>;
+  entryCategoryCounts: Record<string, number>;
+  entryUnitTypeCounts: Record<string, number>;
+  reasonCounts: Record<string, number>;
+  errorCounts: Record<string, number>;
+  samples: Array<{
+    timestamp: number;
+    source: string;
+    fallback?: string;
+    errors?: string[];
+    candidateText: string;
+    entryTexts: string[];
+  }>;
 }
 
 // ============================================================================
@@ -43,21 +175,581 @@ function clampInt(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, Math.trunc(n)));
 }
 
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function formatMemory(memory: any, index?: number): string {
   const prefix = index !== undefined ? `${index + 1}. ` : "";
   const id = memory?.id ? String(memory.id) : "unknown";
   const date = new Date(memory.timestamp || memory.createdAt || Date.now()).toISOString().split('T')[0];
   const fullText = String(memory.text || "");
   const text = fullText.slice(0, 100) + (fullText.length > 100 ? "..." : "");
-  return `${prefix}[${id}] [${memory.category}:${memory.scope}] ${text} (${date})`;
+  const atomic = extractAtomicMemory(memory?.metadata);
+  const atomicBadge = atomic
+    ? `, unit=${atomic.unitType}, source=${atomic.sourceKind}, confidence=${Math.round(atomic.confidence * 100)}%`
+    : "";
+  return `${prefix}[${id}] [${memory.category}:${memory.scope}] ${text} (${date}${atomicBadge})`;
+}
+
+function serializeMemory(memory: MemoryEntry) {
+  const atomic = extractAtomicMemory(memory.metadata);
+  return {
+    id: memory.id,
+    text: memory.text,
+    category: memory.category,
+    scope: memory.scope,
+    importance: memory.importance,
+    timestamp: memory.timestamp,
+    ...(atomic ? { atomic } : {}),
+    knowledgeUnit: describeKnowledgeUnit(memory),
+  };
 }
 
 function formatJson(obj: any): string {
   return JSON.stringify(obj, null, 2);
 }
 
-async function sleep(ms: number): Promise<void> {
-  await new Promise(resolve => setTimeout(resolve, ms));
+function formatGovernanceEntries(title: string, entries: GovernanceReportEntry[], limit = 5): string[] {
+  const lines = [`${title}: ${entries.length}`];
+  entries.slice(0, limit).forEach((entry, index) => {
+    lines.push(`  ${index + 1}. ${governanceEntryLabel(entry)}`);
+    lines.push(`     - ${entry.reasons.join("；")}`);
+  });
+  if (entries.length > limit) lines.push(`     ... 还有 ${entries.length - limit} 条`);
+  return lines;
+}
+
+function formatGovernanceReport(report: GovernanceReport): string {
+  const { summary, buckets } = report;
+  const lines = [
+    "Governance Report:",
+    `• total: ${summary.totalCount}`,
+    `• atomic/plain: ${summary.atomicCount}/${summary.plainCount}`,
+    `• high-value atomic: ${summary.highValueAtomicCount}`,
+    `• verify candidates: ${summary.verifyCandidateCount}`,
+    `• merge/supersede candidates: ${summary.mergeCandidateCount}`,
+    `• archive/noise candidates: ${summary.archiveNoiseCandidateCount}`,
+    `• plain risk: ready=${summary.plainRiskCounts.ready}, cautious=${summary.plainRiskCounts.cautious}, hold=${summary.plainRiskCounts.hold}, noise=${summary.plainRiskCounts.noise}`,
+    "",
+    "Rules:",
+    "• high-value atomic = 高 importance + 高 confidence + user/tool 来源",
+    "• verify = sourceKind 偏 agent/imported，或 confidence/sourceRef 较弱",
+    "• merge/supersede = 同 scope/category 下高文本重叠",
+    "• archive/noise = 会话元信息/测试残留/明显低价值归档候选",
+    "• plain risk = ready / cautious / hold / noise 四层",
+    "",
+    ...formatGovernanceEntries("High-value atomic", buckets.highValueAtomic),
+    "",
+    ...formatGovernanceEntries("Verify candidates", buckets.verifyCandidates),
+    "",
+    ...formatGovernanceEntries("Archive/noise candidates", buckets.archiveNoiseCandidates),
+    "",
+    ...formatGovernanceEntries("Plain-ready", buckets.plainRisk.ready),
+    "",
+    ...formatGovernanceEntries("Plain-cautious", buckets.plainRisk.cautious),
+    "",
+    ...formatGovernanceEntries("Plain-hold", buckets.plainRisk.hold),
+    "",
+    ...formatGovernanceEntries("Plain-noise", buckets.plainRisk.noise),
+  ];
+
+  if (buckets.mergeCandidates.length > 0) {
+    lines.push("");
+    lines.push(`Merge/supersede candidates: ${buckets.mergeCandidates.length}`);
+    buckets.mergeCandidates.slice(0, 5).forEach((candidate, index) => {
+      lines.push(`  ${index + 1}. ${candidate.recommendedAction.toUpperCase()} ${candidate.primary.id} <- ${candidate.secondary.id}`);
+      lines.push(`     - ${candidate.reasons.join("；")}`);
+    });
+    if (buckets.mergeCandidates.length > 5) lines.push(`     ... 还有 ${buckets.mergeCandidates.length - 5} 对`);
+  }
+
+  return lines.join("\n");
+}
+
+function loadObservationCases(filePath: string): SearchObservationCase[] {
+  const raw = JSON.parse(readFileSync(filePath, "utf8"));
+  const items = Array.isArray(raw) ? raw : raw?.cases;
+  if (!Array.isArray(items)) {
+    throw new Error("Observation cases file must be an array or an object with a cases array");
+  }
+  return items.map((item, index) => {
+    if (!item || typeof item.query !== "string" || item.query.trim().length === 0) {
+      throw new Error(`Observation case #${index + 1} is missing a valid query`);
+    }
+    return {
+      id: typeof item.id === "string" && item.id.trim() ? item.id.trim() : `case-${index + 1}`,
+      description: typeof item.description === "string" ? item.description : undefined,
+      query: item.query,
+      expected: item.expected && typeof item.expected === "object" ? item.expected : undefined,
+    } satisfies SearchObservationCase;
+  });
+}
+
+function buildObservationTopHit(result: Awaited<ReturnType<MemoryRetriever["retrieve"]>>[number]): SearchObservationTopHit {
+  const archiveNoiseReasons = classifyArchiveNoiseCandidate(result.entry) || [];
+  return {
+    id: result.entry.id,
+    text: result.entry.text,
+    category: result.entry.category,
+    scope: result.entry.scope,
+    score: result.score,
+    atomic: extractAtomicMemory(result.entry.metadata) || undefined,
+    archiveNoiseReasons,
+  };
+}
+
+function evaluateObservationCase(
+  item: SearchObservationCase,
+  results: Awaited<ReturnType<MemoryRetriever["retrieve"]>>,
+): SearchObservationCaseResult {
+  const topHit = results[0] ? buildObservationTopHit(results[0]) : null;
+  const noiseInTopK = results.filter((result) => Boolean(classifyArchiveNoiseCandidate(result.entry))).length;
+  const failures: string[] = [];
+  const expected = item.expected;
+
+  if (expected) {
+    if (!topHit) {
+      failures.push("无结果");
+    } else {
+      if (expected.topAtomic !== undefined && Boolean(topHit.atomic) !== expected.topAtomic) {
+        failures.push(`topAtomic 期望=${expected.topAtomic} 实际=${Boolean(topHit.atomic)}`);
+      }
+      if (expected.category && topHit.category !== expected.category) {
+        failures.push(`category 期望=${expected.category} 实际=${topHit.category}`);
+      }
+      if (expected.unitType && topHit.atomic?.unitType !== expected.unitType) {
+        failures.push(`unitType 期望=${expected.unitType} 实际=${topHit.atomic?.unitType || "plain"}`);
+      }
+      if (expected.sourceKind && topHit.atomic?.sourceKind !== expected.sourceKind) {
+        failures.push(`sourceKind 期望=${expected.sourceKind} 实际=${topHit.atomic?.sourceKind || "plain"}`);
+      }
+      if (expected.textIncludes?.length) {
+        const lowered = topHit.text.toLowerCase();
+        const missing = expected.textIncludes.filter((token) => !lowered.includes(String(token).toLowerCase()));
+        if (missing.length > 0) {
+          failures.push(`top text 缺少关键词: ${missing.join(", ")}`);
+        }
+      }
+      if (expected.maxArchiveNoiseInTopK !== undefined && noiseInTopK > expected.maxArchiveNoiseInTopK) {
+        failures.push(`top-k archive/noise 数量超限: ${noiseInTopK} > ${expected.maxArchiveNoiseInTopK}`);
+      }
+      if (expected.minTopScore !== undefined && topHit.score < expected.minTopScore) {
+        failures.push(`top score 过低: ${topHit.score.toFixed(3)} < ${expected.minTopScore}`);
+      }
+    }
+  }
+
+  return {
+    id: item.id || item.query,
+    description: item.description,
+    query: item.query,
+    pass: expected ? failures.length === 0 : null,
+    failures,
+    noiseInTopK,
+    topHit,
+    topResults: results.map((result) => ({
+      id: result.entry.id,
+      category: result.entry.category,
+      score: result.score,
+      archiveNoise: Boolean(classifyArchiveNoiseCandidate(result.entry)),
+      atomic: Boolean(extractAtomicMemory(result.entry.metadata)),
+    })),
+  };
+}
+
+function buildObservationReport(cases: SearchObservationCaseResult[]): SearchObservationReport {
+  const expectationCases = cases.filter((item) => item.pass !== null);
+  return {
+    summary: {
+      totalCases: cases.length,
+      expectationCases: expectationCases.length,
+      passedCases: expectationCases.filter((item) => item.pass === true).length,
+      failedCases: expectationCases.filter((item) => item.pass === false).length,
+      noResultCases: cases.filter((item) => !item.topHit).length,
+      topAtomicCount: cases.filter((item) => Boolean(item.topHit?.atomic)).length,
+      topArchiveNoiseCount: cases.filter((item) => Boolean(item.topHit?.archiveNoiseReasons.length)).length,
+      casesWithArchiveNoiseInTopK: cases.filter((item) => item.noiseInTopK > 0).length,
+    },
+    cases,
+  };
+}
+
+function formatObservationReport(report: SearchObservationReport): string {
+  const lines = [
+    "Search Observation Report:",
+    `• cases: ${report.summary.totalCases}`,
+    `• expectation cases: ${report.summary.expectationCases}`,
+    `• passed/failed: ${report.summary.passedCases}/${report.summary.failedCases}`,
+    `• no result: ${report.summary.noResultCases}`,
+    `• top atomic: ${report.summary.topAtomicCount}`,
+    `• top archive/noise: ${report.summary.topArchiveNoiseCount}`,
+    `• cases with archive/noise in top-k: ${report.summary.casesWithArchiveNoiseInTopK}`,
+  ];
+
+  report.cases.forEach((item, index) => {
+    const status = item.pass === null ? "INFO" : item.pass ? "PASS" : "FAIL";
+    lines.push("");
+    lines.push(`${index + 1}. [${status}] ${item.id}: ${item.query}`);
+    if (item.description) lines.push(`   - ${item.description}`);
+    if (item.topHit) {
+      const atomic = item.topHit.atomic
+        ? `, unit=${item.topHit.atomic.unitType}, source=${item.topHit.atomic.sourceKind}`
+        : ", plain";
+      const archive = item.topHit.archiveNoiseReasons.length > 0 ? `, archiveNoise=${item.topHit.archiveNoiseReasons.join("；")}` : "";
+      lines.push(`   - top: [${item.topHit.category}:${item.topHit.scope}] score=${item.topHit.score.toFixed(3)}${atomic}${archive}`);
+    } else {
+      lines.push("   - top: 无结果");
+    }
+    lines.push(`   - top-k archive/noise count: ${item.noiseInTopK}`);
+    if (item.failures.length > 0) {
+      lines.push(`   - failures: ${item.failures.join("；")}`);
+    }
+  });
+
+  return lines.join("\n");
+}
+
+function toReviewPacketItem(queue: "verify" | "archive", entry: GovernanceReportEntry): GovernanceReviewPacketItem {
+  return {
+    queue,
+    proposedAction: queue === "verify" ? "metadata-verify" : "archive-review",
+    riskLevel: queue === "verify" ? "low" : "medium",
+    id: entry.id,
+    category: entry.category,
+    scope: entry.scope,
+    importance: entry.importance,
+    text: entry.text,
+    reasons: entry.reasons,
+    atomic: entry.knowledgeUnit.atomic,
+  };
+}
+
+function buildReviewPacket(
+  report: GovernanceReport,
+  mode: "all" | "verify" | "archive",
+  limit: number,
+): GovernanceReviewPacket {
+  const verify = (mode === "all" || mode === "verify")
+    ? report.buckets.verifyCandidates.slice(0, limit).map((entry) => toReviewPacketItem("verify", entry))
+    : [];
+  const archive = (mode === "all" || mode === "archive")
+    ? report.buckets.archiveNoiseCandidates.slice(0, limit).map((entry) => toReviewPacketItem("archive", entry))
+    : [];
+
+  return {
+    summary: {
+      mode,
+      verifyCount: verify.length,
+      archiveCount: archive.length,
+      totalReviewItems: verify.length + archive.length,
+    },
+    queues: { verify, archive },
+  };
+}
+
+function normalizeReviewPacketItem(
+  queue: "verify" | "archive",
+  item: Record<string, unknown>,
+): GovernanceReviewPacketItem {
+  const atomic = item.atomic && typeof item.atomic === "object"
+    ? item.atomic as NonNullable<ReturnType<typeof extractAtomicMemory>>
+    : undefined;
+  return {
+    queue,
+    proposedAction: item.proposedAction === "archive-review" ? "archive-review" : "metadata-verify",
+    riskLevel: item.riskLevel === "medium" ? "medium" : "low",
+    id: String(item.id || "unknown"),
+    category: String(item.category || "unknown"),
+    scope: String(item.scope || "unknown"),
+    importance: Number.isFinite(item.importance) ? Number(item.importance) : 0,
+    text: String(item.text || item.textLead || ""),
+    reasons: Array.isArray(item.reasons) ? item.reasons.map((reason) => String(reason)) : [],
+    atomic,
+  };
+}
+
+function loadReviewPacketFile(filePath: string): GovernanceReviewPacket {
+  const raw = JSON.parse(readFileSync(filePath, "utf8")) as Record<string, unknown>;
+  if (raw.queues && typeof raw.queues === "object") {
+    const queues = raw.queues as Record<string, unknown>;
+    const verify = Array.isArray(queues.verify)
+      ? queues.verify.map((item) => normalizeReviewPacketItem("verify", item as Record<string, unknown>))
+      : [];
+    const archive = Array.isArray(queues.archive)
+      ? queues.archive.map((item) => normalizeReviewPacketItem("archive", item as Record<string, unknown>))
+      : [];
+    return {
+      summary: {
+        mode: raw.summary && typeof raw.summary === "object" && (raw.summary as Record<string, unknown>).mode === "verify"
+          ? "verify"
+          : raw.summary && typeof raw.summary === "object" && (raw.summary as Record<string, unknown>).mode === "archive"
+            ? "archive"
+            : "all",
+        verifyCount: verify.length,
+        archiveCount: archive.length,
+        totalReviewItems: verify.length + archive.length,
+      },
+      queues: { verify, archive },
+    };
+  }
+
+  const verify = Array.isArray(raw.verify)
+    ? raw.verify.map((item) => normalizeReviewPacketItem("verify", item as Record<string, unknown>))
+    : [];
+  const archive = Array.isArray(raw.archive)
+    ? raw.archive.map((item) => normalizeReviewPacketItem("archive", item as Record<string, unknown>))
+    : [];
+
+  return {
+    summary: {
+      mode: raw.summary && typeof raw.summary === "object" && (raw.summary as Record<string, unknown>).mode === "verify"
+        ? "verify"
+        : raw.summary && typeof raw.summary === "object" && (raw.summary as Record<string, unknown>).mode === "archive"
+          ? "archive"
+          : "all",
+      verifyCount: verify.length,
+      archiveCount: archive.length,
+      totalReviewItems: verify.length + archive.length,
+    },
+    queues: { verify, archive },
+  };
+}
+
+function compareReviewPacketQueue(
+  beforeItems: GovernanceReviewPacketItem[],
+  afterItems: GovernanceReviewPacketItem[],
+): ReviewPacketQueueComparison {
+  const beforeIds = beforeItems.map((item) => item.id);
+  const afterIds = afterItems.map((item) => item.id);
+  const beforeSet = new Set(beforeIds);
+  const afterSet = new Set(afterIds);
+  const retainedIds = afterIds.filter((id) => beforeSet.has(id));
+  const addedIds = afterIds.filter((id) => !beforeSet.has(id));
+  const removedIds = beforeIds.filter((id) => !afterSet.has(id));
+  const unionCount = new Set([...beforeIds, ...afterIds]).size;
+  const overlapRatio = unionCount === 0 ? 1 : Number((retainedIds.length / unionCount).toFixed(3));
+  return {
+    beforeCount: beforeIds.length,
+    afterCount: afterIds.length,
+    overlapCount: retainedIds.length,
+    addedCount: addedIds.length,
+    removedCount: removedIds.length,
+    overlapRatio,
+    retainedIds,
+    addedIds,
+    removedIds,
+  };
+}
+
+function buildReviewPacketComparison(
+  beforeFile: string,
+  beforePacket: GovernanceReviewPacket,
+  afterFile: string,
+  afterPacket: GovernanceReviewPacket,
+): GovernanceReviewPacketComparison {
+  return {
+    summary: {
+      beforeFile,
+      afterFile,
+    },
+    queues: {
+      verify: compareReviewPacketQueue(beforePacket.queues.verify, afterPacket.queues.verify),
+      archive: compareReviewPacketQueue(beforePacket.queues.archive, afterPacket.queues.archive),
+    },
+  };
+}
+
+function formatReviewPacket(packet: GovernanceReviewPacket): string {
+  const lines = [
+    "Governance Review Packet:",
+    `• mode: ${packet.summary.mode}`,
+    `• verify queue: ${packet.summary.verifyCount}`,
+    `• archive queue: ${packet.summary.archiveCount}`,
+    `• total items: ${packet.summary.totalReviewItems}`,
+  ];
+
+  const sections: Array<[string, GovernanceReviewPacketItem[]]> = [
+    ["Verify queue", packet.queues.verify],
+    ["Archive queue", packet.queues.archive],
+  ];
+
+  for (const [title, items] of sections) {
+    lines.push("");
+    lines.push(`${title}:`);
+    if (items.length === 0) {
+      lines.push("  (empty)");
+      continue;
+    }
+    items.forEach((item, index) => {
+      const atomic = item.atomic ? `unit=${item.atomic.unitType}, source=${item.atomic.sourceKind}` : "plain";
+      lines.push(`  ${index + 1}. [${item.id}] ${item.proposedAction} / risk=${item.riskLevel}`);
+      lines.push(`     - [${item.category}:${item.scope}] importance=${item.importance.toFixed(2)}, ${atomic}`);
+      lines.push(`     - ${item.reasons.join("；")}`);
+    });
+  }
+
+  return lines.join("\n");
+}
+
+function formatReviewPacketComparison(comparison: GovernanceReviewPacketComparison): string {
+  const lines = [
+    "Governance Review Packet Comparison:",
+    `• before: ${comparison.summary.beforeFile}`,
+    `• after: ${comparison.summary.afterFile}`,
+  ];
+
+  const sections: Array<[string, ReviewPacketQueueComparison]> = [
+    ["Verify queue", comparison.queues.verify],
+    ["Archive queue", comparison.queues.archive],
+  ];
+
+  for (const [title, queue] of sections) {
+    lines.push("");
+    lines.push(`${title}:`);
+    lines.push(`  • before=${queue.beforeCount}, after=${queue.afterCount}, overlap=${queue.overlapCount}, ratio=${queue.overlapRatio}`);
+    lines.push(`  • added=${queue.addedCount}, removed=${queue.removedCount}`);
+    lines.push(`  • retained IDs: ${queue.retainedIds.join(", ") || "(none)"}`);
+    lines.push(`  • added IDs: ${queue.addedIds.join(", ") || "(none)"}`);
+    lines.push(`  • removed IDs: ${queue.removedIds.join(", ") || "(none)"}`);
+  }
+
+  return lines.join("\n");
+}
+
+function countBy<T extends string>(target: Record<string, number>, key: T | undefined) {
+  if (!key) return;
+  target[key] = (target[key] || 0) + 1;
+}
+
+function topEntries(map: Record<string, number>, limit = 8): Array<[string, number]> {
+  return Object.entries(map).sort((a, b) => b[1] - a[1]).slice(0, limit);
+}
+
+function readNormalizationAudit(logPath: string): NormalizationAuditRecord[] {
+  try {
+    const raw = readFileSync(logPath, "utf8");
+    return raw
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as NormalizationAuditRecord);
+  } catch {
+    return [];
+  }
+}
+
+function summarizeNormalizationAudit(logPath: string, limit = 10): NormalizationAuditSummary {
+  const records = readNormalizationAudit(logPath);
+  const sourceCounts: Record<string, number> = {};
+  const fallbackCounts: Record<string, number> = {};
+  const candidateRoleCounts: Record<string, number> = {};
+  const candidateCategoryCounts: Record<string, number> = {};
+  const candidateUnitTypeCounts: Record<string, number> = {};
+  const entryModeCounts: Record<string, number> = {};
+  const entryCategoryCounts: Record<string, number> = {};
+  const entryUnitTypeCounts: Record<string, number> = {};
+  const reasonCounts: Record<string, number> = {};
+  const errorCounts: Record<string, number> = {};
+
+  for (const record of records) {
+    countBy(sourceCounts, record.source);
+    countBy(fallbackCounts, record.fallback || "llm");
+    countBy(candidateRoleCounts, record.candidate.role);
+    countBy(candidateCategoryCounts, record.candidate.category);
+    countBy(candidateUnitTypeCounts, record.candidate.unitType);
+    for (const error of record.errors || []) countBy(errorCounts, error);
+    for (const entry of record.entries || []) {
+      countBy(entryModeCounts, entry.normalizationMode);
+      countBy(entryCategoryCounts, entry.category);
+      countBy(entryUnitTypeCounts, entry.atomic?.unitType);
+      countBy(reasonCounts, entry.reason);
+    }
+  }
+
+  const samples = records
+    .filter((record) => record.fallback || (record.errors && record.errors.length > 0))
+    .slice(-limit)
+    .reverse()
+    .map((record) => ({
+      timestamp: record.timestamp,
+      source: record.source,
+      ...(record.fallback ? { fallback: record.fallback } : {}),
+      ...(record.errors && record.errors.length > 0 ? { errors: record.errors } : {}),
+      candidateText: record.candidate.text,
+      entryTexts: (record.entries || []).map((entry) => entry.canonicalText),
+    }));
+
+  return {
+    logPath,
+    totalRecords: records.length,
+    sourceCounts,
+    fallbackCounts,
+    candidateRoleCounts,
+    candidateCategoryCounts,
+    candidateUnitTypeCounts,
+    entryModeCounts,
+    entryCategoryCounts,
+    entryUnitTypeCounts,
+    reasonCounts,
+    errorCounts,
+    samples,
+  };
+}
+
+function formatNormalizationAuditSummary(summary: NormalizationAuditSummary): string {
+  const lines = [
+    "Normalization Audit Summary:",
+    `• logPath: ${summary.logPath}`,
+    `• total records: ${summary.totalRecords}`,
+    "",
+    "By source:",
+    ...topEntries(summary.sourceCounts).map(([key, value]) => `  • ${key}: ${value}`),
+    "",
+    "Fallback / path:",
+    ...topEntries(summary.fallbackCounts).map(([key, value]) => `  • ${key}: ${value}`),
+    "",
+    "Candidate roles:",
+    ...topEntries(summary.candidateRoleCounts).map(([key, value]) => `  • ${key}: ${value}`),
+    "",
+    "Candidate categories:",
+    ...topEntries(summary.candidateCategoryCounts).map(([key, value]) => `  • ${key}: ${value}`),
+    "",
+    "Stored entry modes:",
+    ...topEntries(summary.entryModeCounts).map(([key, value]) => `  • ${key}: ${value}`),
+    "",
+    "Stored entry categories:",
+    ...topEntries(summary.entryCategoryCounts).map(([key, value]) => `  • ${key}: ${value}`),
+    "",
+    "Stored entry unit types:",
+    ...topEntries(summary.entryUnitTypeCounts).map(([key, value]) => `  • ${key}: ${value}`),
+  ];
+
+  if (Object.keys(summary.reasonCounts).length > 0) {
+    lines.push("", "Top reasons:");
+    lines.push(...topEntries(summary.reasonCounts).map(([key, value]) => `  • ${key}: ${value}`));
+  }
+
+  if (Object.keys(summary.errorCounts).length > 0) {
+    lines.push("", "Top errors:");
+    lines.push(...topEntries(summary.errorCounts).map(([key, value]) => `  • ${key}: ${value}`));
+  }
+
+  if (summary.samples.length > 0) {
+    lines.push("", "Recent fallback/error samples:");
+    for (const sample of summary.samples) {
+      lines.push(`  • ${new Date(sample.timestamp).toISOString()} [${sample.source}] ${sample.fallback || "error"}`);
+      lines.push(`    candidate: ${sample.candidateText.slice(0, 140)}${sample.candidateText.length > 140 ? "..." : ""}`);
+      if (sample.entryTexts.length > 0) {
+        lines.push(`    stored: ${sample.entryTexts[0].slice(0, 140)}${sample.entryTexts[0].length > 140 ? "..." : ""}`);
+      }
+      if (sample.errors && sample.errors.length > 0) {
+        lines.push(`    errors: ${sample.errors.join(" | ")}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
 }
 
 // ============================================================================
@@ -139,7 +831,7 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
         );
 
         if (options.json) {
-          console.log(formatJson(memories));
+          console.log(formatJson(memories.map((memory) => serializeMemory(memory))));
         } else {
           if (memories.length === 0) {
             console.log("No memories found.");
@@ -232,6 +924,7 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
         } else {
           console.log(`Memory Statistics:`);
           console.log(`• Total memories: ${stats.totalCount}`);
+          console.log(`• Atomic memories: ${stats.atomicCount}`);
           console.log(`• Available scopes: ${scopeStats.totalScopes}`);
           console.log(`• Retrieval mode: ${retrievalConfig.mode}`);
           console.log(`• FTS support: ${context.store.hasFtsSupport ? 'Yes' : 'No'}`);
@@ -247,9 +940,173 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
           Object.entries(stats.categoryCounts).forEach(([category, count]) => {
             console.log(`  • ${category}: ${count}`);
           });
+
+          console.log();
+          console.log("Atomic memories by unit type:");
+          if (Object.keys(stats.atomicUnitTypeCounts).length === 0) {
+            console.log(`  • none`);
+          } else {
+            Object.entries(stats.atomicUnitTypeCounts).forEach(([unitType, count]) => {
+              console.log(`  • ${unitType}: ${count}`);
+            });
+          }
+
+          console.log();
+          console.log("Atomic memories by source kind:");
+          if (Object.keys(stats.atomicSourceKindCounts).length === 0) {
+            console.log(`  • none`);
+          } else {
+            Object.entries(stats.atomicSourceKindCounts).forEach(([sourceKind, count]) => {
+              console.log(`  • ${sourceKind}: ${count}`);
+            });
+          }
         }
       } catch (error) {
         console.error("Failed to get statistics:", error);
+        process.exit(1);
+      }
+    });
+
+  memory
+    .command("normalization-audit [logFile]")
+    .description("Summarize normalizer audit records to support self-maintenance")
+    .option("--limit <n>", "Number of fallback/error samples to show", "10")
+    .option("--json", "Output as JSON")
+    .action(async (logFile, options) => {
+      try {
+        const resolvedLogPath = logFile
+          ? String(logFile)
+          : path.join(homedir(), ".openclaw", "memory", "normalizer-audit.jsonl");
+        const limit = clampInt(parseInt(options.limit || "10", 10), 1, 50);
+        const summary = summarizeNormalizationAudit(resolvedLogPath, limit);
+
+        if (options.json) {
+          console.log(formatJson(summary));
+        } else {
+          console.log(formatNormalizationAuditSummary(summary));
+        }
+      } catch (error) {
+        console.error("Failed to summarize normalization audit:", error);
+        process.exit(1);
+      }
+    });
+
+  memory
+    .command("governance-report")
+    .description("Summarize memory governance candidates and plain-risk tiers")
+    .option("--scope <scope>", "Filter by scope")
+    .option("--limit <n>", "Maximum number of memories to scan (defaults to scope total)")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      try {
+        let scopeFilter: string[] | undefined;
+        if (options.scope) {
+          scopeFilter = [options.scope];
+        }
+
+        const stats = await context.store.stats(scopeFilter);
+        const requestedLimit = options.limit ? clampInt(parseInt(options.limit), 1, 1000) : stats.totalCount;
+        const scanLimit = clampInt(requestedLimit || stats.totalCount || 50, 1, 1000);
+        const entries = await context.store.list(scopeFilter, undefined, scanLimit, 0);
+        const report = buildGovernanceReport(entries);
+
+        if (options.json) {
+          console.log(formatJson(report));
+        } else {
+          console.log(formatGovernanceReport(report));
+        }
+      } catch (error) {
+        console.error("Failed to build governance report:", error);
+        process.exit(1);
+      }
+    });
+
+  memory
+    .command("observe-search <casesFile>")
+    .description("Run a read-only query observation suite and summarize top-hit governance signals")
+    .option("--scope <scope>", "Filter by scope")
+    .option("--category <category>", "Filter all searches by category")
+    .option("--limit <n>", "Maximum number of results per query", "3")
+    .option("--json", "Output as JSON")
+    .action(async (casesFile, options) => {
+      try {
+        const limit = clampInt(parseInt(options.limit), 1, 10);
+        let scopeFilter: string[] | undefined;
+        if (options.scope) {
+          scopeFilter = [options.scope];
+        }
+
+        const cases = loadObservationCases(casesFile);
+        const observations: SearchObservationCaseResult[] = [];
+
+        for (const item of cases) {
+          const results = await runSearch(item.query, limit, scopeFilter, options.category);
+          observations.push(evaluateObservationCase(item, results));
+        }
+
+        const report = buildObservationReport(observations);
+        if (options.json) {
+          console.log(formatJson(report));
+        } else {
+          console.log(formatObservationReport(report));
+        }
+      } catch (error) {
+        console.error("Search observation failed:", error);
+        process.exit(1);
+      }
+    });
+
+  memory
+    .command("review-packet")
+    .description("Build a read-only human-in-the-loop governance review packet from live memory")
+    .option("--scope <scope>", "Filter by scope")
+    .option("--mode <mode>", "Packet mode: all | verify | archive", "all")
+    .option("--scan-limit <n>", "Maximum number of memories to scan (defaults to scope total)")
+    .option("--limit <n>", "Maximum number of review items per queue", "10")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      try {
+        const mode = ["all", "verify", "archive"].includes(options.mode) ? options.mode : "all";
+        const reviewLimit = clampInt(parseInt(options.limit), 1, 50);
+        let scopeFilter: string[] | undefined;
+        if (options.scope) {
+          scopeFilter = [options.scope];
+        }
+
+        const stats = await context.store.stats(scopeFilter);
+        const requestedLimit = options.scanLimit ? clampInt(parseInt(options.scanLimit), 1, 1000) : stats.totalCount;
+        const scanLimit = clampInt(requestedLimit || stats.totalCount || 50, 1, 1000);
+        const entries = await context.store.list(scopeFilter, undefined, scanLimit, 0);
+        const report = buildGovernanceReport(entries);
+        const packet = buildReviewPacket(report, mode as "all" | "verify" | "archive", reviewLimit);
+
+        if (options.json) {
+          console.log(formatJson(packet));
+        } else {
+          console.log(formatReviewPacket(packet));
+        }
+      } catch (error) {
+        console.error("Failed to build governance review packet:", error);
+        process.exit(1);
+      }
+    });
+
+  memory
+    .command("review-compare <beforeFile> <afterFile>")
+    .description("Compare two review-packet JSON snapshots and report queue overlap/churn")
+    .option("--json", "Output as JSON")
+    .action(async (beforeFile, afterFile, options) => {
+      try {
+        const beforePacket = loadReviewPacketFile(beforeFile);
+        const afterPacket = loadReviewPacketFile(afterFile);
+        const comparison = buildReviewPacketComparison(beforeFile, beforePacket, afterFile, afterPacket);
+        if (options.json) {
+          console.log(formatJson(comparison));
+        } else {
+          console.log(formatReviewPacketComparison(comparison));
+        }
+      } catch (error) {
+        console.error("Failed to compare governance review packets:", error);
         process.exit(1);
       }
     });
@@ -419,10 +1276,10 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
             const categoryRaw = memory.category;
             const category: MemoryEntry["category"] =
               categoryRaw === "preference" ||
-                categoryRaw === "fact" ||
-                categoryRaw === "decision" ||
-                categoryRaw === "entity" ||
-                categoryRaw === "other"
+              categoryRaw === "fact" ||
+              categoryRaw === "decision" ||
+              categoryRaw === "entity" ||
+              categoryRaw === "other"
                 ? categoryRaw
                 : "other";
 
@@ -445,13 +1302,11 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
             const idRaw = memory.id;
             const id = typeof idRaw === "string" && idRaw.length > 0 ? idRaw : undefined;
 
-            // Idempotency: if the import file includes an id and we already have it, skip.
             if (id && (await context.store.hasId(id))) {
               skipped++;
               continue;
             }
 
-            // Back-compat dedupe: if no id provided, do a best-effort similarity check.
             if (!id) {
               const existing = await context.retriever.retrieve({
                 query: text,
@@ -465,14 +1320,14 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
             }
 
             const vector = await context.embedder.embedPassage(text);
-
+            const effectiveScope = options.scope || memory.scope || targetScope;
             if (id) {
               await context.store.importEntry({
                 id,
                 text,
                 vector,
                 category,
-                scope: targetScope,
+                scope: effectiveScope,
                 importance,
                 timestamp,
                 metadata,
@@ -483,11 +1338,10 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
                 vector,
                 importance,
                 category,
-                scope: targetScope,
+                scope: effectiveScope,
                 metadata,
               });
             }
-
             imported++;
           } catch (error) {
             console.warn(`Failed to import memory: ${error}`);
@@ -533,10 +1387,10 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
         let targetReal = context.store.dbPath;
         try {
           sourceReal = await fs.realpath(sourceDbPath);
-        } catch { }
+        } catch {}
         try {
           targetReal = await fs.realpath(context.store.dbPath);
-        } catch { }
+        } catch {}
 
         if (!force && sourceReal === targetReal) {
           console.error("Refusing to re-embed in-place: source-db equals target dbPath. Use a new dbPath or pass --force.");
@@ -627,73 +1481,6 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
       }
     });
 
-  // Upgrade legacy memories to new smart memory format
-  memory
-    .command("upgrade")
-    .description("Upgrade legacy memories to new 6-category L0/L1/L2 smart memory format")
-    .option("--dry-run", "Show upgrade statistics without modifying data")
-    .option("--batch-size <n>", "Number of memories per batch", "10")
-    .option("--no-llm", "Skip LLM calls; use simple text truncation for L0/L1")
-    .option("--limit <n>", "Maximum number of memories to upgrade")
-    .option("--scope <scope>", "Only upgrade memories in this scope")
-    .action(async (options) => {
-      try {
-        const upgrader = createMemoryUpgrader(
-          context.store,
-          options.llm === false ? null : (context.llmClient ?? null),
-          { log: console.log },
-        );
-
-        // Show current status first
-        const scopeFilter = options.scope ? [options.scope] : undefined;
-        const counts = await upgrader.countLegacy(scopeFilter);
-
-        console.log(`Memory Upgrade Status:`);
-        console.log(`• Total memories: ${counts.total}`);
-        console.log(`• Legacy (needs upgrade): ${counts.legacy}`);
-        console.log(`• Already new format: ${counts.total - counts.legacy}`);
-        if (Object.keys(counts.byCategory).length > 0) {
-          console.log(`• Legacy by category:`);
-          Object.entries(counts.byCategory).forEach(([cat, n]) => {
-            console.log(`    ${cat}: ${n}`);
-          });
-        }
-
-        if (counts.legacy === 0) {
-          console.log(`\nAll memories are already in the new format. No upgrade needed.`);
-          return;
-        }
-
-        if (options.dryRun) {
-          console.log(`\n[DRY-RUN] Would upgrade ${counts.legacy} memories.`);
-          return;
-        }
-
-        console.log(`\nStarting upgrade...`);
-        const result = await upgrader.upgrade({
-          dryRun: false,
-          batchSize: parseInt(options.batchSize) || 10,
-          noLlm: options.llm === false,
-          limit: options.limit ? parseInt(options.limit) : undefined,
-          scopeFilter,
-        });
-
-        console.log(`\nUpgrade Results:`);
-        console.log(`• Upgraded: ${result.upgraded}`);
-        console.log(`• Already new format: ${result.skipped}`);
-        if (result.errors.length > 0) {
-          console.log(`• Errors: ${result.errors.length}`);
-          result.errors.slice(0, 5).forEach(err => console.log(`  - ${err}`));
-          if (result.errors.length > 5) {
-            console.log(`  ... and ${result.errors.length - 5} more`);
-          }
-        }
-      } catch (error) {
-        console.error("Upgrade failed:", error);
-        process.exit(1);
-      }
-    });
-
   // Migration commands
   const migrate = memory
     .command("migrate")
@@ -780,27 +1567,6 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
         }
       } catch (error) {
         console.error("Verification failed:", error);
-        process.exit(1);
-      }
-    });
-
-  // reindex-fts: Rebuild FTS index
-  program
-    .command("reindex-fts")
-    .description("Rebuild the BM25 full-text search index")
-    .action(async () => {
-      try {
-        const status = context.store.getFtsStatus();
-        console.log(`FTS status before: available=${status.available}, lastError=${status.lastError || "none"}`);
-        const result = await context.store.rebuildFtsIndex();
-        if (result.success) {
-          console.log("✅ FTS index rebuilt successfully");
-        } else {
-          console.error("❌ FTS rebuild failed:", result.error);
-          process.exit(1);
-        }
-      } catch (error) {
-        console.error("FTS rebuild error:", error);
         process.exit(1);
       }
     });

--- a/index.ts
+++ b/index.ts
@@ -37,7 +37,14 @@ import {
 import { createReflectionEventId } from "./src/reflection-event-store.js";
 import { buildReflectionMappedMetadata } from "./src/reflection-mapped-metadata.js";
 import { createMemoryCLI } from "./cli.js";
+import {
+  detectAtomicUnitType,
+  normalizeAndStoreAutoCaptureCandidates,
+  storeAutoCaptureCandidates,
+  type AutoCaptureCandidate,
+} from "./src/auto-capture.js";
 import { isNoise } from "./src/noise-filter.js";
+import { createMemoryNormalizer, type NormalizerConfig } from "./src/normalizer.js";
 
 // Import smart extraction & lifecycle components
 import { SmartExtractor } from "./src/smart-extractor.js";
@@ -75,6 +82,22 @@ interface PluginConfig {
   autoRecallMinLength?: number;
   autoRecallMinRepeated?: number;
   captureAssistant?: boolean;
+  normalization?: {
+    enabled?: boolean;
+    apiKey?: string;
+    model?: string;
+    baseURL?: string;
+    temperature?: number;
+    maxTokens?: number;
+    enableThinking?: boolean;
+    timeoutMs?: number;
+    maxEntriesPerCandidate?: number;
+    fallbackMode?: "rules-then-raw" | "raw-only";
+    audit?: {
+      enabled?: boolean;
+      logPath?: string;
+    };
+  };
   retrieval?: {
     mode?: "hybrid" | "vector";
     vectorWeight?: number;
@@ -1642,6 +1665,17 @@ const memoryLanceDBProPlugin = {
     );
     const scopeManager = createScopeManager(config.scopes);
     const migrator = createMigrator(store);
+    let normalizer: ReturnType<typeof createMemoryNormalizer> | null = null;
+    if (config.normalization?.enabled) {
+      try {
+        normalizer = createMemoryNormalizer(
+          resolveNormalizerConfig(config.normalization, resolvedDbPath),
+          api.logger,
+        );
+      } catch (err) {
+        api.logger.warn(`memory-lancedb-pro: normalizer init failed, continuing without normalization: ${String(err)}`);
+      }
+    }
 
     // Initialize smart extraction
     let smartExtractor: SmartExtractor | null = null;
@@ -1890,7 +1924,7 @@ const memoryLanceDBProPlugin = {
     _autoCaptureDebugLog = (msg: string) => api.logger.debug(msg);
 
     api.logger.info(
-      `memory-lancedb-pro@${pluginVersion}: plugin registered (db: ${resolvedDbPath}, model: ${config.embedding.model || "text-embedding-3-small"}, smartExtraction: ${smartExtractor ? 'ON' : 'OFF'})`
+      `memory-lancedb-pro@${pluginVersion}: plugin registered (db: ${resolvedDbPath}, model: ${config.embedding.model || "text-embedding-3-small"}, smartExtraction: ${smartExtractor ? "ON" : "OFF"}, normalizer: ${normalizer ? "ON" : "OFF"})`
     );
     api.logger.info(`memory-lancedb-pro: diagnostic build tag loaded (${DIAG_BUILD_TAG})`);
 
@@ -1942,6 +1976,7 @@ const memoryLanceDBProPlugin = {
         store,
         scopeManager,
         embedder,
+        normalizer,
         agentId: undefined, // Will be determined at runtime from context
         workspaceDir: getDefaultWorkspaceDir(),
         mdMirror,
@@ -2284,57 +2319,81 @@ const memoryLanceDBProPlugin = {
             `memory-lancedb-pro: regex fallback found ${toCapture.length} capturable text(s) for agent ${agentId}`,
           );
 
-          // Store each capturable piece (limit to 3 per conversation)
-          let stored = 0;
-          for (const text of toCapture.slice(0, 3)) {
-            const category = detectCategory(text);
-            const vector = await embedder.embedPassage(text);
+          const captureCandidates: AutoCaptureCandidate[] = [];
+          for (const msg of event.messages) {
+            if (!msg || typeof msg !== "object") continue;
+            const msgObj = msg as Record<string, unknown>;
+            const role = msgObj.role === "assistant" ? "assistant" : msgObj.role === "user" ? "user" : null;
+            if (!role) continue;
+            if (role === "assistant" && config.captureAssistant !== true) continue;
 
-            // Check for duplicates using raw vector similarity (bypasses importance/recency weighting)
-            // Fail-open by design: dedup should not block auto-capture writes.
-            let existing: Awaited<ReturnType<typeof store.vectorSearch>> = [];
-            try {
-              existing = await store.vectorSearch(vector, 1, 0.1, [
-                defaultScope,
-              ]);
-            } catch (err) {
-              api.logger.warn(
-                `memory-lancedb-pro: auto-capture duplicate pre-check failed, continue store: ${String(err)}`,
-              );
+            const content = msgObj.content;
+            const textBlocks: string[] = typeof content === "string"
+              ? [content]
+              : Array.isArray(content)
+                ? content.flatMap((block) => (
+                    block &&
+                    typeof block === "object" &&
+                    "type" in block &&
+                    (block as Record<string, unknown>).type === "text" &&
+                    typeof (block as Record<string, unknown>).text === "string"
+                  ) ? [(block as Record<string, unknown>).text as string] : [])
+                : [];
+
+            for (const blockText of textBlocks) {
+              const normalized = normalizeAutoCaptureText(role, blockText);
+              if (!normalized || !toCapture.includes(normalized)) continue;
+              const category = detectCategory(normalized);
+              captureCandidates.push({
+                text: normalized,
+                role,
+                sourceKind: role === "assistant" ? "agent" : "user",
+                category,
+                unitType: detectAtomicUnitType(normalized, category),
+              });
+              if (captureCandidates.length >= 3) break;
             }
+            if (captureCandidates.length >= 3) break;
+          }
 
-            if (existing.length > 0 && existing[0].score > 0.95) {
-              continue;
+          if (captureCandidates.length === 0) {
+            for (const text of toCapture.slice(0, 3)) {
+              const category = detectCategory(text);
+              captureCandidates.push({
+                text,
+                role: "user",
+                sourceKind: "user",
+                category,
+                unitType: detectAtomicUnitType(text, category),
+              });
             }
+          }
 
-            await store.store({
-              text,
-              vector,
-              importance: 0.7,
-              category,
-              scope: defaultScope,
-              metadata: stringifySmartMetadata(
-                buildSmartMetadata(
-                  {
-                    text,
-                    category,
-                    importance: 0.7,
-                  },
-                  {
-                    l0_abstract: text,
-                    l1_overview: `- ${text}`,
-                    l2_content: text,
-                    source_session: (event as any).sessionKey || "unknown",
-                  },
-                ),
-              ),
-            });
-            stored++;
+          const storedEntries = normalizer
+            ? await normalizeAndStoreAutoCaptureCandidates({
+                candidates: captureCandidates,
+                store,
+                embedder,
+                scope: defaultScope,
+                importance: 0.7,
+                limit: config.normalization?.maxEntriesPerCandidate ?? 3,
+                normalizer,
+                agentId,
+              })
+            : await storeAutoCaptureCandidates({
+                candidates: captureCandidates,
+                store,
+                embedder,
+                scope: defaultScope,
+                importance: 0.7,
+                limit: 3,
+              });
+          const stored = storedEntries.length;
 
-            // Dual-write to Markdown mirror if enabled
-            if (mdMirror) {
+          if (mdMirror) {
+            for (const entry of storedEntries) {
               await mdMirror(
-                { text, category, scope: defaultScope, timestamp: Date.now() },
+                { text: entry.text, category: entry.category, scope: defaultScope, timestamp: entry.timestamp },
                 { source: "auto-capture", agentId },
               );
             }
@@ -3257,6 +3316,9 @@ export function parsePluginConfig(value: unknown): PluginConfig {
     autoRecallMinLength: parsePositiveInt(cfg.autoRecallMinLength),
     autoRecallMinRepeated: parsePositiveInt(cfg.autoRecallMinRepeated),
     captureAssistant: cfg.captureAssistant === true,
+    normalization: typeof cfg.normalization === "object" && cfg.normalization !== null
+      ? cfg.normalization as any
+      : undefined,
     retrieval: typeof cfg.retrieval === "object" && cfg.retrieval !== null ? cfg.retrieval as any : undefined,
     decay: typeof cfg.decay === "object" && cfg.decay !== null ? cfg.decay as any : undefined,
     tier: typeof cfg.tier === "object" && cfg.tier !== null ? cfg.tier as any : undefined,
@@ -3336,6 +3398,42 @@ export function parsePluginConfig(value: unknown): PluginConfig {
               : undefined,
         }
         : undefined,
+  };
+}
+
+function resolveNormalizerConfig(
+  normalization: NonNullable<PluginConfig["normalization"]>,
+  resolvedDbPath: string,
+): NormalizerConfig {
+  const auditConfig = normalization.audit && typeof normalization.audit === "object" ? normalization.audit : {};
+  const auditPathRaw = typeof auditConfig.logPath === "string"
+    ? resolveEnvVars(auditConfig.logPath)
+    : join(dirname(resolvedDbPath), "normalizer-audit.jsonl");
+  const apiKey = typeof normalization.apiKey === "string" && normalization.apiKey.trim()
+    ? resolveEnvVars(normalization.apiKey)
+    : process.env.MEMORY_NORMALIZER_API_KEY || process.env.SILICONFLOW_API_KEY || "";
+
+  if (!apiKey) {
+    throw new Error("normalization.apiKey is required when normalization.enabled=true");
+  }
+
+  return {
+    enabled: normalization.enabled === true,
+    apiKey,
+    model: typeof normalization.model === "string" ? normalization.model : "Qwen/Qwen3-8B",
+    baseURL: typeof normalization.baseURL === "string"
+      ? resolveEnvVars(normalization.baseURL)
+      : "https://api.siliconflow.cn/v1/chat/completions",
+    temperature: typeof normalization.temperature === "number" ? normalization.temperature : 0.1,
+    maxTokens: parsePositiveInt(normalization.maxTokens) ?? 1200,
+    enableThinking: normalization.enableThinking === true,
+    timeoutMs: parsePositiveInt(normalization.timeoutMs) ?? 12_000,
+    maxEntriesPerCandidate: parsePositiveInt(normalization.maxEntriesPerCandidate) ?? 3,
+    fallbackMode: normalization.fallbackMode === "raw-only" ? "raw-only" : "rules-then-raw",
+    audit: {
+      enabled: auditConfig.enabled !== false,
+      logPath: auditPathRaw,
+    },
   };
 }
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -108,6 +108,76 @@
       "captureAssistant": {
         "type": "boolean"
       },
+      "normalization": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false
+          },
+          "apiKey": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string",
+            "default": "Qwen/Qwen3-8B"
+          },
+          "baseURL": {
+            "type": "string",
+            "default": "https://api.siliconflow.cn/v1/chat/completions"
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "default": 0.1
+          },
+          "maxTokens": {
+            "type": "integer",
+            "minimum": 64,
+            "maximum": 8192,
+            "default": 1200
+          },
+          "enableThinking": {
+            "type": "boolean",
+            "default": false
+          },
+          "timeoutMs": {
+            "type": "integer",
+            "minimum": 1000,
+            "maximum": 60000,
+            "default": 12000
+          },
+          "maxEntriesPerCandidate": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "default": 3
+          },
+          "fallbackMode": {
+            "type": "string",
+            "enum": [
+              "rules-then-raw",
+              "raw-only"
+            ],
+            "default": "rules-then-raw"
+          },
+          "audit": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": true
+              },
+              "logPath": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
       "smartExtraction": {
         "type": "boolean",
         "default": true,
@@ -562,6 +632,70 @@
     "captureAssistant": {
       "label": "Capture Assistant Messages",
       "help": "Also auto-capture assistant messages (default false to reduce memory pollution)",
+      "advanced": true
+    },
+    "normalization.enabled": {
+      "label": "Memory Normalizer",
+      "help": "Normalize auto-captured memories before storing them. Keeps the main agent free while improving long-term memory quality.",
+      "advanced": true
+    },
+    "normalization.apiKey": {
+      "label": "Normalizer API Key",
+      "sensitive": true,
+      "placeholder": "sk-... or ${SILICONFLOW_API_KEY}",
+      "help": "API key for the chat-completions compatible normalizer model.",
+      "advanced": true
+    },
+    "normalization.model": {
+      "label": "Normalizer Model",
+      "placeholder": "Qwen/Qwen3-8B",
+      "help": "Model used only for memory normalization. Recommended: Qwen/Qwen3-8B on SiliconFlow.",
+      "advanced": true
+    },
+    "normalization.baseURL": {
+      "label": "Normalizer Endpoint",
+      "placeholder": "https://api.siliconflow.cn/v1/chat/completions",
+      "help": "Chat-completions compatible endpoint used by the memory normalizer.",
+      "advanced": true
+    },
+    "normalization.temperature": {
+      "label": "Normalizer Temperature",
+      "help": "Lower values improve consistency for structured output.",
+      "advanced": true
+    },
+    "normalization.maxTokens": {
+      "label": "Normalizer Max Tokens",
+      "help": "Maximum response tokens for the normalizer model.",
+      "advanced": true
+    },
+    "normalization.enableThinking": {
+      "label": "Normalizer Thinking",
+      "help": "Enable provider-side thinking mode if supported. Default off for stable JSON.",
+      "advanced": true
+    },
+    "normalization.timeoutMs": {
+      "label": "Normalizer Timeout",
+      "help": "Abort the normalizer request after this many milliseconds.",
+      "advanced": true
+    },
+    "normalization.maxEntriesPerCandidate": {
+      "label": "Max Entries Per Candidate",
+      "help": "Maximum number of memory entries the normalizer may produce from a single candidate.",
+      "advanced": true
+    },
+    "normalization.fallbackMode": {
+      "label": "Normalizer Fallback",
+      "help": "Fallback behavior when the normalizer model fails.",
+      "advanced": true
+    },
+    "normalization.audit.enabled": {
+      "label": "Normalizer Audit Log",
+      "help": "Record normalization decisions and fallbacks to a JSONL audit file.",
+      "advanced": true
+    },
+    "normalization.audit.logPath": {
+      "label": "Normalizer Audit Path",
+      "help": "Optional custom path for the normalizer audit log.",
       "advanced": true
     },
     "retrieval.mode": {

--- a/src/atomic-memory.ts
+++ b/src/atomic-memory.ts
@@ -1,0 +1,153 @@
+import type { MemoryEntry } from "./store.js";
+
+export const ATOMIC_MEMORY_SCHEMA = "openclaw.atomic-memory/v1";
+export const ATOMIC_MEMORY_UNIT_TYPES = [
+  "preference",
+  "fact",
+  "decision",
+  "lesson",
+  "environment",
+  "entity",
+  "other",
+] as const;
+export const ATOMIC_MEMORY_SOURCE_KINDS = ["user", "tool", "agent", "imported"] as const;
+
+export type AtomicMemoryUnitType = (typeof ATOMIC_MEMORY_UNIT_TYPES)[number];
+export type AtomicMemorySourceKind = (typeof ATOMIC_MEMORY_SOURCE_KINDS)[number];
+
+export interface AtomicMemory {
+  schema: typeof ATOMIC_MEMORY_SCHEMA;
+  unitType: AtomicMemoryUnitType;
+  sourceKind: AtomicMemorySourceKind;
+  confidence: number;
+  sourceRef?: string;
+  tags?: string[];
+}
+
+export interface AtomicMemoryInput {
+  unitType?: AtomicMemoryUnitType;
+  sourceKind?: AtomicMemorySourceKind;
+  confidence?: number;
+  sourceRef?: string;
+  tags?: string[];
+}
+
+type MetadataEnvelope = Record<string, unknown> & { atomic?: unknown };
+
+function clamp01(value: unknown, fallback = 0.7): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(1, Math.max(0, n));
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function normalizeTags(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const tags = value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, 8);
+  return tags.length > 0 ? tags : undefined;
+}
+
+function defaultUnitTypeForCategory(category: MemoryEntry["category"] | string): AtomicMemoryUnitType {
+  switch (category) {
+    case "preference":
+    case "fact":
+    case "decision":
+    case "entity":
+      return category;
+    default:
+      return "other";
+  }
+}
+
+export function parseMemoryMetadata(raw?: string): MetadataEnvelope {
+  if (!raw || raw.trim().length === 0) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as MetadataEnvelope)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+export function extractAtomicMemory(raw?: string): AtomicMemory | undefined {
+  const atomic = parseMemoryMetadata(raw).atomic;
+  if (!atomic || typeof atomic !== "object" || Array.isArray(atomic)) return undefined;
+
+  const node = atomic as Record<string, unknown>;
+  const unitType = ATOMIC_MEMORY_UNIT_TYPES.includes(node.unitType as AtomicMemoryUnitType)
+    ? (node.unitType as AtomicMemoryUnitType)
+    : undefined;
+  const sourceKind = ATOMIC_MEMORY_SOURCE_KINDS.includes(node.sourceKind as AtomicMemorySourceKind)
+    ? (node.sourceKind as AtomicMemorySourceKind)
+    : undefined;
+
+  if (node.schema !== ATOMIC_MEMORY_SCHEMA || !unitType || !sourceKind) return undefined;
+
+  const sourceRef = asString(node.sourceRef);
+  const tags = normalizeTags(node.tags);
+
+  return {
+    schema: ATOMIC_MEMORY_SCHEMA,
+    unitType,
+    sourceKind,
+    confidence: clamp01(node.confidence, 0.7),
+    ...(sourceRef ? { sourceRef } : {}),
+    ...(tags ? { tags } : {}),
+  };
+}
+
+export function buildAtomicMemoryMetadata(
+  category: MemoryEntry["category"] | string,
+  atomic?: AtomicMemoryInput,
+  existingRaw?: string,
+): string | undefined {
+  if (!atomic) return existingRaw;
+
+  const metadata = parseMemoryMetadata(existingRaw);
+  const existingAtomic = extractAtomicMemory(existingRaw);
+  const unitType = ATOMIC_MEMORY_UNIT_TYPES.includes(atomic.unitType as AtomicMemoryUnitType)
+    ? (atomic.unitType as AtomicMemoryUnitType)
+    : existingAtomic?.unitType ?? defaultUnitTypeForCategory(category);
+  const sourceKind = ATOMIC_MEMORY_SOURCE_KINDS.includes(atomic.sourceKind as AtomicMemorySourceKind)
+    ? (atomic.sourceKind as AtomicMemorySourceKind)
+    : existingAtomic?.sourceKind ?? "user";
+  const sourceRef = asString(atomic.sourceRef) ?? existingAtomic?.sourceRef;
+  const tags = normalizeTags(atomic.tags) ?? existingAtomic?.tags;
+  const confidence = atomic.confidence !== undefined
+    ? clamp01(atomic.confidence, existingAtomic?.confidence ?? 0.7)
+    : existingAtomic?.confidence ?? 0.7;
+
+  metadata.atomic = {
+    schema: ATOMIC_MEMORY_SCHEMA,
+    unitType,
+    sourceKind,
+    confidence,
+    ...(sourceRef ? { sourceRef } : {}),
+    ...(tags ? { tags } : {}),
+  } satisfies AtomicMemory;
+
+  return JSON.stringify(metadata);
+}
+
+export function describeKnowledgeUnit(
+  entry: Pick<MemoryEntry, "id" | "text" | "category" | "scope" | "importance" | "metadata">,
+) {
+  const atomic = extractAtomicMemory(entry.metadata);
+  return {
+    id: entry.id,
+    text: entry.text,
+    category: entry.category,
+    scope: entry.scope,
+    importance: entry.importance,
+    ...(atomic ? { atomic } : {}),
+  };
+}

--- a/src/auto-capture.ts
+++ b/src/auto-capture.ts
@@ -1,0 +1,280 @@
+import { buildAtomicMemoryMetadata, type AtomicMemoryUnitType } from "./atomic-memory.js";
+import type { Embedder } from "./embedder.js";
+import type { createMemoryNormalizer } from "./normalizer.js";
+import { isRuntimeChatter } from "./normalization-rules.js";
+import type { NormalizedMemoryDraft } from "./normalization-types.js";
+import type { MemoryEntry, MemoryStore } from "./store.js";
+
+const MEMORY_TRIGGERS = [
+  /zapamatuj si|pamatuj|remember/i,
+  /preferuji|radši|nechci|prefer/i,
+  /rozhodli jsme|budeme používat/i,
+  /\b(we )?decided\b|we'?ll use|we will use|switch(ed)? to|migrate(d)? to|going forward|from now on/i,
+  /\+\d{10,}/,
+  /[\w.-]+@[\w.-]+\.\w+/,
+  /můj\s+\w+\s+je|je\s+můj/i,
+  /my\s+\w+\s+is|is\s+my/i,
+  /i (like|prefer|hate|love|want|need|care)/i,
+  /always|never|important/i,
+  /記住|记住|記一下|记一下|別忘了|别忘了|備註|备注/,
+  /偏好|喜好|喜歡|喜欢|討厭|讨厌|不喜歡|不喜欢|愛用|爱用|習慣|习惯/,
+  /決定|决定|選擇了|选择了|改用|換成|换成|以後用|以后用/,
+  /我的\S+是|叫我|稱呼|称呼/,
+  /老是|講不聽|總是|总是|從不|从不|一直|每次都/,
+  /重要|關鍵|关键|注意|千萬別|千万别/,
+  /幫我|筆記|存檔|存起来|存起來|存一下|重點|重点|原則|原则|底線|底线/,
+] as const;
+
+const CAPTURE_EXCLUDE_PATTERNS = [
+  /\b(memory-pro|memory_store|memory_recall|memory_forget|memory_update)\b/i,
+  /\bopenclaw\s+memory-pro\b/i,
+  /\b(delete|remove|forget|purge|cleanup|clean up|clear)\b.*\b(memory|memories|entry|entries)\b/i,
+  /\b(memory|memories)\b.*\b(delete|remove|forget|purge|cleanup|clean up|clear)\b/i,
+  /\bhow do i\b.*\b(delete|remove|forget|purge|cleanup|clear)\b/i,
+  /(删除|刪除|清理|清除).{0,12}(记忆|記憶|memory)/i,
+] as const;
+
+type MessageRole = "user" | "assistant";
+
+export interface AutoCaptureCandidate {
+  text: string;
+  role: MessageRole;
+  sourceKind: "user" | "agent";
+  category: MemoryEntry["category"];
+  unitType: AtomicMemoryUnitType;
+}
+
+export interface StoreAutoCaptureParams {
+  candidates: AutoCaptureCandidate[];
+  store: MemoryStore;
+  embedder: Pick<Embedder, "embedPassage">;
+  scope: string;
+  importance?: number;
+  limit?: number;
+}
+
+export interface NormalizeAndStoreAutoCaptureParams extends StoreAutoCaptureParams {
+  normalizer: ReturnType<typeof createMemoryNormalizer>;
+  agentId?: string;
+}
+
+export function shouldCapture(text: string): boolean {
+  let s = text.trim();
+
+  // Strip OpenClaw metadata headers before trigger matching so transport/session
+  // wrappers do not get mistaken for meaningful memory content.
+  const metadataPattern = /^(Conversation info|Sender) \(untrusted metadata\):[\s\S]*?\n\s*\n/gim;
+  s = s.replace(metadataPattern, "");
+
+  const hasCJK = /[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/.test(s);
+  const minLen = hasCJK ? 4 : 10;
+  if (s.length < minLen || s.length > 500) return false;
+  if (isRuntimeChatter(s)) return false;
+  if (s.includes("<relevant-memories>")) return false;
+  if (s.startsWith("<") && s.includes("</")) return false;
+  if (s.includes("**") && s.includes("\n-")) return false;
+  const emojiCount = (s.match(/[\u{1F300}-\u{1F9FF}]/gu) || []).length;
+  if (emojiCount > 3) return false;
+  if (CAPTURE_EXCLUDE_PATTERNS.some((pattern) => pattern.test(s))) return false;
+  return MEMORY_TRIGGERS.some((pattern) => pattern.test(s));
+}
+
+export function detectCategory(text: string): MemoryEntry["category"] {
+  const lower = text.toLowerCase();
+  if (/prefer|radši|like|love|hate|want|偏好|喜歡|喜欢|討厭|讨厌|不喜歡|不喜欢|愛用|爱用|習慣|习惯|希望|想要|最好/i.test(lower)) {
+    return "preference";
+  }
+  if (/rozhodli|decided|we decided|will use|we will use|we'?ll use|switch(ed)? to|migrate(d)? to|going forward|from now on|budeme|決定|决定|選擇了|选择了|改用|換成|换成|以後用|以后用|規則|规则|流程|SOP/i.test(lower)) {
+    return "decision";
+  }
+  if (/\+\d{10,}|@[\w.-]+\.\w+|is called|jmenuje se|我的\S+是|叫我|稱呼|称呼/i.test(lower)) {
+    return "entity";
+  }
+  if (/\b(is|are|has|have|je|má|jsou)\b|總是|总是|從不|从不|一直|每次都|老是/i.test(lower)) {
+    return "fact";
+  }
+  return "other";
+}
+
+export function detectAtomicUnitType(
+  text: string,
+  category: MemoryEntry["category"],
+): AtomicMemoryUnitType {
+  const lower = text.toLowerCase();
+  if (/pitfall|lesson learned|踩坑|教训|千萬別|千万别|別再|别再/i.test(lower)) {
+    return "lesson";
+  }
+  if (/\b(path|shell|node|zsh|bash|launchd|gateway|workspace|env|environment)\b|环境|環境|路径|路徑/i.test(lower)) {
+    return "environment";
+  }
+  switch (category) {
+    case "preference":
+    case "fact":
+    case "decision":
+    case "entity":
+      return category;
+    default:
+      return "other";
+  }
+}
+
+function extractTextBlocks(content: unknown): string[] {
+  if (typeof content === "string") return [content];
+  if (!Array.isArray(content)) return [];
+  const texts: string[] = [];
+  for (const block of content) {
+    if (
+      block &&
+      typeof block === "object" &&
+      "type" in block &&
+      (block as Record<string, unknown>).type === "text" &&
+      "text" in block &&
+      typeof (block as Record<string, unknown>).text === "string"
+    ) {
+      texts.push((block as Record<string, unknown>).text as string);
+    }
+  }
+  return texts;
+}
+
+export function extractAutoCaptureCandidates(
+  messages: unknown[],
+  options: { captureAssistant?: boolean } = {},
+): AutoCaptureCandidate[] {
+  const candidates: AutoCaptureCandidate[] = [];
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") continue;
+    const msgObj = msg as Record<string, unknown>;
+    const role = msgObj.role;
+    if (role !== "user" && !(options.captureAssistant === true && role === "assistant")) {
+      continue;
+    }
+
+    const texts = extractTextBlocks(msgObj.content);
+    for (const text of texts) {
+      if (!text || !shouldCapture(text)) continue;
+      const category = detectCategory(text);
+      candidates.push({
+        text,
+        role: role as MessageRole,
+        sourceKind: role === "assistant" ? "agent" : "user",
+        category,
+        unitType: detectAtomicUnitType(text, category),
+      });
+    }
+  }
+  return candidates;
+}
+
+async function storeNormalizedDrafts({
+  drafts,
+  store,
+  embedder,
+  scope,
+  importance = 0.7,
+}: {
+  drafts: NormalizedMemoryDraft[];
+  store: MemoryStore;
+  embedder: Pick<Embedder, "embedPassage">;
+  scope: string;
+  importance?: number;
+}): Promise<MemoryEntry[]> {
+  const stored: MemoryEntry[] = [];
+
+  for (const draft of drafts) {
+    const vector = await embedder.embedPassage(draft.canonicalText);
+    const existing = await store.vectorSearch(vector, 1, 0.1, [scope]);
+    if (existing.length > 0 && existing[0].score > 0.95) {
+      continue;
+    }
+
+    const metadata = buildAtomicMemoryMetadata(draft.category, {
+      unitType: draft.atomic.unitType,
+      sourceKind: draft.atomic.sourceKind,
+      confidence: draft.atomic.confidence ?? importance,
+      sourceRef: draft.atomic.sourceRef,
+      tags: draft.atomic.tags,
+    });
+
+    const entry = await store.store({
+      text: draft.canonicalText,
+      vector,
+      importance,
+      category: draft.category,
+      scope,
+      ...(metadata ? { metadata } : {}),
+    });
+    stored.push(entry);
+  }
+
+  return stored;
+}
+
+export async function storeAutoCaptureCandidates({
+  candidates,
+  store,
+  embedder,
+  scope,
+  importance = 0.7,
+  limit = 3,
+}: StoreAutoCaptureParams): Promise<MemoryEntry[]> {
+  const stored: MemoryEntry[] = [];
+
+  for (const candidate of candidates.slice(0, limit)) {
+    const vector = await embedder.embedPassage(candidate.text);
+    const existing = await store.vectorSearch(vector, 1, 0.1, [scope]);
+    if (existing.length > 0 && existing[0].score > 0.95) {
+      continue;
+    }
+
+    const metadata = buildAtomicMemoryMetadata(candidate.category, {
+      unitType: candidate.unitType,
+      sourceKind: candidate.sourceKind,
+      confidence: importance,
+    });
+
+    const entry = await store.store({
+      text: candidate.text,
+      vector,
+      importance,
+      category: candidate.category,
+      scope,
+      ...(metadata ? { metadata } : {}),
+    });
+    stored.push(entry);
+  }
+
+  return stored;
+}
+
+export async function normalizeAndStoreAutoCaptureCandidates({
+  candidates,
+  store,
+  embedder,
+  scope,
+  importance = 0.7,
+  limit = 3,
+  normalizer,
+  agentId,
+}: NormalizeAndStoreAutoCaptureParams): Promise<MemoryEntry[]> {
+  const normalizedDrafts: NormalizedMemoryDraft[] = [];
+
+  for (const candidate of candidates.slice(0, limit)) {
+    const entries = await normalizer.normalizeCandidate(candidate, {
+      agentId,
+      scope,
+      source: "auto_capture",
+      confidence: importance,
+      sourceRef: "auto_capture",
+    });
+    normalizedDrafts.push(...entries.slice(0, limit));
+  }
+
+  return storeNormalizedDrafts({
+    drafts: normalizedDrafts.slice(0, limit),
+    store,
+    embedder,
+    scope,
+    importance,
+  });
+}

--- a/src/governance-report.ts
+++ b/src/governance-report.ts
@@ -1,0 +1,237 @@
+import { describeKnowledgeUnit, extractAtomicMemory } from "./atomic-memory.js";
+import { isNoise } from "./noise-filter.js";
+import type { MemoryEntry } from "./store.js";
+
+export interface GovernanceReportEntry {
+  id: string;
+  text: string;
+  category: string;
+  scope: string;
+  importance: number;
+  timestamp: number;
+  knowledgeUnit: ReturnType<typeof describeKnowledgeUnit>;
+  reasons: string[];
+}
+
+export interface GovernancePairCandidate {
+  recommendedAction: "merge" | "supersede";
+  overlap: number;
+  primary: GovernanceReportEntry;
+  secondary: GovernanceReportEntry;
+  reasons: string[];
+}
+
+export interface GovernanceReport {
+  summary: {
+    totalCount: number;
+    atomicCount: number;
+    plainCount: number;
+    highValueAtomicCount: number;
+    verifyCandidateCount: number;
+    mergeCandidateCount: number;
+    archiveNoiseCandidateCount: number;
+    plainRiskCounts: { ready: number; cautious: number; hold: number; noise: number };
+  };
+  buckets: {
+    highValueAtomic: GovernanceReportEntry[];
+    verifyCandidates: GovernanceReportEntry[];
+    mergeCandidates: GovernancePairCandidate[];
+    archiveNoiseCandidates: GovernanceReportEntry[];
+    plainRisk: {
+      ready: GovernanceReportEntry[];
+      cautious: GovernanceReportEntry[];
+      hold: GovernanceReportEntry[];
+      noise: GovernanceReportEntry[];
+    };
+  };
+}
+
+const NOISE_MARKERS = [/conversation info/i, /system metadata/i, /scope_test/i, /^system\s*\+/i];
+const PENDING_MARKERS = [/\bpending\b/i, /待确认/, /计划态/, /\btodo\b/i, /\bplan\b/i, /计划/];
+const HOLD_MARKERS = [/pitfall/i, /principle/i, /prevention/i, /\bfix\b/i, /反思/, /督促/, /自我要求/, /核心概念/];
+
+function tokenize(text: string): string[] {
+  return String(text).toLowerCase().match(/[a-z0-9\u4e00-\u9fff]+/g) || [];
+}
+
+function textFingerprint(text: string): string {
+  return tokenize(text)
+    .filter((token) => token.length >= 2)
+    .slice(0, 16)
+    .join(" ");
+}
+
+function clauseCount(text: string): number {
+  const matches = String(text).match(/[\n;；。!?：:]/g);
+  return matches ? matches.length + 1 : 1;
+}
+
+function hasNoiseMarkers(text: string): boolean {
+  return NOISE_MARKERS.some((pattern) => pattern.test(text));
+}
+
+function toReportEntry(entry: MemoryEntry, reasons: string[]): GovernanceReportEntry {
+  return {
+    id: entry.id,
+    text: entry.text,
+    category: entry.category,
+    scope: entry.scope,
+    importance: entry.importance,
+    timestamp: entry.timestamp,
+    knowledgeUnit: describeKnowledgeUnit(entry),
+    reasons,
+  };
+}
+
+export function classifyPlainRisk(entry: MemoryEntry): { bucket: "ready" | "cautious" | "hold" | "noise"; reasons: string[] } {
+  const text = entry.text || "";
+  const reasons: string[] = [];
+  if (isNoise(text) || hasNoiseMarkers(text)) {
+    reasons.push("命中噪声/会话元信息规则");
+    return { bucket: "noise", reasons };
+  }
+  if (PENDING_MARKERS.some((pattern) => pattern.test(text))) {
+    reasons.push("包含 pending/计划态信号");
+    return { bucket: "hold", reasons };
+  }
+  if (HOLD_MARKERS.some((pattern) => pattern.test(text))) {
+    reasons.push("包含 pitfall/principle/fix/反思 类混合信号");
+    return { bucket: "hold", reasons };
+  }
+  const clauses = clauseCount(text);
+  if (text.length <= 140 && clauses <= 2 && entry.importance >= 0.7 && entry.category !== "other") {
+    reasons.push("文本较短、主题较单一、接近直接 atomic repair");
+    return { bucket: "ready", reasons };
+  }
+  reasons.push(text.length > 180 ? "文本较长" : "存在多子句/摘要式结构");
+  return { bucket: "cautious", reasons };
+}
+
+export function classifyArchiveNoiseCandidate(entry: MemoryEntry): string[] | null {
+  const text = entry.text || "";
+  const reasons: string[] = [];
+  if (isNoise(text) || hasNoiseMarkers(text)) reasons.push("命中噪声/会话元信息规则");
+  if (!extractAtomicMemory(entry.metadata) && entry.importance <= 0.55 && text.length > 180) {
+    reasons.push("plain 且重要性偏低，更像归档材料而非长期高权重记忆");
+  }
+  return reasons.length > 0 ? reasons : null;
+}
+
+export function buildGovernanceReport(entries: MemoryEntry[]): GovernanceReport {
+  const highValueAtomic: GovernanceReportEntry[] = [];
+  const verifyCandidates: GovernanceReportEntry[] = [];
+  const archiveNoiseCandidates: GovernanceReportEntry[] = [];
+  const plainRisk = { ready: [] as GovernanceReportEntry[], cautious: [] as GovernanceReportEntry[], hold: [] as GovernanceReportEntry[], noise: [] as GovernanceReportEntry[] };
+
+  for (const entry of entries) {
+    const atomic = extractAtomicMemory(entry.metadata);
+    const archiveReasons = classifyArchiveNoiseCandidate(entry);
+    if (archiveReasons) archiveNoiseCandidates.push(toReportEntry(entry, archiveReasons));
+
+    if (atomic) {
+      const highValueReasons: string[] = [];
+      if (entry.importance >= 0.85) highValueReasons.push("importance >= 0.85");
+      if (atomic.confidence >= 0.8) highValueReasons.push("atomic.confidence >= 0.80");
+      if (["user", "tool"].includes(atomic.sourceKind)) highValueReasons.push(`sourceKind=${atomic.sourceKind}`);
+      if (highValueReasons.length >= 3 && !archiveReasons) {
+        highValueAtomic.push(toReportEntry(entry, highValueReasons));
+      }
+
+      const verifyReasons: string[] = [];
+      if (atomic.sourceKind === "agent" || atomic.sourceKind === "imported") verifyReasons.push(`sourceKind=${atomic.sourceKind} 需要回源确认`);
+      if (atomic.confidence < 0.8) verifyReasons.push("confidence < 0.80");
+      if (!atomic.sourceRef) verifyReasons.push("缺少 sourceRef，回溯性较弱");
+      if (verifyReasons.length > 0 && !archiveReasons) {
+        verifyCandidates.push(toReportEntry(entry, verifyReasons));
+      }
+      continue;
+    }
+
+    const plain = classifyPlainRisk(entry);
+    plainRisk[plain.bucket].push(toReportEntry(entry, plain.reasons));
+  }
+
+  const mergeCandidates: GovernancePairCandidate[] = [];
+  const seenPairs = new Set<string>();
+  for (let i = 0; i < entries.length; i += 1) {
+    for (let j = i + 1; j < entries.length; j += 1) {
+      const left = entries[i];
+      const right = entries[j];
+      if (left.scope !== right.scope || left.category !== right.category) continue;
+      if (hasNoiseMarkers(left.text) || hasNoiseMarkers(right.text)) continue;
+
+      const leftTokens = new Set(tokenize(left.text));
+      const rightTokens = new Set(tokenize(right.text));
+      if (leftTokens.size === 0 || rightTokens.size === 0) continue;
+
+      const shared = [...leftTokens].filter((token) => rightTokens.has(token));
+      const overlap = shared.length / Math.max(leftTokens.size, rightTokens.size);
+      if (shared.length < 3 || overlap < 0.68) continue;
+
+      const pairKey = [left.id, right.id].sort().join(":");
+      if (seenPairs.has(pairKey)) continue;
+      seenPairs.add(pairKey);
+
+      const leftAtomic = extractAtomicMemory(left.metadata);
+      const rightAtomic = extractAtomicMemory(right.metadata);
+      const primary = leftAtomic && !rightAtomic
+        ? left
+        : rightAtomic && !leftAtomic
+          ? right
+          : (left.importance >= right.importance ? left : right);
+      const secondary = primary.id === left.id ? right : left;
+      const recommendedAction = extractAtomicMemory(primary.metadata) && !extractAtomicMemory(secondary.metadata)
+        ? "supersede"
+        : "merge";
+
+      mergeCandidates.push({
+        recommendedAction,
+        overlap: Number(overlap.toFixed(2)),
+        primary: toReportEntry(primary, [`与 ${secondary.id} 存在高文本重叠`]),
+        secondary: toReportEntry(secondary, [`与 ${primary.id} 存在高文本重叠`]),
+        reasons: [
+          `共享 ${shared.length} 个 token，重叠度 ${overlap.toFixed(2)}`,
+          recommendedAction === "supersede" ? "atomic/plain 阴影对，优先考虑 supersede 关系" : "相似内容双写，优先人工判断是否 merge",
+        ],
+      });
+    }
+  }
+
+  const atomicCount = entries.filter((entry) => extractAtomicMemory(entry.metadata)).length;
+  const plainCount = entries.length - atomicCount;
+
+  return {
+    summary: {
+      totalCount: entries.length,
+      atomicCount,
+      plainCount,
+      highValueAtomicCount: highValueAtomic.length,
+      verifyCandidateCount: verifyCandidates.length,
+      mergeCandidateCount: mergeCandidates.length,
+      archiveNoiseCandidateCount: archiveNoiseCandidates.length,
+      plainRiskCounts: {
+        ready: plainRisk.ready.length,
+        cautious: plainRisk.cautious.length,
+        hold: plainRisk.hold.length,
+        noise: plainRisk.noise.length,
+      },
+    },
+    buckets: {
+      highValueAtomic: highValueAtomic.sort((a, b) => b.importance - a.importance || b.timestamp - a.timestamp),
+      verifyCandidates: verifyCandidates.sort((a, b) => b.timestamp - a.timestamp),
+      mergeCandidates: mergeCandidates.sort((a, b) => b.overlap - a.overlap),
+      archiveNoiseCandidates: archiveNoiseCandidates.sort((a, b) => b.timestamp - a.timestamp),
+      plainRisk: {
+        ready: plainRisk.ready.sort((a, b) => b.importance - a.importance),
+        cautious: plainRisk.cautious.sort((a, b) => b.importance - a.importance),
+        hold: plainRisk.hold.sort((a, b) => b.timestamp - a.timestamp),
+        noise: plainRisk.noise.sort((a, b) => b.timestamp - a.timestamp),
+      },
+    },
+  };
+}
+
+export function governanceEntryLabel(entry: GovernanceReportEntry): string {
+  const fingerprint = textFingerprint(entry.text);
+  return `[${entry.id}] [${entry.category}:${entry.scope}] ${fingerprint || entry.text.slice(0, 80)}`;
+}

--- a/src/normalization-rules.ts
+++ b/src/normalization-rules.ts
@@ -1,0 +1,252 @@
+import type { AtomicMemoryUnitType } from "./atomic-memory.js";
+import type { NormalizationCandidate, NormalizedMemoryDraft } from "./normalization-types.js";
+import type { MemoryEntry } from "./store.js";
+
+const RUNTIME_CHATTER_PATTERNS = [
+  /^\[\[reply_to_current\]\]/i,
+  /\bheartbeat\b/i,
+  /\bpoll(?:ing)?\b/i,
+  /\bstatus\b/i,
+  /\bchecking\b/i,
+  /\bfound key information\b/i,
+  /找到关键信息了/,
+  /我去看一下/,
+  /我先看一下/,
+  /我先按/,
+  /我重点看/,
+  /等它跑完/,
+  /我继续帮你验/,
+  /我继续帮你看/,
+  /任务本身有没有/,
+  /看它有没有/,
+  /再决定要不要/,
+  /\bdo you want me to\b/i,
+  /要不要我/,
+  /\bi can (?:continue|fix|handle)\b/i,
+] as const;
+
+const KEEP_RUNTIME_INCIDENT_PATTERNS = [
+  /\bstall\b/i,
+  /\btimeout\b/i,
+  /\bfailed\b/i,
+  /\berror\b/i,
+  /\brestart\b/i,
+  /\bgetupdates\b/i,
+  /\bHTTP\s*[45]\d{2}\b/i,
+  /\ballowlist miss\b/i,
+  /\btoken pool is empty\b/i,
+] as const;
+
+const TECHNICAL_MARKERS = [
+  /\b[A-Z_]{3,}\b/,
+  /\b\d{3,5}\b/,
+  /[A-Za-z0-9_.-]+\.(?:json|jsonl|md|ts|js|py|plist)\b/,
+  /(?:\/|~\/)[^\s]+/,
+  /\b(?:error|timeout|gateway|proxy|session|telegram|embedding|rerank|allowlist|lock|threadbindings|captureassistant|rerankprovider|baseurl)\b/i,
+] as const;
+
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function stripMetadataHeaders(text: string): string {
+  return text.replace(/^(Conversation info|Sender) \(untrusted metadata\):[\s\S]*?\n\s*\n/gim, "").trim();
+}
+
+function stripMarkdownNoise(text: string): string {
+  return text
+    .replace(/^[-*]\s+/gm, "")
+    .replace(/^>\s?/gm, "")
+    .replace(/`{1,3}/g, "");
+}
+
+function stripAckPreamble(text: string): string {
+  return text
+    .replace(/^(好的[，, ]*|明白了?[，, ]*|收到[，, ]*|我明白了?[，, ]*|我知道了?[，, ]*|好[的吧]?[，, ]*)/i, "")
+    .replace(/^(okay[,. ]*|ok[,. ]*|understood[,. ]*|got it[,. ]*)/i, "")
+    .trim();
+}
+
+function removeTrailingPrompt(text: string): string {
+  return text
+    .replace(/(。|！|!|\.)?\s*(要不要我现在[\s\S]*)$/u, "")
+    .replace(/(。|！|!|\.)?\s*(do you want me to[\s\S]*)$/iu, "")
+    .trim();
+}
+
+export function cleanupCandidateText(text: string): string {
+  return collapseWhitespace(removeTrailingPrompt(stripAckPreamble(stripMarkdownNoise(stripMetadataHeaders(text)))));
+}
+
+export function isRuntimeChatter(text: string): boolean {
+  const cleaned = cleanupCandidateText(text);
+  if (KEEP_RUNTIME_INCIDENT_PATTERNS.some((pattern) => pattern.test(cleaned))) {
+    return false;
+  }
+  return cleaned.length < 12 || RUNTIME_CHATTER_PATTERNS.some((pattern) => pattern.test(cleaned));
+}
+
+export function detectNormalizationKind(candidate: NormalizationCandidate): "technical" | "decision" | "preference" | "generic" {
+  if (candidate.category === "decision") return "decision";
+  if (candidate.category === "preference") return "preference";
+  if (TECHNICAL_MARKERS.some((pattern) => pattern.test(candidate.text))) return "technical";
+  return "generic";
+}
+
+function detectKindFromText(text: string, fallback: "technical" | "decision" | "preference" | "generic" = "generic") {
+  const lower = cleanupCandidateText(text).toLowerCase();
+  if (/(?:偏好|喜欢|喜歡|希望|prefer|preference)/i.test(lower)) return "preference";
+  if (/(?:决定|決定|原则|原則|规则|規則|decision|rule|principle)/i.test(lower)) return "decision";
+  if (TECHNICAL_MARKERS.some((pattern) => pattern.test(lower))) return "technical";
+  return fallback;
+}
+
+function inferRuleCategory(candidate: NormalizationCandidate): MemoryEntry["category"] {
+  const kind = detectNormalizationKind(candidate);
+  if (kind === "technical") return "fact";
+  return candidate.category;
+}
+
+function inferRuleUnitType(candidate: NormalizationCandidate): AtomicMemoryUnitType {
+  const kind = detectNormalizationKind(candidate);
+  if (kind === "technical") return candidate.unitType === "lesson" ? "lesson" : "fact";
+  return candidate.unitType;
+}
+
+export function deriveTagsFromText(text: string, candidate?: Pick<NormalizationCandidate, "category" | "unitType">): string[] | undefined {
+  const tags = new Set<string>();
+  const cleaned = cleanupCandidateText(text);
+
+  const pathMatches = cleaned.match(/[A-Za-z0-9_.-]+\.(?:json|jsonl|md|ts|js|py|plist)\b/g) || [];
+  for (const match of pathMatches.slice(0, 3)) tags.add(match.toLowerCase());
+
+  const errorMatches = cleaned.match(/\b(?:EISDIR|HTTP 4\d{2}|HTTP 5\d{2}|RPM 1002|allowlist miss|threadBindings|runtime\.modelAuth|captureAssistant|rerankProvider|baseURL)\b/gi) || [];
+  for (const match of errorMatches.slice(0, 4)) tags.add(match);
+
+  const keywords = [
+    "telegram", "proxy", "gateway", "session", "embedding", "rerank", "openclaw", "codex", "lossless-claw", "tushare",
+    "metadata", "principle", "allowlist", "security", "execution", "configuration", "websocket", "path"
+  ];
+  for (const keyword of keywords) {
+    if (cleaned.toLowerCase().includes(keyword.toLowerCase())) tags.add(keyword);
+  }
+
+  if (/acpx-with-proxy/i.test(cleaned)) tags.add("acpx-with-proxy");
+  if (/\b7897\b/.test(cleaned)) tags.add("7897");
+  if (/tools\.exec\.security/i.test(cleaned)) tags.add("tools.exec.security");
+  if (/allowlist miss/i.test(cleaned)) tags.add("allowlist miss");
+  if (/practice|实践优先|原则/i.test(cleaned)) tags.add("principle");
+  if (/metadata/i.test(cleaned)) tags.add("metadata");
+  if (/原子记忆|atomic memory/i.test(cleaned)) tags.add("atomic memory");
+  if (/node bin/i.test(cleaned)) tags.add("node bin");
+  if (/skill eligibility/i.test(cleaned)) tags.add("skill eligibility");
+  if (/polling stall|getupdates/i.test(cleaned)) tags.add("polling");
+
+  if (candidate?.category === "decision") tags.add("decision");
+  if (candidate?.unitType === "lesson") tags.add("lesson");
+
+  return tags.size > 0 ? Array.from(tags).slice(0, 8) : undefined;
+}
+
+function deriveTags(candidate: NormalizationCandidate): string[] | undefined {
+  return deriveTagsFromText(candidate.text, candidate);
+}
+
+export function inferTaxonomyFromText(
+  text: string,
+  candidate: Pick<NormalizationCandidate, "category" | "unitType" | "sourceKind">,
+): { category: MemoryEntry["category"]; unitType: AtomicMemoryUnitType } {
+  const cleaned = cleanupCandidateText(text);
+  const kind = detectKindFromText(cleaned, detectNormalizationKind(candidate as NormalizationCandidate));
+
+  if (kind === "preference") {
+    return { category: "preference", unitType: "preference" };
+  }
+
+  if (kind === "decision") {
+    return { category: "decision", unitType: "decision" };
+  }
+
+  if (kind === "technical") {
+    const lessonish = /(pitfall|教训|lesson|避免|不要|别|別|prevention|fix|原因是|root cause|根因)/i.test(cleaned);
+    return {
+      category: "fact",
+      unitType: lessonish ? "lesson" : "fact",
+    };
+  }
+
+  if (/(entity|联系人|联系方式|联系人|called|叫我)/i.test(cleaned)) {
+    return { category: "entity", unitType: "entity" };
+  }
+
+  return {
+    category: candidate.category,
+    unitType: candidate.unitType,
+  };
+}
+
+function buildCanonicalText(candidate: NormalizationCandidate): string {
+  const cleaned = cleanupCandidateText(candidate.text);
+  const kind = detectNormalizationKind(candidate);
+
+  switch (kind) {
+    case "technical":
+      return cleaned.startsWith("Pitfall(") || cleaned.startsWith("Fact(") || cleaned.startsWith("Constraint(")
+        ? cleaned
+        : `Technical memory: ${cleaned}`;
+    case "decision":
+      return cleaned.startsWith("Decision(") || cleaned.startsWith("Rule(") || cleaned.startsWith("Principle(")
+        ? cleaned
+        : `Decision: ${cleaned}`;
+    case "preference":
+      return cleaned.startsWith("Preference(") ? cleaned : `Preference: ${cleaned}`;
+    default:
+      return cleaned;
+  }
+}
+
+export function buildRuleDrafts(
+  candidate: NormalizationCandidate,
+  options: { confidence?: number; sourceRef?: string } = {},
+): NormalizedMemoryDraft[] {
+  const canonicalText = buildCanonicalText(candidate);
+  if (!canonicalText) return [];
+
+  return [{
+    canonicalText,
+    category: inferRuleCategory(candidate),
+    atomic: {
+      unitType: inferRuleUnitType(candidate),
+      sourceKind: candidate.sourceKind,
+      confidence: typeof options.confidence === "number" ? options.confidence : 0.7,
+      ...(options.sourceRef ? { sourceRef: options.sourceRef } : {}),
+      ...(deriveTags(candidate) ? { tags: deriveTags(candidate) } : {}),
+    },
+    normalizationMode: "rules",
+    reason: detectNormalizationKind(candidate),
+    sourceText: candidate.text,
+  }];
+}
+
+export function buildRawFallbackDraft(
+  candidate: NormalizationCandidate,
+  options: { confidence?: number; sourceRef?: string } = {},
+): NormalizedMemoryDraft[] {
+  const cleaned = cleanupCandidateText(candidate.text) || collapseWhitespace(candidate.text);
+  if (!cleaned) return [];
+
+  return [{
+    canonicalText: cleaned,
+    category: candidate.category,
+    atomic: {
+      unitType: candidate.unitType,
+      sourceKind: candidate.sourceKind,
+      confidence: typeof options.confidence === "number" ? options.confidence : 0.55,
+      ...(options.sourceRef ? { sourceRef: options.sourceRef } : {}),
+      ...(deriveTags(candidate) ? { tags: deriveTags(candidate) } : {}),
+    },
+    normalizationMode: "raw_fallback",
+    reason: "fallback_raw",
+    sourceText: candidate.text,
+  }];
+}

--- a/src/normalization-types.ts
+++ b/src/normalization-types.ts
@@ -1,0 +1,44 @@
+import type { MemoryEntry } from "./store.js";
+import type { AtomicMemorySourceKind, AtomicMemoryUnitType } from "./atomic-memory.js";
+
+export type MessageRole = "user" | "assistant";
+
+export interface NormalizationCandidate {
+  text: string;
+  role: MessageRole;
+  sourceKind: "user" | "agent";
+  category: MemoryEntry["category"];
+  unitType: AtomicMemoryUnitType;
+}
+
+export interface NormalizedMemoryDraft {
+  canonicalText: string;
+  category: MemoryEntry["category"];
+  atomic: {
+    unitType: AtomicMemoryUnitType;
+    sourceKind: AtomicMemorySourceKind;
+    confidence: number;
+    sourceRef?: string;
+    tags?: string[];
+  };
+  normalizationMode: "llm" | "rules" | "raw_fallback";
+  reason?: string;
+  sourceText: string;
+}
+
+export interface NormalizationAuditRecord {
+  timestamp: number;
+  agentId?: string;
+  scope: string;
+  source: string;
+  candidate: Pick<NormalizationCandidate, "text" | "role" | "sourceKind" | "category" | "unitType">;
+  entries: Array<{
+    canonicalText: string;
+    category: MemoryEntry["category"];
+    atomic: NormalizedMemoryDraft["atomic"];
+    normalizationMode: NormalizedMemoryDraft["normalizationMode"];
+    reason?: string;
+  }>;
+  fallback?: string;
+  errors?: string[];
+}

--- a/src/normalization-validate.ts
+++ b/src/normalization-validate.ts
@@ -1,0 +1,154 @@
+import { ATOMIC_MEMORY_SOURCE_KINDS, ATOMIC_MEMORY_UNIT_TYPES } from "./atomic-memory.js";
+import { cleanupCandidateText, detectNormalizationKind, deriveTagsFromText, inferTaxonomyFromText, isRuntimeChatter } from "./normalization-rules.js";
+import type { NormalizationCandidate, NormalizedMemoryDraft } from "./normalization-types.js";
+
+function clamp01(value: unknown, fallback = 0.7): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(1, Math.max(0, n));
+}
+
+function normalizeTags(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const tags = value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, 8);
+  return tags.length > 0 ? tags : undefined;
+}
+
+function mergeTags(...groups: Array<string[] | undefined>): string[] | undefined {
+  const tags = new Set<string>();
+  for (const group of groups) {
+    if (!group) continue;
+    for (const tag of group) {
+      const cleaned = tag.trim();
+      if (cleaned) tags.add(cleaned);
+    }
+  }
+  return tags.size > 0 ? Array.from(tags).slice(0, 8) : undefined;
+}
+
+function resolveConfidence(value: unknown, fallback = 0.7): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return clamp01(n, fallback);
+}
+
+export function validateNormalizedDrafts(
+  candidate: NormalizationCandidate,
+  drafts: unknown,
+  options: {
+    maxEntries?: number;
+    confidence?: number;
+    sourceRef?: string;
+  } = {},
+): { entries: NormalizedMemoryDraft[]; errors: string[] } {
+  const maxEntries = Math.max(1, Math.min(5, options.maxEntries ?? 3));
+  const errors: string[] = [];
+
+  if (!Array.isArray(drafts)) {
+    return { entries: [], errors: ["entries_not_array"] };
+  }
+
+  const entries: NormalizedMemoryDraft[] = [];
+
+  for (const draft of drafts.slice(0, maxEntries)) {
+    if (!draft || typeof draft !== "object") {
+      errors.push("entry_not_object");
+      continue;
+    }
+
+    const node = draft as Record<string, unknown>;
+    const rawText = typeof node.canonicalText === "string" ? cleanupCandidateText(node.canonicalText) : "";
+    if (!rawText || rawText.length < 4) {
+      errors.push("empty_canonical_text");
+      continue;
+    }
+    if (rawText.length > 500) {
+      errors.push("canonical_text_too_long");
+      continue;
+    }
+    if (isRuntimeChatter(rawText)) {
+      errors.push("runtime_chatter");
+      continue;
+    }
+
+    const categoryCandidate = ["preference", "fact", "decision", "entity", "other"].includes(String(node.category))
+      ? (node.category as NormalizedMemoryDraft["category"])
+      : candidate.category;
+
+    const atomicRaw = node.atomic && typeof node.atomic === "object" ? node.atomic as Record<string, unknown> : {};
+    const unitTypeCandidate = ATOMIC_MEMORY_UNIT_TYPES.includes(String(atomicRaw.unitType) as any)
+      ? (atomicRaw.unitType as NormalizedMemoryDraft["atomic"]["unitType"])
+      : candidate.unitType;
+    const sourceKind = ATOMIC_MEMORY_SOURCE_KINDS.includes(String(atomicRaw.sourceKind) as any)
+      ? (atomicRaw.sourceKind as NormalizedMemoryDraft["atomic"]["sourceKind"])
+      : candidate.sourceKind;
+
+    const inferred = inferTaxonomyFromText(rawText, {
+      category: categoryCandidate,
+      unitType: unitTypeCandidate,
+      sourceKind,
+    });
+
+    const reason = typeof node.reason === "string" ? node.reason.trim() : undefined;
+    const normalizationMode = node.normalizationMode === "llm" || node.normalizationMode === "rules" || node.normalizationMode === "raw_fallback"
+      ? node.normalizationMode
+      : "llm";
+
+    const normalized: NormalizedMemoryDraft = {
+      canonicalText: rawText,
+      category: inferred.category,
+      atomic: {
+        unitType: inferred.unitType,
+        sourceKind,
+        confidence: resolveConfidence(atomicRaw.confidence, options.confidence ?? 0.7),
+        ...(typeof atomicRaw.sourceRef === "string" && atomicRaw.sourceRef.trim()
+          ? { sourceRef: atomicRaw.sourceRef.trim() }
+          : options.sourceRef ? { sourceRef: options.sourceRef } : {}),
+        ...(mergeTags(normalizeTags(atomicRaw.tags), deriveTagsFromText(rawText, {
+          category: inferred.category,
+          unitType: inferred.unitType,
+          sourceKind,
+        })) ? { tags: mergeTags(normalizeTags(atomicRaw.tags), deriveTagsFromText(rawText, {
+          category: inferred.category,
+          unitType: inferred.unitType,
+          sourceKind,
+        })) } : {}),
+      },
+      normalizationMode,
+      ...(reason ? { reason } : {}),
+      sourceText: candidate.text,
+    };
+
+    const kind = detectNormalizationKind(candidate);
+    if (kind === "technical") {
+      const lowerSource = candidate.text.toLowerCase();
+      const lowerCanon = normalized.canonicalText.toLowerCase();
+      const anchors = [
+        "allowlist miss",
+        "runtime.modelauth",
+        "threadbindings",
+        "captureassistant",
+        "rerankprovider",
+        "baseurl",
+        "eisdir",
+        "telegram",
+        "proxy",
+        "gateway",
+        "session",
+        "embedding",
+      ].filter((anchor) => lowerSource.includes(anchor));
+      if (anchors.length > 0 && !anchors.some((anchor) => lowerCanon.includes(anchor))) {
+        errors.push("technical_anchor_missing");
+        continue;
+      }
+    }
+
+    entries.push(normalized);
+  }
+
+  return { entries, errors };
+}

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -1,0 +1,227 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { MemoryEntry } from "./store.js";
+import { buildRawFallbackDraft, buildRuleDrafts } from "./normalization-rules.js";
+import { validateNormalizedDrafts } from "./normalization-validate.js";
+import type { NormalizationAuditRecord, NormalizationCandidate, NormalizedMemoryDraft } from "./normalization-types.js";
+
+type Logger = {
+  debug?: (message: string) => void;
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+};
+
+export interface NormalizerConfig {
+  enabled: boolean;
+  apiKey: string;
+  model: string;
+  baseURL: string;
+  temperature: number;
+  maxTokens: number;
+  enableThinking: boolean;
+  timeoutMs: number;
+  maxEntriesPerCandidate: number;
+  fallbackMode: "rules-then-raw" | "raw-only";
+  audit: {
+    enabled: boolean;
+    logPath?: string;
+  };
+}
+
+interface NormalizerDeps {
+  fetchImpl?: typeof fetch;
+}
+
+interface NormalizationContext {
+  agentId?: string;
+  scope: string;
+  source: string;
+  confidence?: number;
+  sourceRef?: string;
+}
+
+function extractMessageText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const textParts = content
+      .filter((item): item is { type?: unknown; text?: unknown } => Boolean(item) && typeof item === "object")
+      .filter((item) => item.type === "text" && typeof item.text === "string")
+      .map((item) => item.text as string);
+    return textParts.join("\n");
+  }
+  return "";
+}
+
+function extractJson(text: string): string {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenced?.[1]) return fenced[1].trim();
+  const firstBrace = text.indexOf("{");
+  const lastBrace = text.lastIndexOf("}");
+  if (firstBrace !== -1 && lastBrace > firstBrace) {
+    return text.slice(firstBrace, lastBrace + 1);
+  }
+  return text.trim();
+}
+
+function buildPrompt(candidate: NormalizationCandidate, maxEntries: number): Array<{ role: "system" | "user"; content: string }> {
+  const payload = {
+    text: candidate.text,
+    role: candidate.role,
+    categoryHint: candidate.category,
+    atomicHint: {
+      unitType: candidate.unitType,
+      sourceKind: candidate.sourceKind,
+    },
+    constraints: {
+      maxEntries,
+      preserveTechnicalAnchors: true,
+      noSpeculation: true,
+    },
+  };
+
+  return [
+    {
+      role: "system",
+      content:
+        "You are a memory normalizer. Transform a candidate memory into 1 to 3 long-term memory entries. " +
+        "Preserve exact technical anchors such as error phrases, file names, config keys, model names, ports, and paths. " +
+        "Do not invent facts. Remove acknowledgements, chatter, and process-only wording. " +
+        "Return strict JSON only with shape {\"entries\":[{\"canonicalText\":\"...\",\"category\":\"preference|fact|decision|entity|other\",\"atomic\":{\"unitType\":\"preference|fact|decision|lesson|environment|entity|other\",\"sourceKind\":\"user|tool|agent|imported\",\"confidence\":0.0,\"tags\":[\"...\"]},\"reason\":\"...\"}]}.",
+    },
+    {
+      role: "user",
+      content: JSON.stringify(payload),
+    },
+  ];
+}
+
+async function appendAuditRecord(logPath: string | undefined, record: NormalizationAuditRecord): Promise<void> {
+  if (!logPath) return;
+  await mkdir(dirname(logPath), { recursive: true });
+  await appendFile(logPath, `${JSON.stringify(record)}\n`, "utf8");
+}
+
+export function createMemoryNormalizer(config: NormalizerConfig, logger?: Logger, deps: NormalizerDeps = {}) {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+
+  async function normalizeWithLLM(candidate: NormalizationCandidate, context: NormalizationContext): Promise<NormalizedMemoryDraft[]> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), config.timeoutMs);
+
+    try {
+      const response = await fetchImpl(config.baseURL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${config.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: config.model,
+          messages: buildPrompt(candidate, config.maxEntriesPerCandidate),
+          temperature: config.temperature,
+          max_tokens: config.maxTokens,
+          enable_thinking: config.enableThinking,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new Error(`normalizer_api_${response.status}: ${body.slice(0, 300)}`);
+      }
+
+      const payload = await response.json() as Record<string, unknown>;
+      const choices = Array.isArray(payload.choices) ? payload.choices as Array<Record<string, unknown>> : [];
+      const first = choices[0] || {};
+      const message = first.message && typeof first.message === "object" ? first.message as Record<string, unknown> : {};
+      const contentText = extractMessageText(message.content);
+      const jsonText = extractJson(contentText);
+      const parsed = JSON.parse(jsonText) as { entries?: unknown };
+      const validation = validateNormalizedDrafts(candidate, parsed.entries, {
+        maxEntries: config.maxEntriesPerCandidate,
+        confidence: context.confidence,
+        sourceRef: context.sourceRef,
+      });
+      if (validation.entries.length === 0) {
+        throw new Error(`normalizer_validation_failed:${validation.errors.join(",") || "unknown"}`);
+      }
+      return validation.entries.map((entry) => ({ ...entry, normalizationMode: "llm" }));
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async function normalizeCandidate(candidate: NormalizationCandidate, context: NormalizationContext): Promise<NormalizedMemoryDraft[]> {
+    const auditBase: Omit<NormalizationAuditRecord, "entries"> = {
+      timestamp: Date.now(),
+      agentId: context.agentId,
+      scope: context.scope,
+      source: context.source,
+      candidate: {
+        text: candidate.text,
+        role: candidate.role,
+        sourceKind: candidate.sourceKind,
+        category: candidate.category,
+        unitType: candidate.unitType,
+      },
+    };
+
+    if (!config.enabled) {
+      return buildRawFallbackDraft(candidate, {
+        confidence: context.confidence,
+        sourceRef: context.sourceRef,
+      });
+    }
+
+    try {
+      const entries = await normalizeWithLLM(candidate, context);
+      if (config.audit.enabled) {
+        await appendAuditRecord(config.audit.logPath, {
+          ...auditBase,
+          entries: entries.map((entry) => ({
+            canonicalText: entry.canonicalText,
+            category: entry.category,
+            atomic: entry.atomic,
+            normalizationMode: entry.normalizationMode,
+            ...(entry.reason ? { reason: entry.reason } : {}),
+          })),
+        });
+      }
+      return entries;
+    } catch (error) {
+      logger?.warn?.(`memory-lancedb-pro: normalizer LLM failed, using fallback (${String(error)})`);
+      const fallbackEntries = config.fallbackMode === "raw-only"
+        ? buildRawFallbackDraft(candidate, { confidence: context.confidence, sourceRef: context.sourceRef })
+        : buildRuleDrafts(candidate, { confidence: context.confidence, sourceRef: context.sourceRef });
+
+      const validated = validateNormalizedDrafts(candidate, fallbackEntries, {
+        maxEntries: config.maxEntriesPerCandidate,
+        confidence: context.confidence,
+        sourceRef: context.sourceRef,
+      });
+      const entries = validated.entries.length > 0
+        ? validated.entries
+        : buildRawFallbackDraft(candidate, { confidence: context.confidence, sourceRef: context.sourceRef });
+
+      if (config.audit.enabled) {
+        await appendAuditRecord(config.audit.logPath, {
+          ...auditBase,
+          entries: entries.map((entry) => ({
+            canonicalText: entry.canonicalText,
+            category: entry.category,
+            atomic: entry.atomic,
+            normalizationMode: entry.normalizationMode,
+            ...(entry.reason ? { reason: entry.reason } : {}),
+          })),
+          fallback: validated.entries.length > 0 ? "rules" : "raw",
+          errors: [String(error), ...validated.errors],
+        });
+      }
+      return entries;
+    }
+  }
+
+  return {
+    normalizeCandidate,
+  };
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -10,9 +10,19 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { MemoryRetriever, RetrievalResult } from "./retriever.js";
 import type { MemoryStore } from "./store.js";
+import {
+  ATOMIC_MEMORY_SOURCE_KINDS,
+  ATOMIC_MEMORY_UNIT_TYPES,
+  buildAtomicMemoryMetadata,
+  describeKnowledgeUnit,
+  extractAtomicMemory,
+  type AtomicMemoryInput,
+} from "./atomic-memory.js";
 import { isNoise } from "./noise-filter.js";
 import type { MemoryScopeManager } from "./scopes.js";
 import type { Embedder } from "./embedder.js";
+import type { createMemoryNormalizer } from "./normalizer.js";
+import type { NormalizedMemoryDraft } from "./normalization-types.js";
 import {
   appendRelation,
   buildSmartMetadata,
@@ -53,6 +63,7 @@ interface ToolContext {
   store: MemoryStore;
   scopeManager: MemoryScopeManager;
   embedder: Embedder;
+  normalizer?: ReturnType<typeof createMemoryNormalizer> | null;
   agentId?: string;
   workspaceDir?: string;
   mdMirror?: MdMirrorWriter | null;
@@ -78,17 +89,106 @@ function clamp01(value: number, fallback = 0.7): number {
   return Math.min(1, Math.max(0, value));
 }
 
+function looksEnvironmentFact(text: string): boolean {
+  return /\b(path|shell|node|npm|pnpm|zsh|bash|launchd|gateway|workspace|env|environment|runtime|cli|curl|python|log|logs|test|tests|playwright)\b|环境|環境|路径|路徑|运行时|運行時|终端|終端|日志|日誌|测试|測試|命令/.test(text.toLowerCase());
+}
+
+function inferAtomicForStore(
+  category: string,
+  text: string,
+  confidence: number,
+): AtomicMemoryInput | undefined {
+  switch (category) {
+    case "preference":
+      return { unitType: "preference", sourceKind: "user", confidence };
+    case "decision":
+      return { unitType: "decision", sourceKind: "user", confidence };
+    case "entity":
+      return { unitType: "entity", sourceKind: "user", confidence };
+    case "fact":
+      if (looksEnvironmentFact(text)) {
+        return { unitType: "environment", sourceKind: "tool", confidence };
+      }
+      return { unitType: "fact", sourceKind: "agent", confidence };
+    default:
+      return undefined;
+  }
+}
+
+const atomicMemoryInputSchema = Type.Object(
+  {
+    unitType: Type.Optional(stringEnum(ATOMIC_MEMORY_UNIT_TYPES)),
+    sourceKind: Type.Optional(stringEnum(ATOMIC_MEMORY_SOURCE_KINDS)),
+    confidence: Type.Optional(Type.Number({ description: "Confidence score 0-1 (defaults to importance)" })),
+    sourceRef: Type.Optional(Type.String({ description: "Optional source reference for this atomic memory" })),
+    tags: Type.Optional(Type.Array(Type.String({ description: "Short keyword tag" }))),
+  },
+  { additionalProperties: false },
+);
+
 function sanitizeMemoryForSerialization(results: RetrievalResult[]) {
-  return results.map((r) => ({
-    id: r.entry.id,
-    text: r.entry.text,
-    category: getDisplayCategoryTag(r.entry),
-    rawCategory: r.entry.category,
-    scope: r.entry.scope,
-    importance: r.entry.importance,
-    score: r.score,
-    sources: r.sources,
-  }));
+  return results.map((r) => {
+    const atomic = extractAtomicMemory(r.entry.metadata);
+    return {
+      id: r.entry.id,
+      text: r.entry.text,
+      category: getDisplayCategoryTag(r.entry),
+      rawCategory: r.entry.category,
+      scope: r.entry.scope,
+      importance: r.entry.importance,
+      score: r.score,
+      sources: r.sources,
+      ...(atomic ? { atomic } : {}),
+      knowledgeUnit: describeKnowledgeUnit(r.entry),
+    };
+  });
+}
+
+async function storeDrafts(
+  drafts: NormalizedMemoryDraft[],
+  context: Pick<ToolContext, "store" | "embedder">,
+  targetScope: string,
+  defaultImportance = 0.7,
+) {
+  const stored = [];
+
+  for (const draft of drafts) {
+    const vector = await context.embedder.embedPassage(draft.canonicalText);
+    let existing: Awaited<ReturnType<MemoryStore["vectorSearch"]>> = [];
+    try {
+      existing = await context.store.vectorSearch(vector, 1, 0.1, [targetScope], {
+        excludeInactive: true,
+      });
+    } catch (err) {
+      console.warn(
+        `memory-lancedb-pro: normalized duplicate pre-check failed, continue store: ${String(err)}`,
+      );
+    }
+    if (existing.length > 0 && existing[0].score > 0.98) {
+      continue;
+    }
+
+    const metadata = buildAtomicMemoryMetadata(draft.category, {
+      unitType: draft.atomic.unitType,
+      sourceKind: draft.atomic.sourceKind,
+      confidence: draft.atomic.confidence ?? defaultImportance,
+      sourceRef: draft.atomic.sourceRef,
+      tags: draft.atomic.tags,
+    });
+
+    const entry = await context.store.store({
+      text: draft.canonicalText,
+      vector,
+      importance: defaultImportance,
+      category: draft.category,
+      scope: targetScope,
+      ...(metadata ? { metadata } : {}),
+    });
+
+    stored.push(entry);
+  }
+
+  return stored;
 }
 
 function parseAgentIdFromSessionKey(sessionKey: string | undefined): string | undefined {
@@ -546,6 +646,7 @@ export function registerMemoryStoreTool(
             description: "Memory scope (optional, defaults to agent scope)",
           }),
         ),
+        atomic: Type.Optional(atomicMemoryInputSchema),
       }),
       async execute(_toolCallId, params) {
         const {
@@ -553,11 +654,13 @@ export function registerMemoryStoreTool(
           importance = 0.7,
           category = "other",
           scope,
+          atomic,
         } = params as {
           text: string;
           importance?: number;
           category?: string;
           scope?: string;
+          atomic?: AtomicMemoryInput;
         };
 
         try {
@@ -595,83 +698,173 @@ export function registerMemoryStoreTool(
           }
 
           const safeImportance = clamp01(importance, 0.7);
-          const vector = await runtimeContext.embedder.embedPassage(text);
+          const inferredAtomic = inferAtomicForStore(category, text, safeImportance);
+          const effectiveAtomic = atomic ?? inferredAtomic;
 
-          // Check for duplicates using raw vector similarity (bypasses importance/recency weighting)
-          // Fail-open by design: dedup must never block a legitimate memory write.
-          // excludeInactive: superseded historical records must not block new writes.
-          let existing: Awaited<ReturnType<MemoryStore["vectorSearch"]>> = [];
-          try {
-            existing = await runtimeContext.store.vectorSearch(vector, 1, 0.1, [
-              targetScope,
-            ], { excludeInactive: true });
-          } catch (err) {
-            console.warn(
-              `memory-lancedb-pro: duplicate pre-check failed, continue store: ${String(err)}`,
-            );
-          }
+          if (atomic || !runtimeContext.normalizer) {
+            const vector = await runtimeContext.embedder.embedPassage(text);
 
-          if (existing.length > 0 && existing[0].score > 0.98) {
+            // Check for duplicates using raw vector similarity (bypasses importance/recency weighting)
+            // Fail-open by design: dedup must never block a legitimate memory write.
+            // excludeInactive: superseded historical records must not block new writes.
+            let existing: Awaited<ReturnType<MemoryStore["vectorSearch"]>> = [];
+            try {
+              existing = await runtimeContext.store.vectorSearch(vector, 1, 0.1, [
+                targetScope,
+              ], { excludeInactive: true });
+            } catch (err) {
+              console.warn(
+                `memory-lancedb-pro: duplicate pre-check failed, continue store: ${String(err)}`,
+              );
+            }
+
+            if (existing.length > 0 && existing[0].score > 0.98) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `Similar memory already exists: "${existing[0].entry.text}"`,
+                  },
+                ],
+                details: {
+                  action: "duplicate",
+                  existingId: existing[0].entry.id,
+                  existingText: existing[0].entry.text,
+                  existingScope: existing[0].entry.scope,
+                  similarity: existing[0].score,
+                  existingKnowledgeUnit: describeKnowledgeUnit(existing[0].entry),
+                },
+              };
+            }
+
+            const metadata = effectiveAtomic
+              ? buildAtomicMemoryMetadata(category, {
+                  ...effectiveAtomic,
+                  confidence: effectiveAtomic.confidence ?? safeImportance,
+                })
+              : stringifySmartMetadata(
+                  buildSmartMetadata(
+                    {
+                      text,
+                      category: category as any,
+                      importance: safeImportance,
+                    },
+                    {
+                      l0_abstract: text,
+                      l1_overview: `- ${text}`,
+                      l2_content: text,
+                    },
+                  ),
+                );
+
+            const entry = await runtimeContext.store.store({
+              text,
+              vector,
+              importance: safeImportance,
+              category: category as any,
+              scope: targetScope,
+              ...(metadata ? { metadata } : {}),
+            });
+
+            if (runtimeContext.mdMirror) {
+              await runtimeContext.mdMirror(
+                { text, category: category as string, scope: targetScope, timestamp: entry.timestamp },
+                { source: "memory_store", agentId },
+              );
+            }
+
+            const atomicMemory = extractAtomicMemory(entry.metadata);
+            const knowledgeUnit = describeKnowledgeUnit(entry);
+
             return {
               content: [
                 {
                   type: "text",
-                  text: `Similar memory already exists: "${existing[0].entry.text}"`,
+                  text: `Stored: "${text.slice(0, 100)}${text.length > 100 ? "..." : ""}" in scope '${targetScope}'`,
                 },
               ],
               details: {
-                action: "duplicate",
-                existingId: existing[0].entry.id,
-                existingText: existing[0].entry.text,
-                existingScope: existing[0].entry.scope,
-                similarity: existing[0].score,
+                action: "created",
+                id: entry.id,
+                scope: entry.scope,
+                category: entry.category,
+                importance: entry.importance,
+                ...(atomicMemory ? { atomic: atomicMemory } : {}),
+                knowledgeUnit,
               },
             };
           }
 
-          const entry = await runtimeContext.store.store({
+          const normalizedEntries = await runtimeContext.normalizer.normalizeCandidate({
             text,
-            vector,
-            importance: safeImportance,
+            role: "user",
+            sourceKind: effectiveAtomic?.sourceKind === "agent" || effectiveAtomic?.sourceKind === "imported"
+              ? effectiveAtomic.sourceKind
+              : "user",
             category: category as any,
+            unitType: effectiveAtomic?.unitType ?? (inferredAtomic?.unitType ?? "other"),
+          }, {
+            agentId: runtimeContext.agentId,
             scope: targetScope,
-            metadata: stringifySmartMetadata(
-              buildSmartMetadata(
-                {
-                  text,
-                  category: category as any,
-                  importance: safeImportance,
-                },
-                {
-                  l0_abstract: text,
-                  l1_overview: `- ${text}`,
-                  l2_content: text,
-                },
-              ),
-            ),
+            source: "memory_store",
+            confidence: safeImportance,
+            sourceRef: "memory_store",
           });
 
-          // Dual-write to Markdown mirror if enabled
-          if (context.mdMirror) {
-            await context.mdMirror(
-              { text, category: category as string, scope: targetScope, timestamp: entry.timestamp },
-              { source: "memory_store", agentId },
-            );
+          const created = await storeDrafts(normalizedEntries, runtimeContext, targetScope, safeImportance);
+
+          if (created.length === 0) {
+            return {
+              content: [{ type: "text", text: `No new memory stored. Normalized result matched existing memories in scope '${targetScope}'.` }],
+              details: {
+                action: "duplicate_after_normalization",
+                scope: targetScope,
+                normalized: normalizedEntries.map((entry) => ({
+                  text: entry.canonicalText,
+                  category: entry.category,
+                  atomic: entry.atomic,
+                })),
+              },
+            };
           }
 
+          if (runtimeContext.mdMirror) {
+            for (const entry of created) {
+              await runtimeContext.mdMirror(
+                { text: entry.text, category: entry.category, scope: entry.scope, timestamp: entry.timestamp },
+                { source: "memory_store", agentId },
+              );
+            }
+          }
+
+          const knowledgeUnits = created.map((entry) => describeKnowledgeUnit(entry));
           return {
-            content: [
-              {
-                type: "text",
-                text: `Stored: "${text.slice(0, 100)}${text.length > 100 ? "..." : ""}" in scope '${targetScope}'`,
-              },
-            ],
+            content: [{
+              type: "text",
+              text: created.length === 1
+                ? `Stored normalized memory in scope '${targetScope}': "${created[0].text.slice(0, 100)}${created[0].text.length > 100 ? "..." : ""}"`
+                : `Stored ${created.length} normalized memories in scope '${targetScope}'.`,
+            }],
             details: {
-              action: "created",
-              id: entry.id,
-              scope: entry.scope,
-              category: entry.category,
-              importance: entry.importance,
+              action: created.length === 1 ? "created" : "created_batch",
+              count: created.length,
+              ids: created.map((entry) => entry.id),
+              memories: created.map((entry) => ({
+                id: entry.id,
+                text: entry.text,
+                category: entry.category,
+                scope: entry.scope,
+                importance: entry.importance,
+                atomic: extractAtomicMemory(entry.metadata),
+              })),
+              knowledgeUnits,
+              normalization: normalizedEntries.map((entry) => ({
+                canonicalText: entry.canonicalText,
+                category: entry.category,
+                atomic: entry.atomic,
+                normalizationMode: entry.normalizationMode,
+                reason: entry.reason,
+              })),
             },
           };
         } catch (error) {

--- a/test/memory-store-normalizer.mjs
+++ b/test/memory-store-normalizer.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+
+function embedText(text, dim = 24) {
+  const vector = Array(dim).fill(0);
+  const tokens = String(text).toLowerCase().match(/[a-z0-9\u4e00-\u9fff._/-]+/g) || [];
+  for (const token of tokens) {
+    let hash = 0;
+    for (const char of token) hash = (hash * 33 + char.charCodeAt(0)) >>> 0;
+    vector[hash % dim] += 1;
+  }
+  const norm = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
+  return norm > 0 ? vector.map((value) => value / norm) : vector;
+}
+
+async function main() {
+  const { MemoryStore } = jiti("../src/store.ts");
+  const { createScopeManager } = jiti("../src/scopes.ts");
+  const { createRetriever } = jiti("../src/retriever.ts");
+  const { createMemoryNormalizer } = jiti("../src/normalizer.ts");
+  const { registerMemoryStoreTool } = jiti("../src/tools.ts");
+  const { extractAtomicMemory } = jiti("../src/atomic-memory.ts");
+
+  const workDir = mkdtempSync(path.join(tmpdir(), "memory-lancedb-pro-store-normalizer-"));
+
+  try {
+    const store = new MemoryStore({ dbPath: path.join(workDir, "db"), vectorDim: 24 });
+    const embedder = {
+      async embedPassage(text) { return embedText(text); },
+      async embedQuery(text) { return embedText(text); },
+    };
+    const retriever = createRetriever(store, embedder, {
+      mode: "vector",
+      rerank: "none",
+      minScore: 0.1,
+      hardMinScore: 0.05,
+      filterNoise: false,
+    });
+    const scopeManager = createScopeManager({
+      default: "agent:main",
+      definitions: {
+        global: { description: "global" },
+        "agent:main": { description: "main" },
+      },
+      agentAccess: {
+        main: ["global", "agent:main"],
+      },
+    });
+
+    const normalizer = createMemoryNormalizer({
+      enabled: true,
+      apiKey: "sk-test",
+      model: "Qwen/Qwen3-8B",
+      baseURL: "https://api.siliconflow.cn/v1/chat/completions",
+      temperature: 0.1,
+      maxTokens: 1200,
+      enableThinking: false,
+      timeoutMs: 3000,
+      maxEntriesPerCandidate: 3,
+      fallbackMode: "rules-then-raw",
+      audit: {
+        enabled: false,
+      },
+    }, undefined, {
+      fetchImpl: async () => ({
+        ok: true,
+        async json() {
+          return {
+            choices: [{
+              message: {
+                content: JSON.stringify({
+                  entries: [{
+                    canonicalText: "重要原则：实践优先，准备充分后大胆尝试，不要长期停留在保守观望。",
+                    category: "decision",
+                    atomic: {
+                      unitType: "decision",
+                      sourceKind: "user",
+                      confidence: 0.82,
+                      tags: ["principle"],
+                    },
+                    reason: "principle_rewrite",
+                  }],
+                }),
+              },
+            }],
+          };
+        },
+      }),
+    });
+
+    let registeredTool;
+    const api = {
+      registerTool(definition) {
+        registeredTool = definition;
+      },
+    };
+
+    registerMemoryStoreTool(api, {
+      retriever,
+      store,
+      scopeManager,
+      embedder,
+      normalizer,
+      agentId: "main",
+    });
+
+    assert(registeredTool, "memory_store tool should register");
+
+    const resolvedTool = typeof registeredTool === "function"
+      ? registeredTool({ agentId: "main", sessionKey: "agent:main:test" })
+      : registeredTool;
+
+    const result = await resolvedTool.execute("tool-call-1", {
+      text: "重要原则：实践优先，准备充分后大胆尝试，不要长期停留在保守观望。要不要我现在顺手把实验方案也落下来？",
+      category: "decision",
+      importance: 0.7,
+    });
+
+    assert.equal(result.details.action, "created");
+    assert.equal(result.details.memories[0].text, "重要原则：实践优先，准备充分后大胆尝试，不要长期停留在保守观望。");
+    assert.equal(result.details.memories[0].atomic.unitType, "decision");
+    assert.equal(result.details.memories[0].atomic.sourceKind, "user");
+    assert(result.details.memories[0].atomic.tags.includes("principle"));
+
+    const list = await store.list(["agent:main"], undefined, 10, 0);
+    assert.equal(list.length, 1);
+    assert.equal(list[0].text, "重要原则：实践优先，准备充分后大胆尝试，不要长期停留在保守观望。");
+    assert.equal(extractAtomicMemory(list[0].metadata)?.unitType, "decision");
+
+    console.log("OK: memory_store normalizer rewrite passed");
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error("FAIL: memory_store normalizer rewrite failed");
+  console.error(error);
+  process.exit(1);
+});

--- a/test/normalizer-auto-capture.mjs
+++ b/test/normalizer-auto-capture.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+
+function embedText(text, dim = 24) {
+  const vector = Array(dim).fill(0);
+  const tokens = String(text).toLowerCase().match(/[a-z0-9\u4e00-\u9fff._/-]+/g) || [];
+  for (const token of tokens) {
+    let hash = 0;
+    for (const char of token) hash = (hash * 33 + char.charCodeAt(0)) >>> 0;
+    vector[hash % dim] += 1;
+  }
+  const norm = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
+  return norm > 0 ? vector.map((value) => value / norm) : vector;
+}
+
+async function main() {
+  const { MemoryStore } = jiti("../src/store.ts");
+  const { extractAtomicMemory } = jiti("../src/atomic-memory.ts");
+  const { extractAutoCaptureCandidates, normalizeAndStoreAutoCaptureCandidates } = jiti("../src/auto-capture.ts");
+  const { createMemoryNormalizer } = jiti("../src/normalizer.ts");
+
+  const workDir = mkdtempSync(path.join(tmpdir(), "memory-lancedb-pro-normalizer-"));
+
+  try {
+    const store = new MemoryStore({ dbPath: path.join(workDir, "db"), vectorDim: 24 });
+    const embedder = {
+      async embedPassage(text) { return embedText(text); },
+      async embedQuery(text) { return embedText(text); },
+    };
+
+    const fetchImpl = async () => ({
+      ok: true,
+      async json() {
+        return {
+          choices: [{
+            message: {
+              content: JSON.stringify({
+                entries: [{
+                  canonicalText: "Decision: Codex ACP should use `acpx-with-proxy` so the ACP runtime always inherits Clash mixed-port 7897 when needed.",
+                  category: "decision",
+                  atomic: {
+                    unitType: "decision",
+                    sourceKind: "agent",
+                    confidence: 0.86,
+                    tags: ["Codex", "acpx-with-proxy", "proxy", "7897"],
+                  },
+                  reason: "technical_decision",
+                }],
+              }),
+            },
+          }],
+        };
+      },
+    });
+
+    const normalizer = createMemoryNormalizer({
+      enabled: true,
+      apiKey: "sk-test",
+      model: "Qwen/Qwen3-8B",
+      baseURL: "https://api.siliconflow.cn/v1/chat/completions",
+      temperature: 0.1,
+      maxTokens: 1200,
+      enableThinking: false,
+      timeoutMs: 3000,
+      maxEntriesPerCandidate: 3,
+      fallbackMode: "rules-then-raw",
+      audit: {
+        enabled: true,
+        logPath: path.join(workDir, "normalizer-audit.jsonl"),
+      },
+    }, undefined, { fetchImpl });
+
+    const messages = [
+      { role: "assistant", content: "决定：之后 Codex ACP 固定通过 acpx-with-proxy 走代理 7897，避免 websocket 超时。" },
+    ];
+
+    const candidates = extractAutoCaptureCandidates(messages, { captureAssistant: true });
+    assert.equal(candidates.length, 1);
+
+    const chatterCandidates = extractAutoCaptureCandidates([
+      { role: "assistant", content: "[[reply_to_current]] 我去看一下刚才那次运行的实际产出，等它跑完我继续帮你验。" },
+    ], { captureAssistant: true });
+    assert.equal(chatterCandidates.length, 0);
+
+    const stored = await normalizeAndStoreAutoCaptureCandidates({
+      candidates,
+      store,
+      embedder,
+      scope: "agent:main",
+      importance: 0.7,
+      limit: 3,
+      normalizer,
+      agentId: "main",
+    });
+
+    assert.equal(stored.length, 1);
+    assert.equal(
+      stored[0].text,
+      "Decision: Codex ACP should use acpx-with-proxy so the ACP runtime always inherits Clash mixed-port 7897 when needed.",
+    );
+    assert.notEqual(stored[0].text, messages[0].content);
+    assert.equal(extractAtomicMemory(stored[0].metadata)?.sourceKind, "agent");
+    assert.equal(extractAtomicMemory(stored[0].metadata)?.unitType, "decision");
+    const tags = extractAtomicMemory(stored[0].metadata)?.tags || [];
+    assert(tags.includes("acpx-with-proxy"));
+    assert(tags.includes("proxy"));
+    assert(tags.includes("7897"));
+
+    console.log("OK: normalizer auto-capture rewrite passed");
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error("FAIL: normalizer auto-capture rewrite failed");
+  console.error(error);
+  process.exit(1);
+});

--- a/test/normalizer-phase1-live-ab.mjs
+++ b/test/normalizer-phase1-live-ab.mjs
@@ -1,0 +1,372 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+
+function embedText(text, dim = 48) {
+  const vector = Array(dim).fill(0);
+  const tokens = String(text).toLowerCase().match(/[a-z0-9\u4e00-\u9fff._/-]+/g) || [];
+  for (const token of tokens) {
+    let hash = 0;
+    for (const char of token) hash = (hash * 33 + char.charCodeAt(0)) >>> 0;
+    vector[hash % dim] += 1;
+  }
+  const norm = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
+  return norm > 0 ? vector.map((value) => value / norm) : vector;
+}
+
+function getEnv(name) {
+  const value = process.env[name];
+  return value || "";
+}
+
+function readAudit(logPath) {
+  if (!existsSync(logPath)) return [];
+  const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
+  return lines.map((line) => JSON.parse(line));
+}
+
+function noiseLike(text) {
+  return /^(好的|明白了|收到|我确认了|好[的吧]?|okay|ok|understood|got it)/i.test(text)
+    || /要不要我|do you want me to|我现在|顺手|继续处理/.test(text);
+}
+
+function topHitMatches(result, expected) {
+  const text = result?.entry?.text || "";
+  return expected.some((snippet) => text.includes(snippet));
+}
+
+function countNoiseInResults(results) {
+  return results.filter((item) => noiseLike(item.entry.text)).length;
+}
+
+const CASES = [
+  {
+    id: "proxy-wrapper",
+    role: "assistant",
+    content: "决定：之后 Codex ACP 固定通过 acpx-with-proxy 走代理 7897，避免 websocket 超时。",
+    queries: [
+      { q: "Codex ACP 代理包装器", expected: ["acpx-with-proxy", "7897"] },
+      { q: "acpx-with-proxy", expected: ["acpx-with-proxy"] },
+    ],
+    anchors: ["acpx-with-proxy", "7897", "websocket"],
+  },
+  {
+    id: "reporting-preference",
+    role: "user",
+    content: "记住：我希望进度汇报里直接给结论，不要太散。",
+    queries: [
+      { q: "汇报偏好", expected: ["进度汇报里直接给结论"] },
+    ],
+    anchors: ["进度汇报", "结论"],
+  },
+  {
+    id: "gateway-path",
+    role: "user",
+    content: "重要：Gateway PATH 少了 node bin 会导致 skill eligibility 偏差。",
+    queries: [
+      { q: "Gateway PATH node bin", expected: ["Gateway PATH 少了 node bin"] },
+      { q: "skill eligibility 偏差", expected: ["skill eligibility 偏差"] },
+    ],
+    anchors: ["Gateway", "PATH", "node bin", "skill eligibility"],
+  },
+  {
+    id: "polling-stall",
+    role: "assistant",
+    content: "重要：Polling stall detected (no getUpdates for 96.36s); forcing restart",
+    queries: [
+      { q: "Polling stall detected", expected: ["Polling stall detected"] },
+      { q: "getUpdates forcing restart", expected: ["getUpdates", "forcing restart"] },
+    ],
+    anchors: ["Polling stall detected", "getUpdates", "forcing restart"],
+  },
+  {
+    id: "metadata-decision",
+    role: "assistant",
+    content: "决定：P3 先用 metadata 承载原子记忆。",
+    queries: [
+      { q: "metadata 承载原子记忆", expected: ["metadata 承载原子记忆"] },
+    ],
+    anchors: ["P3", "metadata", "原子记忆"],
+  },
+  {
+    id: "runtime-modelauth",
+    role: "assistant",
+    content: "决定：lossless-claw 在 OpenClaw 2026.3.8 缺 runtime.modelAuth，所以先走 legacy auth-profiles fallback。",
+    queries: [
+      { q: "runtime.modelAuth", expected: ["runtime.modelAuth"] },
+      { q: "lossless-claw fallback", expected: ["legacy auth-profiles fallback"] },
+    ],
+    anchors: ["lossless-claw", "runtime.modelAuth", "legacy auth-profiles fallback"],
+  },
+  {
+    id: "allowlist-miss",
+    role: "assistant",
+    content: "重要：exec denied: allowlist miss 的原因是 tools.exec.security 默认还是 allowlist，改成 full 即可。",
+    queries: [
+      { q: "allowlist miss", expected: ["allowlist miss"] },
+      { q: "tools.exec.security full", expected: ["tools.exec.security", "full"] },
+    ],
+    anchors: ["allowlist miss", "tools.exec.security", "full"],
+  },
+  {
+    id: "eisdir",
+    role: "assistant",
+    content: "重要：read failed: EISDIR 是因为把目录当文件读了，不是权限问题。",
+    queries: [
+      { q: "EISDIR 目录 read", expected: ["EISDIR"] },
+    ],
+    anchors: ["EISDIR", "目录", "文件"],
+  },
+  {
+    id: "minimax-rpm",
+    role: "assistant",
+    content: "重要：MiniMax-M2.5 的 429 rate limit exceeded(RPM) (1002) 是频率限制，不是余额不足。",
+    queries: [
+      { q: "RPM 1002", expected: ["RPM", "1002"] },
+      { q: "MiniMax 余额不足 频率限制", expected: ["频率限制", "余额不足"] },
+    ],
+    anchors: ["MiniMax-M2.5", "RPM", "1002", "余额不足"],
+  },
+  {
+    id: "practice-principle",
+    role: "assistant",
+    content: "重要原则：实践优先，准备充分后大胆尝试，不要长期停留在保守观望。要不要我现在顺手把实验方案也落下来？",
+    queries: [
+      { q: "实践优先 原则", expected: ["实践优先"] },
+    ],
+    anchors: ["实践优先", "大胆尝试", "保守观望"],
+  },
+];
+
+async function main() {
+  const { MemoryStore } = jiti("../src/store.ts");
+  const { createRetriever } = jiti("../src/retriever.ts");
+  const { extractAutoCaptureCandidates, storeAutoCaptureCandidates, normalizeAndStoreAutoCaptureCandidates } = jiti("../src/auto-capture.ts");
+  const { createMemoryNormalizer } = jiti("../src/normalizer.ts");
+
+  const workDir = mkdtempSync(path.join(tmpdir(), "memory-lancedb-pro-phase1-ab-"));
+  const rawDbPath = path.join(workDir, "raw-db");
+  const normalizedDbPath = path.join(workDir, "normalized-db");
+  const auditPath = path.join(workDir, "normalizer-audit.jsonl");
+
+  try {
+    const storeRaw = new MemoryStore({ dbPath: rawDbPath, vectorDim: 48 });
+    const storeNormalized = new MemoryStore({ dbPath: normalizedDbPath, vectorDim: 48 });
+    const embedder = {
+      async embedPassage(text) { return embedText(text); },
+      async embedQuery(text) { return embedText(text); },
+    };
+    const retrieverRaw = createRetriever(storeRaw, embedder, {
+      mode: "vector",
+      rerank: "none",
+      minScore: 0.1,
+      hardMinScore: 0.05,
+      filterNoise: false,
+    });
+    const retrieverNormalized = createRetriever(storeNormalized, embedder, {
+      mode: "vector",
+      rerank: "none",
+      minScore: 0.1,
+      hardMinScore: 0.05,
+      filterNoise: false,
+    });
+
+    const apiKey = getEnv("MEMORY_NORMALIZER_API_KEY");
+    if (!apiKey) {
+      console.log("SKIP: normalizer phase1 live A/B requires MEMORY_NORMALIZER_API_KEY");
+      return;
+    }
+
+    const normalizer = createMemoryNormalizer({
+      enabled: true,
+      apiKey,
+      model: process.env.MEMORY_NORMALIZER_MODEL || "Qwen/Qwen3-8B",
+      baseURL: process.env.MEMORY_NORMALIZER_BASE_URL || "https://api.siliconflow.cn/v1/chat/completions",
+      temperature: 0.1,
+      maxTokens: 1200,
+      enableThinking: false,
+      timeoutMs: 12000,
+      maxEntriesPerCandidate: 3,
+      fallbackMode: "rules-then-raw",
+      audit: {
+        enabled: true,
+        logPath: auditPath,
+      },
+    }, console);
+
+    const rawStored = [];
+    const normalizedStored = [];
+    const perCase = [];
+
+    for (const item of CASES) {
+      const messages = [{ role: item.role, content: item.content }];
+      const candidates = extractAutoCaptureCandidates(messages, { captureAssistant: true });
+      assert(candidates.length >= 1, `Expected candidate for case ${item.id}`);
+
+      const rawEntries = await storeAutoCaptureCandidates({
+        candidates,
+        store: storeRaw,
+        embedder,
+        scope: "global",
+        importance: 0.7,
+        limit: 3,
+      });
+
+      const normalizedEntries = await normalizeAndStoreAutoCaptureCandidates({
+        candidates,
+        store: storeNormalized,
+        embedder,
+        scope: "global",
+        importance: 0.7,
+        limit: 3,
+        normalizer,
+        agentId: "main",
+      });
+
+      rawStored.push(...rawEntries.map((entry) => ({ caseId: item.id, text: entry.text })));
+      normalizedStored.push(...normalizedEntries.map((entry) => ({ caseId: item.id, text: entry.text })));
+      perCase.push({
+        id: item.id,
+        source: item.content,
+        raw: rawEntries.map((entry) => entry.text),
+        normalized: normalizedEntries.map((entry) => entry.text),
+      });
+    }
+
+    const audits = readAudit(auditPath);
+    const fallbackCounts = audits.reduce((acc, record) => {
+      const key = record.fallback || "llm";
+      acc[key] = (acc[key] || 0) + 1;
+      return acc;
+    }, {});
+
+    let rawTop1Hits = 0;
+    let rawTop3Hits = 0;
+    let normalizedTop1Hits = 0;
+    let normalizedTop3Hits = 0;
+    let rawNoiseAt3 = 0;
+    let normalizedNoiseAt3 = 0;
+
+    const queryResults = [];
+
+    for (const item of CASES) {
+      for (const query of item.queries) {
+        const rawResults = await retrieverRaw.retrieve({ query: query.q, limit: 3, scopeFilter: ["global"] });
+        const normalizedResults = await retrieverNormalized.retrieve({ query: query.q, limit: 3, scopeFilter: ["global"] });
+
+        if (topHitMatches(rawResults[0], query.expected)) rawTop1Hits += 1;
+        if (rawResults.some((result) => topHitMatches(result, query.expected))) rawTop3Hits += 1;
+        if (topHitMatches(normalizedResults[0], query.expected)) normalizedTop1Hits += 1;
+        if (normalizedResults.some((result) => topHitMatches(result, query.expected))) normalizedTop3Hits += 1;
+
+        rawNoiseAt3 += countNoiseInResults(rawResults);
+        normalizedNoiseAt3 += countNoiseInResults(normalizedResults);
+
+        queryResults.push({
+          caseId: item.id,
+          query: query.q,
+          expected: query.expected,
+          rawTop: rawResults.map((result) => result.entry.text),
+          normalizedTop: normalizedResults.map((result) => result.entry.text),
+        });
+      }
+    }
+
+    const normalizedTopEntryByCase = new Map(
+      perCase.map((item) => [item.id, item.normalized[0] || ""])
+    );
+    const rawTopEntryByCase = new Map(
+      perCase.map((item) => [item.id, item.raw[0] || ""])
+    );
+
+    const rewriteCount = CASES.filter((item) => {
+      const raw = rawTopEntryByCase.get(item.id) || "";
+      const normalized = normalizedTopEntryByCase.get(item.id) || "";
+      return raw && normalized && raw !== normalized;
+    }).length;
+
+    const ackReducedCount = CASES.filter((item) => {
+      const raw = rawTopEntryByCase.get(item.id) || "";
+      const normalized = normalizedTopEntryByCase.get(item.id) || "";
+      return noiseLike(raw) && !noiseLike(normalized);
+    }).length;
+
+    const anchorPreservedCount = CASES.filter((item) => {
+      const normalized = normalizedTopEntryByCase.get(item.id) || "";
+      const lower = normalized.toLowerCase();
+      return item.anchors.every((anchor) => lower.includes(anchor.toLowerCase()));
+    }).length;
+
+    const totalQueries = CASES.reduce((sum, item) => sum + item.queries.length, 0);
+
+    const summary = {
+      cases: CASES.length,
+      totalQueries,
+      rawStoredCount: rawStored.length,
+      normalizedStoredCount: normalizedStored.length,
+      rewriteCount,
+      ackReducedCount,
+      anchorPreservedCount,
+      fallbackCounts,
+      rawTop1HitRate: Number((rawTop1Hits / totalQueries).toFixed(3)),
+      rawTop3HitRate: Number((rawTop3Hits / totalQueries).toFixed(3)),
+      normalizedTop1HitRate: Number((normalizedTop1Hits / totalQueries).toFixed(3)),
+      normalizedTop3HitRate: Number((normalizedTop3Hits / totalQueries).toFixed(3)),
+      rawNoiseAt3,
+      normalizedNoiseAt3,
+    };
+
+    const outputDir = process.env.NORMALIZER_AB_OUTPUT_DIR || "/Users/victor/.openclaw/backups/memory-experiments";
+    await mkdir(outputDir, { recursive: true });
+
+    const jsonPath = path.join(outputDir, "normalizer-phase1-live-ab-20260315.json");
+    const mdPath = path.join(outputDir, "normalizer-phase1-live-ab-20260315.md");
+    await writeFile(jsonPath, JSON.stringify({ summary, perCase, queryResults, audits }, null, 2), "utf8");
+
+    const md = [
+      "# Memory Normalizer Phase 1 Live A/B",
+      "",
+      `- Cases: ${summary.cases}`,
+      `- Queries: ${summary.totalQueries}`,
+      `- Raw stored count: ${summary.rawStoredCount}`,
+      `- Normalized stored count: ${summary.normalizedStoredCount}`,
+      `- Rewrite count: ${summary.rewriteCount}`,
+      `- Ack reduced count: ${summary.ackReducedCount}`,
+      `- Anchor preserved count: ${summary.anchorPreservedCount}/${summary.cases}`,
+      `- Fallback counts: ${JSON.stringify(summary.fallbackCounts)}`,
+      `- Raw Top1 hit rate: ${summary.rawTop1HitRate}`,
+      `- Raw Top3 hit rate: ${summary.rawTop3HitRate}`,
+      `- Normalized Top1 hit rate: ${summary.normalizedTop1HitRate}`,
+      `- Normalized Top3 hit rate: ${summary.normalizedTop3HitRate}`,
+      `- Raw Noise@3: ${summary.rawNoiseAt3}`,
+      `- Normalized Noise@3: ${summary.normalizedNoiseAt3}`,
+      "",
+      "## Per-case examples",
+      ...perCase.flatMap((item) => [
+        `### ${item.id}`,
+        `- Source: ${item.source}`,
+        `- Raw: ${item.raw.join(" | ") || "(none)"}`,
+        `- Normalized: ${item.normalized.join(" | ") || "(none)"}`,
+        "",
+      ]),
+    ].join("\n");
+    await writeFile(mdPath, md, "utf8");
+
+    console.log(jsonPath);
+    console.log(mdPath);
+    console.log(JSON.stringify(summary, null, 2));
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error("FAIL: normalizer phase1 live A/B failed");
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a configurable memory normalizer pipeline with audit logging and rule/raw fallbacks
- route `memory_store` and regex auto-capture writes through atomic metadata aware normalization
- add governance/normalizer CLI surfaces plus targeted regression tests

## What Changed
- introduced `src/normalizer.ts` plus normalization rule/validation/types helpers
- added atomic metadata utilities and governance reporting helpers used by CLI/tool outputs
- updated `index.ts` to initialize the normalizer from plugin config and use it in auto-capture fallback
- updated `src/tools.ts` so `memory_store` can accept atomic input or normalize free-form candidate text before persistence
- extended `openclaw.plugin.json` with normalization settings
- added tests for `memory_store` normalization, auto-capture normalization, and a live A/B harness

## Validation
- `node test/memory-store-normalizer.mjs`
- `node test/normalizer-auto-capture.mjs`
- `node test/cli-smoke.mjs`
- `node test/plugin-manifest-regression.mjs`
- `node test/normalizer-phase1-live-ab.mjs` (skips unless `MEMORY_NORMALIZER_API_KEY` is set)

## Notes
- this branch is rebased onto `CortexReach/master` and intentionally excludes the earlier local stable-merge history
