### PR TITLE
fix: handle array apiKey in LLM client init and add missing json5 dep

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -207,6 +207,14 @@ function resolveEnvVars(value: string): string {
   });
 }
 
+function resolveFirstApiKey(apiKey: string | string[]): string {
+  const key = Array.isArray(apiKey) ? apiKey[0] : apiKey;
+  if (!key) {
+    throw new Error("embedding.apiKey is empty");
+  }
+  return resolveEnvVars(key);
+}
+
 function resolveOptionalPathWithEnv(
   api: Pick<OpenClawPluginApi, "resolvePath">,
   value: string | undefined,
@@ -1672,7 +1680,7 @@ const memoryLanceDBProPlugin = {
           ? undefined
           : config.llm?.apiKey
             ? resolveEnvVars(config.llm.apiKey)
-            : resolveEnvVars(config.embedding.apiKey);
+            : resolveFirstApiKey(config.embedding.apiKey);
         const llmBaseURL = llmAuth === "oauth"
           ? (config.llm?.baseURL ? resolveEnvVars(config.llm.baseURL) : undefined)
           : config.llm?.baseURL
@@ -2040,7 +2048,7 @@ const memoryLanceDBProPlugin = {
               ? undefined
               : config.llm?.apiKey
                 ? resolveEnvVars(config.llm.apiKey)
-                : resolveEnvVars(config.embedding.apiKey);
+                : resolveFirstApiKey(config.embedding.apiKey);
             const llmBaseURL = llmAuth === "oauth"
               ? (config.llm?.baseURL ? resolveEnvVars(config.llm.baseURL) : undefined)
               : config.llm?.baseURL

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@lancedb/lancedb": "^0.26.2",
         "@sinclair/typebox": "0.34.48",
         "apache-arrow": "18.1.0",
+        "json5": "^2.2.3",
         "openai": "^6.21.0"
       },
       "devDependencies": {
@@ -395,6 +396,18 @@
       "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@lancedb/lancedb": "^0.26.2",
     "@sinclair/typebox": "0.34.48",
     "apache-arrow": "18.1.0",
+    "json5": "^2.2.3",
     "openai": "^6.21.0"
   },
   "openclaw": {
@@ -36,7 +37,7 @@
     ]
   },
   "scripts": {
-    "test": "node test/embedder-error-hints.test.mjs && node test/cjk-recursion-regression.test.mjs && node test/migrate-legacy-schema.test.mjs && node --test test/config-session-strategy-migration.test.mjs && node --test test/scope-access-undefined.test.mjs && node --test test/reflection-bypass-hook.test.mjs && node --test test/smart-extractor-scope-filter.test.mjs && node --test test/store-empty-scope-filter.test.mjs && node --test test/recall-text-cleanup.test.mjs && node test/update-consistency-lancedb.test.mjs && node --test test/strip-envelope-metadata.test.mjs && node test/cli-smoke.mjs && node test/functional-e2e.mjs && node test/retriever-rerank-regression.mjs && node test/smart-memory-lifecycle.mjs && node test/smart-extractor-branches.mjs && node test/plugin-manifest-regression.mjs && node --test test/sync-plugin-version.test.mjs && node test/smart-metadata-v2.mjs && node test/vector-search-cosine.test.mjs && node test/context-support-e2e.mjs && node test/temporal-facts.test.mjs && node test/memory-update-supersede.test.mjs && node test/memory-upgrader-diagnostics.test.mjs && node --test test/llm-api-key-client.test.mjs && node --test test/llm-oauth-client.test.mjs && node --test test/cli-oauth-login.test.mjs && node --test test/workflow-fork-guards.test.mjs",
+    "test": "node test/embedder-error-hints.test.mjs && node test/cjk-recursion-regression.test.mjs && node test/migrate-legacy-schema.test.mjs && node --test test/config-session-strategy-migration.test.mjs && node --test test/scope-access-undefined.test.mjs && node --test test/reflection-bypass-hook.test.mjs && node --test test/smart-extractor-scope-filter.test.mjs && node --test test/store-empty-scope-filter.test.mjs && node --test test/recall-text-cleanup.test.mjs && node test/update-consistency-lancedb.test.mjs && node --test test/strip-envelope-metadata.test.mjs && node test/cli-smoke.mjs && node test/functional-e2e.mjs && node test/retriever-rerank-regression.mjs && node test/smart-memory-lifecycle.mjs && node test/smart-extractor-branches.mjs && node test/plugin-manifest-regression.mjs && node --test test/sync-plugin-version.test.mjs && node test/smart-metadata-v2.mjs && node test/vector-search-cosine.test.mjs && node test/context-support-e2e.mjs && node test/temporal-facts.test.mjs && node test/memory-update-supersede.test.mjs && node test/memory-upgrader-diagnostics.test.mjs && node --test test/llm-api-key-client.test.mjs && node --test test/llm-oauth-client.test.mjs && node --test test/cli-oauth-login.test.mjs && node --test test/workflow-fork-guards.test.mjs && node --test test/resolve-env-vars-array.test.mjs",
     "test:openclaw-host": "node test/openclaw-host-functional.mjs",
     "version": "node scripts/sync-plugin-version.mjs openclaw.plugin.json package.json && git add openclaw.plugin.json"
   },

--- a/test/resolve-env-vars-array.test.mjs
+++ b/test/resolve-env-vars-array.test.mjs
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import http from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const plugin = jiti("../index.ts");
+const { parsePluginConfig } = plugin;
+
+const EMBEDDING_DIMENSIONS = 64;
+
+function createEmbeddingServer() {
+  return http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    const inputs = Array.isArray(body.input) ? body.input : [body.input];
+    const value = 1 / Math.sqrt(EMBEDDING_DIMENSIONS);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      object: "list",
+      data: inputs.map((_, index) => ({
+        object: "embedding", index,
+        embedding: new Array(EMBEDDING_DIMENSIONS).fill(value),
+      })),
+      model: body.model,
+      usage: { prompt_tokens: 0, total_tokens: 0 },
+    }));
+  });
+}
+
+function createLlmServer() {
+  return http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      id: "chatcmpl-test", object: "chat.completion",
+      created: Math.floor(Date.now() / 1000), model: "mock",
+      choices: [{ index: 0, message: { role: "assistant", content: JSON.stringify({ memories: [] }) }, finish_reason: "stop" }],
+    }));
+  });
+}
+
+async function withTestEnv(apiKeyConfig, fn) {
+  const workDir = mkdtempSync(path.join(tmpdir(), "env-vars-array-test-"));
+  const dbPath = path.join(workDir, "test.db");
+  const embeddingServer = createEmbeddingServer();
+  const llmServer = createLlmServer();
+  await new Promise((r) => embeddingServer.listen(0, "127.0.0.1", r));
+  await new Promise((r) => llmServer.listen(0, "127.0.0.1", r));
+  const ePort = embeddingServer.address().port;
+  const lPort = llmServer.address().port;
+
+  try {
+    const logs = [];
+    const api = {
+      pluginConfig: {
+        dbPath,
+        autoCapture: false,
+        autoRecall: false,
+        smartExtraction: true,
+        embedding: {
+          apiKey: apiKeyConfig,
+          model: "mock-model",
+          baseURL: `http://127.0.0.1:${ePort}/v1`,
+          dimensions: EMBEDDING_DIMENSIONS,
+        },
+        llm: {
+          model: "mock-llm",
+          baseURL: `http://127.0.0.1:${lPort}`,
+        },
+        retrieval: { mode: "hybrid" },
+        scopes: {
+          default: "global",
+          definitions: { global: { description: "shared" } },
+        },
+      },
+      hooks: {},
+      toolFactories: {},
+      services: [],
+      logger: {
+        info(...args) { logs.push(["info", args.join(" ")]); },
+        warn(...args) { logs.push(["warn", args.join(" ")]); },
+        error(...args) { logs.push(["error", args.join(" ")]); },
+        debug(...args) { logs.push(["debug", args.join(" ")]); },
+      },
+      resolvePath(v) { return v; },
+      registerTool(t, m) { this.toolFactories[m.name] = typeof t === "function" ? t : () => t; },
+      registerCli() {},
+      registerService(s) { this.services.push(s); },
+      on(name, handler) { this.hooks[name] = handler; },
+      registerHook(name, handler) { this.hooks[name] = handler; },
+    };
+
+    plugin.register(api);
+    await fn(logs);
+  } finally {
+    await new Promise((r) => embeddingServer.close(r));
+    await new Promise((r) => llmServer.close(r));
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+test("smart extraction initializes with string[] apiKey (no llm.apiKey fallback)", async () => {
+  await withTestEnv(["key-alpha", "key-beta"], (logs) => {
+    const warnLogs = logs.filter(([level]) => level === "warn").map(([, msg]) => msg);
+    const infoLogs = logs.filter(([level]) => level === "info").map(([, msg]) => msg);
+
+    assert.ok(
+      !warnLogs.some((msg) => msg.includes("smart extraction init failed")),
+      `should not fail with array apiKey, got: ${JSON.stringify(warnLogs)}`,
+    );
+    assert.ok(
+      infoLogs.some((msg) => msg.includes("smart extraction enabled")),
+      `smart extraction should be enabled, got: ${JSON.stringify(infoLogs)}`,
+    );
+  });
+});
+
+test("smart extraction initializes with single-element array apiKey", async () => {
+  await withTestEnv(["only-key"], (logs) => {
+    const warnLogs = logs.filter(([level]) => level === "warn").map(([, msg]) => msg);
+    assert.ok(
+      !warnLogs.some((msg) => msg.includes("smart extraction init failed")),
+      `single-element array should work, got: ${JSON.stringify(warnLogs)}`,
+    );
+  });
+});
+
+test("smart extraction initializes with env var in array apiKey", async () => {
+  process.env.__TEST_MEMORY_KEY = "resolved-from-env";
+  try {
+    await withTestEnv(["${__TEST_MEMORY_KEY}"], (logs) => {
+      const warnLogs = logs.filter(([level]) => level === "warn").map(([, msg]) => msg);
+      assert.ok(
+        !warnLogs.some((msg) => msg.includes("smart extraction init failed")),
+        `env var in array should resolve, got: ${JSON.stringify(warnLogs)}`,
+      );
+    });
+  } finally {
+    delete process.env.__TEST_MEMORY_KEY;
+  }
+});
+
+test("parsePluginConfig preserves string[] apiKey", () => {
+  const config = parsePluginConfig({
+    embedding: {
+      apiKey: ["key-one", "key-two"],
+      model: "text-embedding-3-small",
+      baseURL: "https://api.example.com/v1",
+    },
+  });
+  assert.ok(Array.isArray(config.embedding.apiKey));
+  assert.equal(config.embedding.apiKey.length, 2);
+});
+
+test("parsePluginConfig preserves single string apiKey", () => {
+  const config = parsePluginConfig({
+    embedding: {
+      apiKey: "single-key",
+      model: "text-embedding-3-small",
+    },
+  });
+  assert.equal(config.embedding.apiKey, "single-key");
+});
+
+test("parsePluginConfig rejects empty array apiKey", () => {
+  assert.throws(
+    () => parsePluginConfig({
+      embedding: {
+        apiKey: [],
+        model: "text-embedding-3-small",
+      },
+    }),
+    /apiKey/,
+  );
+});


### PR DESCRIPTION
## Summary

- Fix runtime crash when `embedding.apiKey` is configured as `string[]` (round-robin rotation) and no separate `llm.apiKey` is set. The LLM client initialization calls `resolveEnvVars()` which only accepts `string`, causing a type error when it receives an array.
- Add `json5` to `dependencies` in `package.json` — it was already imported at runtime but missing from the manifest, causing `Cannot find module 'json5'` on fresh installs. Fixes #283.

## Root cause

`embedding.apiKey` supports both `string` and `string[]` (for key rotation), but two fallback paths in the LLM client setup passed `config.embedding.apiKey` directly to `resolveEnvVars(value: string)` without handling the array case. When users configured multiple API keys and omitted `llm.apiKey`, the plugin silently degraded smart extraction to regex mode.

## Changes

- **`index.ts`**: Add `resolveFirstApiKey(apiKey: string | string[]): string` helper that safely extracts the first key from an array (or returns the string as-is) before resolving env vars. Replace both `resolveEnvVars(config.embedding.apiKey)` call sites with `resolveFirstApiKey(config.embedding.apiKey)`.
- **`package.json`**: Add `json5@^2.2.3` to `dependencies`. Add new test to `npm test` script.
- **`test/resolve-env-vars-array.test.mjs`**: 6 regression tests covering array apiKey in smart extraction init, single-element arrays, env var resolution within arrays, `parsePluginConfig` preservation of array shape, and rejection of empty arrays.

## Test plan

- [x] `npm test` passes (29 test files, 0 failures)
- [x] Configure `embedding.apiKey` as `["key1", "key2"]` with no `llm.apiKey` — smart extraction initializes without error
- [x] Configure `embedding.apiKey` as a plain string — behavior unchanged
- [x] Fresh `npm install` resolves `json5` without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)