### PR TITLE
fix: add /opt/homebrew extensionAPI fallback

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -345,6 +345,7 @@ function getExtensionApiImportSpecifiers(): string[] {
 
   specifiers.push(toImportSpecifier("/usr/lib/node_modules/openclaw/dist/extensionAPI.js"));
   specifiers.push(toImportSpecifier("/usr/local/lib/node_modules/openclaw/dist/extensionAPI.js"));
+  specifiers.push(toImportSpecifier("/opt/homebrew/lib/node_modules/openclaw/dist/extensionAPI.js"));
 
   return [...new Set(specifiers.filter(Boolean))];
 }


### PR DESCRIPTION
## Summary
- add `/opt/homebrew/lib/node_modules/openclaw/dist/extensionAPI.js` to the dynamic import fallback list
- preserve compatibility with Apple Silicon macOS installs where OpenClaw is installed via Homebrew

## Why
The plugin already tries common global install locations such as `/usr/lib/...` and `/usr/local/...`, but Homebrew on Apple Silicon uses `/opt/homebrew/...`.

Without this fallback, the plugin can fail to resolve `openclaw/dist/extensionAPI.js` in some Homebrew-based deployments even though the file exists on disk.

## Validation
- `npm test` ✅
- verified local Homebrew install path exists on macOS Apple Silicon ✅
