### PR TITLE
fix: use require() for LanceDB to fix Windows ESM URL scheme error

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -55,7 +55,8 @@ export const loadLanceDB = async (): Promise<
   typeof import("@lancedb/lancedb")
 > => {
   if (!lancedbImportPromise) {
-    lancedbImportPromise = import("@lancedb/lancedb");
+    // Use require() for CommonJS modules on Windows to avoid ESM URL scheme issues
+    lancedbImportPromise = Promise.resolve(require("@lancedb/lancedb"));
   }
   try {
     return await lancedbImportPromise;


### PR DESCRIPTION
## Problem

On Windows, memory-lancedb-pro fails to load with the following error:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

## Root Cause

- LanceDB is a CommonJS module with native bindings (`.node` files)
- The dynamic `import()` call goes through Node.js ESM loader
- On Windows, the ESM loader cannot handle Windows paths (C:\...) without proper URL encoding

## Solution

Use `require()` instead of `import()` for loading LanceDB:
- `require()` bypasses the ESM loader
- CommonJS modules work correctly with native bindings on Windows

## Changes

```diff
- lancedbImportPromise = import("@lancedb/lancedb");
+ // Use require() for CommonJS modules on Windows to avoid ESM URL scheme issues
+ lancedbImportPromise = Promise.resolve(require("@lancedb/lancedb"));
```

## Testing

Tested on Windows 11 with OpenClaw:
- Before: `openclaw memory-pro stats` → Error
- After: `openclaw memory-pro stats` → Works correctly

Fixes Windows compatibility for memory-lancedb-pro plugin.