### PR TITLE
fix: use resolveToolContext for scope resolution in forget/update/stats/list tools

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -760,7 +760,7 @@ export function registerMemoryForgetTool(
 ) {
   api.registerTool(
     (toolCtx) => {
-      const agentId = resolveAgentId((toolCtx as any)?.agentId, context.agentId) ?? "main";
+      const runtimeContext = resolveToolContext(context, toolCtx);
       return {
         name: "memory_forget",
       label: "Memory Forget",
@@ -787,7 +787,7 @@ export function registerMemoryForgetTool(
         };
 
         try {
-          const agentId = resolveRuntimeAgentId(context.agentId, runtimeCtx);
+          const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
           // Determine accessible scopes
           let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
           if (scope) {
@@ -920,7 +920,7 @@ export function registerMemoryUpdateTool(
 ) {
   api.registerTool(
     (toolCtx) => {
-      const agentId = resolveAgentId((toolCtx as any)?.agentId, context.agentId) ?? "main";
+      const runtimeContext = resolveToolContext(context, toolCtx);
       return {
         name: "memory_update",
       label: "Memory Update",
@@ -963,7 +963,7 @@ export function registerMemoryUpdateTool(
           }
 
           // Determine accessible scopes
-          const agentId = resolveRuntimeAgentId(context.agentId, runtimeCtx);
+          const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
           const scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
 
           // Resolve memoryId: if it doesn't look like a UUID, try search
@@ -1184,7 +1184,7 @@ export function registerMemoryStatsTool(
 ) {
   api.registerTool(
     (toolCtx) => {
-      const agentId = resolveAgentId((toolCtx as any)?.agentId, context.agentId) ?? "main";
+      const runtimeContext = resolveToolContext(context, toolCtx);
       return {
         name: "memory_stats",
       label: "Memory Statistics",
@@ -1200,7 +1200,7 @@ export function registerMemoryStatsTool(
         const { scope } = params as { scope?: string };
 
         try {
-          const agentId = resolveRuntimeAgentId(context.agentId, runtimeCtx);
+          const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
           // Determine accessible scopes
           let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
           if (scope) {
@@ -1277,7 +1277,7 @@ export function registerMemoryListTool(
 ) {
   api.registerTool(
     (toolCtx) => {
-      const agentId = resolveAgentId((toolCtx as any)?.agentId, context.agentId) ?? "main";
+      const runtimeContext = resolveToolContext(context, toolCtx);
       return {
         name: "memory_list",
       label: "Memory List",
@@ -1315,7 +1315,7 @@ export function registerMemoryListTool(
         try {
           const safeLimit = clampInt(limit, 1, 50);
           const safeOffset = clampInt(offset, 0, 1000);
-          const agentId = resolveRuntimeAgentId(context.agentId, runtimeCtx);
+          const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
 
           // Determine accessible scopes
           let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);


### PR DESCRIPTION
## Problem

The `memory_forget`, `memory_update`, `memory_stats`, and `memory_list` tools fail with **"outside accessible scopes"** errors (or return empty results) when the agent's memories are stored under an agent-specific scope like `agent:main`.

### Root Cause

These four tools use an inconsistent agentId resolution pattern compared to `memory_recall` and `memory_store`:

| Tool | Closure pattern | execute() pattern | Works? |
|------|----------------|-------------------|--------|
| `memory_recall` | `resolveToolContext(context, toolCtx)` | `runtimeContext.agentId` | ✅ |
| `memory_store` | `resolveToolContext(context, toolCtx)` | `runtimeContext.agentId` | ✅ |
| `memory_forget` | `resolveAgentId(toolCtx...)` (unused) | `resolveRuntimeAgentId(context.agentId, ...)` | ❌ |
| `memory_update` | `resolveAgentId(toolCtx...)` (unused) | `resolveRuntimeAgentId(context.agentId, ...)` | ❌ |
| `memory_stats` | `resolveAgentId(toolCtx...)` (unused) | `resolveRuntimeAgentId(context.agentId, ...)` | ❌ |
| `memory_list` | `resolveAgentId(toolCtx...)` (unused) | `resolveRuntimeAgentId(context.agentId, ...)` | ❌ |

The broken tools resolve agentId in the closure via `resolveAgentId` but then **shadow it** inside `execute()` with `resolveRuntimeAgentId(context.agentId, runtimeCtx)`. Since `context.agentId` is often `undefined` at the static ToolContext level, and `runtimeCtx` (the 5th execute parameter) may not carry agentId either, the final resolved agentId becomes `undefined`.

When `getAccessibleScopes(undefined)` is called, it returns only globally-configured scopes (e.g. `["global"]`), **missing the agent-specific scope** (`agent:main`). This causes:
- `memory_update` / `memory_forget` (by ID): "outside accessible scopes" error
- `memory_stats` / `memory_list`: return 0 results / empty

## Fix

Use `resolveToolContext(context, toolCtx)` in the closure — the same pattern already used by `memory_recall` and `memory_store` — so that `runtimeContext.agentId` is correctly resolved from the tool context, then passed through `resolveRuntimeAgentId` for final resolution inside `execute()`.

## Changes

- `src/tools.ts`: 8 lines changed across 4 tool registration functions
  - Replace `resolveAgentId((toolCtx as any)?.agentId, context.agentId)` with `resolveToolContext(context, toolCtx)`
  - Replace `resolveRuntimeAgentId(context.agentId, runtimeCtx)` with `resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx)`

## Testing

Verified on OpenClaw with memory-lancedb-pro v1.1.0-beta.9:
- Before fix: `memory_update` and `memory_forget` (by ID) always fail; `memory_stats` and `memory_list` return empty without explicit scope parameter
- After fix: All 6 tools work correctly with automatic scope resolution