### PR TITLE
fix: default agentId to 'main' in memory_list and memory_stats

### DIFF
--- a/test/runtime-agent-id-defaults.test.mjs
+++ b/test/runtime-agent-id-defaults.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("../src/tools.ts", import.meta.url), "utf8");
+
+test("resolveRuntimeAgentId has a central main fallback", () => {
+  assert.match(
+    source,
+    /function resolveRuntimeAgentId\([\s\S]*?\): string \{[\s\S]*?return fallback \|\| "main";[\s\S]*?const resolved = ctxAgentId \|\| parseAgentIdFromSessionKey\(ctxSessionKey\) \|\| staticAgentId;[\s\S]*?return trimmed \? trimmed : "main";/,
+  );
+});
+
+test("caller-level main fallbacks were removed from memory_forget and memory_update", () => {
+  assert.doesNotMatch(
+    source,
+    /resolveRuntimeAgentId\(context\.agentId, runtimeCtx\) \|\| 'main'/,
+  );
+});
+
+test("memory_stats and memory_list use the central runtime agent resolver", () => {
+  assert.match(source, /name: "memory_stats"[\s\S]*?const agentId = resolveRuntimeAgentId\(context\.agentId, runtimeCtx\);/);
+  assert.match(source, /name: "memory_list"[\s\S]*?const agentId = resolveRuntimeAgentId\(context\.agentId, runtimeCtx\);/);
+});


### PR DESCRIPTION
## Summary
- default unresolved runtime `agentId` to `'main'` in `memory_stats`
- default unresolved runtime `agentId` to `'main'` in `memory_list`

## Why
On some runtime paths `resolveRuntimeAgentId(...)` can be `undefined`, which makes scope resolution fall back incorrectly and leads to empty / broken `memory_stats` and `memory_list` results even when memories exist in `agent:main`.

## Validation
- local runtime verified: `memory_stats` restored from 0 to correct counts
- local runtime verified: `memory_list` working again
- local runtime verified: `memory_recall` healthy after full restart

## Notes
This clean PR supersedes #187, which was opened against the obsolete `main-legacy` base and now shows a large unrelated diff.
