### PR TITLE
fix: prevent LanceDB runtime install failures on macOS x64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "commander": "^14.0.0",
         "jiti": "^2.6.0",
         "typescript": "^5.9.3"
+      },
+      "optionalDependencies": {
+        "@lancedb/lancedb-darwin-x64": "0.26.2"
       }
     },
     "node_modules/@lancedb/lancedb": {
@@ -69,6 +72,9 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/@lancedb/lancedb-darwin-x64": {
+      "optional": true
     },
     "node_modules/@lancedb/lancedb-linux-arm64-gnu": {
       "version": "0.26.2",
@@ -222,7 +228,6 @@
       "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-18.1.0.tgz",
       "integrity": "sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/command-line-args": "^5.2.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "json5": "^2.2.3",
     "openai": "^6.21.0"
   },
+  "optionalDependencies": {
+    "@lancedb/lancedb-darwin-x64": "0.26.2"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -106,6 +106,11 @@ assert.equal(
   "18.1.0",
   "package.json should declare apache-arrow directly so OpenClaw plugin installs do not miss the LanceDB runtime dependency",
 );
+assert.equal(
+  pkg.optionalDependencies?.["@lancedb/lancedb-darwin-x64"],
+  pkg.dependencies["@lancedb/lancedb"].replace(/^[~^]/, ""),
+  "package.json should declare the missing LanceDB Intel macOS native package so x64 installs do not fail at runtime",
+);
 
 const workDir = mkdtempSync(path.join(tmpdir(), "memory-plugin-regression-"));
 const services = [];


### PR DESCRIPTION
## Summary
  - update `package-lock.json`
  - add a regression check to keep the darwin-x64 native package aligned with the pinned `@lancedb/lancedb` version

  ## Why

  `@lancedb/lancedb@0.26.2` can try to load `@lancedb/lancedb-darwin-x64` on macOS x64, but that package is not declared upstream in its optional dependencies.
  This can make installs succeed but fail later at runtime with `Cannot find module '@lancedb/lancedb-darwin-x64'`.

  ## Verification

  - `npm install --package-lock-only --ignore-scripts`
  - `node --test test/sync-plugin-version.test.mjs`