### PR TITLE
fix: prevent hang with long messages by truncating queries and adding…

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ import { createMigrator } from "./src/migrate.js";
 import { registerAllMemoryTools } from "./src/tools.js";
 import { appendSelfImprovementEntry, ensureSelfImprovementLearningFiles } from "./src/self-improvement-files.js";
 import type { MdMirrorWriter } from "./src/tools.js";
-import { shouldSkipRetrieval } from "./src/adaptive-retrieval.js";
+import { shouldSkipRetrieval, isQueryTooLongForRecall } from "./src/adaptive-retrieval.js";
 import { runWithReflectionTransientRetryOnce } from "./src/reflection-retry.js";
 import { resolveReflectionSessionSearchDirs, stripResetSuffix } from "./src/session-recovery.js";
 import {
@@ -79,6 +79,7 @@ interface PluginConfig {
   autoRecall?: boolean;
   autoRecallMinLength?: number;
   autoRecallMinRepeated?: number;
+  autoRecallMaxQueryChars?: number;
   captureAssistant?: boolean;
   retrieval?: {
     mode?: "hybrid" | "vector";
@@ -2076,10 +2077,17 @@ const memoryLanceDBProPlugin = {
     // Default is OFF to prevent the model from accidentally echoing injected context.
     if (config.autoRecall === true) {
       api.on("before_agent_start", async (event, ctx) => {
-        if (
-          !event.prompt ||
-          shouldSkipRetrieval(event.prompt, config.autoRecallMinLength)
-        ) {
+        // Skip if no prompt, too short, or too long
+        if (!event.prompt) return;
+        
+        // Check max query length to prevent context overflow
+        const maxQueryChars = config.autoRecallMaxQueryChars ?? 4000;
+        if (maxQueryChars > 0 && isQueryTooLongForRecall(event.prompt, maxQueryChars)) {
+          api.logger.debug?.(`memory-lancedb-pro: skipping auto-recall for long prompt (${event.prompt.length} chars, max ${maxQueryChars})`);
+          return;
+        }
+        
+        if (shouldSkipRetrieval(event.prompt, config.autoRecallMinLength)) {
           return;
         }
 
@@ -3372,6 +3380,7 @@ export function parsePluginConfig(value: unknown): PluginConfig {
     autoRecall: cfg.autoRecall === true,
     autoRecallMinLength: parsePositiveInt(cfg.autoRecallMinLength),
     autoRecallMinRepeated: parsePositiveInt(cfg.autoRecallMinRepeated),
+    autoRecallMaxQueryChars: parsePositiveInt(cfg.autoRecallMaxQueryChars) ?? 4000,
     captureAssistant: cfg.captureAssistant === true,
     retrieval: typeof cfg.retrieval === "object" && cfg.retrieval !== null ? cfg.retrieval as any : undefined,
     decay: typeof cfg.decay === "object" && cfg.decay !== null ? cfg.decay as any : undefined,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -105,6 +105,13 @@
         "default": 0,
         "description": "Minimum number of turns before the same memory can be recalled again in the same session. Set to 0 to disable deduplication (default behavior: inject all memories)."
       },
+      "autoRecallMaxQueryChars": {
+        "type": "integer",
+        "minimum": 100,
+        "maximum": 100000,
+        "default": 4000,
+        "description": "Maximum prompt length (in characters) to trigger auto-recall. Prompts longer than this will skip auto-recall to prevent context overflow. Default: 4000. Set to 0 to disable."
+      },
       "captureAssistant": {
         "type": "boolean"
       },
@@ -616,6 +623,11 @@
     "autoRecallMinRepeated": {
       "label": "Auto-Recall Min Repeated",
       "help": "Minimum number of conversation turns before a specific memory can be re-injected in the same session.",
+      "advanced": true
+    },
+    "autoRecallMaxQueryChars": {
+      "label": "Auto-Recall Max Query Chars",
+      "help": "Maximum prompt length to trigger auto-recall. Longer prompts skip auto-recall to prevent context overflow. Default: 4000 chars.",
       "advanced": true
     },
     "captureAssistant": {

--- a/src/adaptive-retrieval.ts
+++ b/src/adaptive-retrieval.ts
@@ -95,3 +95,26 @@ export function shouldSkipRetrieval(query: string, minLength?: number): boolean 
   // Default: do retrieve
   return false;
 }
+
+/**
+ * Truncate query for embedding to avoid context overflow.
+ * Long pastes don't need full-text embedding - first 512 chars are sufficient for recall.
+ * @param query The raw query text
+ * @param maxChars Maximum characters to keep (default: 512)
+ * @returns Truncated query
+ */
+export function truncateQueryForEmbedding(query: string, maxChars: number = 512): string {
+  if (query.length <= maxChars) return query;
+  return query.slice(0, maxChars);
+}
+
+/**
+ * Check if query exceeds max length threshold for auto-recall.
+ * Returns true if query is too long and recall should be skipped.
+ * @param query The raw prompt text
+ * @param maxChars Maximum characters allowed (default: 4000)
+ */
+export function isQueryTooLongForRecall(query: string, maxChars: number = 4000): boolean {
+  const normalized = normalizeQuery(query);
+  return normalized.length > maxChars;
+}

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -11,6 +11,7 @@ import {
   parseAccessMetadata,
 } from "./access-tracker.js";
 import { filterNoise } from "./noise-filter.js";
+import { truncateQueryForEmbedding } from "./adaptive-retrieval.js";
 import type { DecayEngine, DecayableMemory } from "./decay-engine.js";
 import type { TierManager } from "./tier-manager.js";
 import {
@@ -407,7 +408,9 @@ export class MemoryRetriever {
     scopeFilter?: string[],
     category?: string,
   ): Promise<RetrievalResult[]> {
-    const queryVector = await this.embedder.embedQuery(query);
+    // Truncate query for embedding to avoid context overflow with long messages
+    const truncatedQuery = truncateQueryForEmbedding(query);
+    const queryVector = await this.embedder.embedQuery(truncatedQuery);
     const results = await this.store.vectorSearch(
       queryVector,
       limit,
@@ -459,7 +462,9 @@ export class MemoryRetriever {
     );
 
     // Compute query embedding once, reuse for vector search + reranking
-    const queryVector = await this.embedder.embedQuery(query);
+    // Truncate query for embedding to avoid context overflow with long messages
+    const truncatedQuery = truncateQueryForEmbedding(query);
+    const queryVector = await this.embedder.embedQuery(truncatedQuery);
 
     // Run vector and BM25 searches in parallel
     const [vectorResults, bm25Results] = await Promise.all([


### PR DESCRIPTION
… max length skip

- Add truncateQueryForEmbedding() to limit embedding queries to 512 chars
- Add isQueryTooLongForRecall() to skip auto-recall for very long prompts
- Add new config autoRecallMaxQueryChars (default: 4000) to control max prompt length
- Update retriever.ts to use query truncation before embedding

Fixes #244