### PR TITLE
revert: undo #221 (store.close flush)

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -495,11 +495,6 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
           }
         }
 
-        // Close store to flush pending writes
-        if (context.store.close) {
-          await context.store.close();
-        }
-
         console.log(`Import completed: ${imported} imported, ${skipped} skipped`);
       } catch (error) {
         console.error("Import failed:", error);

--- a/src/store.ts
+++ b/src/store.ts
@@ -984,20 +984,6 @@ export class MemoryStore {
     return this._lastFtsError;
   }
 
-  /** Close the database connection and flush pending writes. */
-  async close(): Promise<void> {
-    if (this.table) {
-      try {
-        await this.table.optimize();
-        await this.table.close();
-      } catch {
-        // Ignore close errors
-      }
-      this.table = undefined;
-      this.initPromise = null;
-    }
-  }
-
   /** Get FTS index health status */
   getFtsStatus(): { available: boolean; lastError: string | null } {
     return {


### PR DESCRIPTION
## Summary

Reverts #221.

The stated root cause ("LanceDB writes are asynchronous and not flushed") is incorrect. `importEntry()` already `await`s `table.add()`, so data is persisted when the Promise resolves. `table.optimize()` is a compaction/index operation, not a write flush. `table.close()` releases file handles, not data durability.

The change is not harmful but is based on a false premise and adds unnecessary code to the critical path.