### PR TITLE
fix: support agent-scoped memory update/forget paths

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -684,11 +684,7 @@ export class MemoryStore {
     const rowScope = (candidates[0].scope as string | undefined) ?? "global";
 
     // Check scope permissions
-    if (
-      scopeFilter &&
-      scopeFilter.length > 0 &&
-      !scopeFilter.includes(rowScope)
-    ) {
+    if (!scopeFilterAllows(scopeFilter, rowScope)) {
       throw new Error(`Memory ${resolvedId} is outside accessible scopes`);
     }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -964,7 +964,22 @@ export function registerMemoryUpdateTool(
 
           // Determine accessible scopes
           const agentId = resolveRuntimeAgentId(context.agentId, runtimeCtx);
-          const scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
+          let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
+          if (scope) {
+            if (context.scopeManager.isAccessible(scope, agentId)) {
+              scopeFilter = [scope];
+            } else {
+              return {
+                content: [
+                  { type: "text", text: `Access denied to scope: ${scope}` },
+                ],
+                details: {
+                  error: "scope_access_denied",
+                  requestedScope: scope,
+                },
+              };
+            }
+          }
 
           // Resolve memoryId: if it doesn't look like a UUID, try search
           let resolvedId = memoryId;


### PR DESCRIPTION
## Summary

Fix agent-scoped `memory_update` / `memory_forget` failures caused by inconsistent scope handling on exact-ID management paths.

This PR implements the same direction discussed in the existing bug reports:
- add an optional `scope` parameter to `memory_update`
- normalize scope comparison in the store layer so exact-ID delete/update paths do not reject accessible agent-scoped rows due to inconsistent scope matching

## Background

There are already multiple reports that agent-scoped memories (for example `agent:main`) can be:
- stored successfully
- recalled successfully
- listed / counted successfully
- but then rejected by `memory_update` or `memory_forget(memoryId=...)` with:

```text
Memory <id> is outside accessible scopes
```

Related issues:
- #231
- #266

## Root cause

Two things were off:

1. `memory_update` had no way to accept an explicit `scope`, even though the existing discussion pointed to that as part of the fix direction.
2. The exact-ID management path in `store.ts` compared scope strings with a direct `includes(rowScope)` check, instead of using a normalized comparison path.

That made the write/read path and the exact-ID management path behave inconsistently for agent-scoped rows.

## What changed

### 1) `memory_update` now accepts optional `scope`

Tool schema and execution now support:

```json
{
  "memoryId": "...",
  "text": "...",
  "scope": "agent:main"
}
```

If `scope` is provided:
- access is validated through `scopeManager.isAccessible(scope, agentId)`
- `scopeFilter` is narrowed to `[scope]`

This matches the direction already discussed in #231.

### 2) normalize scope checks in exact-ID store paths

Added a small helper in `src/store.ts`:
- `normalizeScopeId(...)`
- `scopeFilterAllows(scopeFilter, rowScope)`

Then reused that helper in the exact-ID management checks so these paths use normalized scope matching instead of a raw `includes(rowScope)` string comparison:
- `delete(...)`
- `update(...)`

## Why this PR is intentionally small

I kept this PR minimal on purpose:
- no config/schema redesign
- no behavior changes outside the failing management path
- no broad scope-system refactor

The goal is only to make agent-scoped update/delete behave consistently with store/recall/list/stats.

## Validation

### Real-world validation (Windows / OpenClaw 2026.3.13-1 / beta.9)

I validated the same fix direction on a live OpenClaw setup using:
- memory-lancedb-pro `1.1.0-beta.9`
- OpenClaw `2026.3.13-1`
- scope `agent:main`

Observed after patch:
- `memory_store` ✅
- `memory_recall` ✅
- `memory_update(..., scope: "agent:main")` ✅
- `memory_forget(memoryId=...)` ✅

### Repo tests run

Passed locally in this PR branch:
- `node --test test/scope-access-undefined.test.mjs`
- `node test/memory-update-supersede.test.mjs`

## Notes

This PR does **not** attempt to redesign all scope handling everywhere. It only closes the specific inconsistency affecting exact-ID management for agent-scoped memories.

If you want, I can follow up with dedicated regression tests that explicitly cover:
- `memory_update` on `agent:main`
- `memory_forget(memoryId=...)` on `agent:main`
- with and without explicit `scope`
