### PR TITLE
feat(capture): add scored capture pipeline and ingestion safeguards

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,12 @@ import { createScopeManager, resolveScopeFilter, isSystemBypassId, parseAgentIdF
 import { createMigrator } from "./src/migrate.js";
 import { registerAllMemoryTools } from "./src/tools.js";
 import { appendSelfImprovementEntry, ensureSelfImprovementLearningFiles } from "./src/self-improvement-files.js";
-import type { MdMirrorWriter } from "./src/tools.js";
+import type {
+  CaptureIngressResult,
+  CaptureIngressValidator,
+  CaptureIngressWriter,
+  MdMirrorWriter,
+} from "./src/tools.js";
 import { shouldSkipRetrieval } from "./src/adaptive-retrieval.js";
 import { runWithReflectionTransientRetryOnce } from "./src/reflection-retry.js";
 import { resolveReflectionSessionSearchDirs, stripResetSuffix } from "./src/session-recovery.js";
@@ -57,6 +62,21 @@ import {
   isUserMdExclusiveMemory,
   type WorkspaceBoundaryConfig,
 } from "./src/workspace-boundary.js";
+import {
+  DEFAULT_CAPTURE_POLICY,
+  detectMemoryCategory,
+  mergeCaptureMetadata,
+  parseCaptureMetadata,
+  scoreMemoryCandidate,
+  type CapturePolicyConfig,
+  type CaptureRole,
+  type CaptureSourceApp,
+} from "./src/capture-pipeline.js";
+import {
+  createExternalIngestionManager,
+  type ExternalCaptureCandidate,
+  type ExternalIngestionConfig,
+} from "./src/external-ingestion.js";
 
 // ============================================================================
 // Configuration & Types
@@ -80,10 +100,12 @@ interface PluginConfig {
   autoRecallMinLength?: number;
   autoRecallMinRepeated?: number;
   captureAssistant?: boolean;
+  capturePolicy?: CapturePolicyConfig;
   retrieval?: {
     mode?: "hybrid" | "vector";
     vectorWeight?: number;
     bm25Weight?: number;
+    queryExpansion?: boolean;
     minScore?: number;
     rerank?: "cross-encoder" | "lightweight" | "none";
     candidatePoolSize?: number;
@@ -95,6 +117,7 @@ interface PluginConfig {
       | "siliconflow"
       | "voyage"
       | "pinecone"
+      | "vllm"
       | "dashscope"
       | "tei";
     recencyHalfLifeDays?: number;
@@ -106,6 +129,7 @@ interface PluginConfig {
     reinforcementFactor?: number;
     maxHalfLifeMultiplier?: number;
   };
+  externalIngestion?: ExternalIngestionConfig;
   decay?: {
     recencyHalfLifeDays?: number;
     recencyWeight?: number;
@@ -228,6 +252,29 @@ function parsePositiveInt(value: unknown): number | undefined {
     if (Number.isFinite(n) && n > 0) return Math.floor(n);
   }
   return undefined;
+}
+
+function parseNonNegativeNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const s = value.trim();
+    if (!s) return undefined;
+    const resolved = resolveEnvVars(s);
+    const n = Number(resolved);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  return undefined;
+}
+
+function parseStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const parsed = value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => resolveEnvVars(item.trim()))
+    .filter((item) => item.length > 0);
+  return parsed.length > 0 ? parsed : undefined;
 }
 
 function resolveLlmTimeoutMs(config: PluginConfig): number {
@@ -1999,6 +2046,245 @@ const memoryLanceDBProPlugin = {
     // ========================================================================
 
     const mdMirror = createMdMirrorWriter(api, config);
+    const capturePolicy: CapturePolicyConfig = {
+      ...DEFAULT_CAPTURE_POLICY,
+      ...(config.capturePolicy || {}),
+    };
+    const externalDefaultScope = config.scopes?.default ?? "global";
+
+    const captureValidator: CaptureIngressValidator = async (params) => {
+      const sanitizedText = redactSecrets(String(params.text || "")).trim();
+      const scored = scoreMemoryCandidate(
+        {
+          text: sanitizedText,
+          role: (params.scoringRole ?? params.sourceRole) as CaptureRole,
+          sourceApp: params.sourceApp,
+          sourceProvider: params.sourceProvider,
+          confirmed: params.confirmed,
+          repetitionCount: params.repetitionCount,
+          captureAssistant: config.captureAssistant === true,
+        },
+        capturePolicy,
+      );
+
+      const explicitWriteSoftReject =
+        params.explicitWrite === true &&
+        (
+          scored.rejectedReason === "too-long" ||
+          scored.rejectedReason === "too-short" ||
+          scored.rejectedReason === "assistant-capture-disabled" ||
+          scored.rejectedReason === "assistant-not-memory-like" ||
+          scored.rejectedReason === "below-threshold" ||
+          scored.rejectedReason === "low-signal"
+        );
+
+      if (scored.rejectedReason && !explicitWriteSoftReject) {
+        return {
+          accepted: false,
+          reason: scored.rejectedReason,
+          text: sanitizedText,
+        };
+      }
+
+      const captureReasons = [...new Set([
+        ...(scored.reasons || []),
+        ...(params.explicitWrite === true ? ["explicit-tool-request"] : []),
+      ])].slice(0, 8);
+
+      return {
+        accepted: true,
+        text: sanitizedText,
+        metadataPayload: {
+          memoryTier: scored.tier === "discard" ? "formal" : scored.tier,
+          captureScore:
+            scored.score > 0 ? scored.score : capturePolicy.formalMinScore,
+          captureReasons,
+          normalizedKey: scored.normalizedKey,
+          sourceApp: params.sourceApp,
+          sourceRole: params.sourceRole,
+          sourceProvider: params.sourceProvider,
+          ingestionMode: params.ingestionMode,
+          confirmed: params.confirmed,
+          occurredAt: params.occurredAt,
+        },
+      };
+    };
+
+    const persistCapturedText = async (params: {
+      text: string;
+      scope: string;
+      importance?: number;
+      category?: "preference" | "fact" | "decision" | "entity" | "other";
+      sourceApp: CaptureSourceApp;
+      sourceRole: CaptureRole;
+      scoringRole?: CaptureRole;
+      sourceProvider?: string;
+      sourcePath?: string;
+      sourceSessionId?: string;
+      sourceModel?: string;
+      sourceWorkspace?: string;
+      ingestionMode: string;
+      explicitWrite?: boolean;
+      confirmed?: boolean;
+      occurredAt?: number;
+      repetitionCount?: number;
+      vector?: number[];
+      agentId?: string;
+      additionalMetadata?: Record<string, unknown>;
+    }): Promise<CaptureIngressResult> => {
+      const validation = await captureValidator({
+        text: params.text,
+        sourceApp: params.sourceApp,
+        sourceRole: params.sourceRole,
+        scoringRole: params.scoringRole,
+        sourceProvider: params.sourceProvider,
+        repetitionCount: params.repetitionCount,
+        ingestionMode: params.ingestionMode,
+        explicitWrite: params.explicitWrite,
+        confirmed: params.confirmed,
+      });
+
+      if (!validation.accepted || !validation.metadataPayload) {
+        return {
+          action: "skipped",
+          reason: validation.reason || "filtered",
+        };
+      }
+
+      if (isUserMdExclusiveMemory({ text: validation.text }, config.workspaceBoundary)) {
+        return {
+          action: "skipped",
+          reason: "user-md-exclusive",
+        };
+      }
+
+      const category = params.category || detectMemoryCategory(validation.text);
+      const importance =
+        typeof params.importance === "number" && Number.isFinite(params.importance)
+          ? Math.max(0, Math.min(1, params.importance))
+          : validation.metadataPayload.memoryTier === "formal"
+            ? 0.8
+            : 0.65;
+      const captureMetadata = parseCaptureMetadata(mergeCaptureMetadata(undefined, {
+        ...validation.metadataPayload,
+        sourcePath: params.sourcePath,
+        sourceSessionId: params.sourceSessionId,
+        sourceModel: params.sourceModel,
+        sourceWorkspace: params.sourceWorkspace,
+      }));
+      const metadata = JSON.stringify({
+        ...(params.additionalMetadata || {}),
+        ...captureMetadata,
+      });
+      const vector = Array.isArray(params.vector) && params.vector.length > 0
+        ? params.vector
+        : await embedder.embedPassage(validation.text);
+
+      let existing: Awaited<ReturnType<typeof store.vectorSearch>> = [];
+      try {
+        existing = await store.vectorSearch(vector, 1, 0.1, [params.scope]);
+      } catch (error) {
+        api.logger.warn(
+          `memory-lancedb-pro: capture duplicate pre-check failed, continuing write: ${String(error)}`,
+        );
+      }
+
+      if (existing.length > 0 && existing[0].score > 0.98) {
+        const matched = existing[0];
+        const mergedCaptureMetadata = parseCaptureMetadata(mergeCaptureMetadata(matched.entry.metadata, {
+          ...validation.metadataPayload,
+          sourcePath: params.sourcePath,
+          sourceSessionId: params.sourceSessionId,
+          sourceModel: params.sourceModel,
+          sourceWorkspace: params.sourceWorkspace,
+        }));
+        const mergedMetadata = JSON.stringify({
+          ...parseCaptureMetadata(matched.entry.metadata),
+          ...(params.additionalMetadata || {}),
+          ...mergedCaptureMetadata,
+        });
+        const updated = await store.update(
+          matched.entry.id,
+          {
+            metadata: mergedMetadata,
+            importance: Math.max(matched.entry.importance ?? 0.7, importance),
+            category: params.category || matched.entry.category,
+          },
+          [params.scope],
+        );
+        if (updated && mdMirror) {
+          await mdMirror(
+            { text: updated.text, category: updated.category, scope: updated.scope, timestamp: updated.timestamp },
+            { source: params.ingestionMode, agentId: params.agentId },
+          );
+        }
+        return {
+          action: "updated",
+          entry: updated ?? matched.entry,
+          matchedExisting: {
+            id: matched.entry.id,
+            text: matched.entry.text,
+            scope: matched.entry.scope,
+            similarity: matched.score,
+          },
+        };
+      }
+
+      const entry = await store.store({
+        text: validation.text,
+        vector,
+        importance,
+        category,
+        scope: params.scope,
+        metadata,
+      });
+      if (mdMirror) {
+        await mdMirror(
+          { text: entry.text, category: entry.category, scope: entry.scope, timestamp: entry.timestamp },
+          { source: params.ingestionMode, agentId: params.agentId },
+        );
+      }
+      return {
+        action: "stored",
+        entry,
+      };
+    };
+
+    const captureIngress: CaptureIngressWriter = async (params) =>
+      persistCapturedText({
+        ...params,
+        scope: params.scope,
+      });
+
+    const externalIngestionManager = createExternalIngestionManager({
+      config: config.externalIngestion,
+      stateFilePath: api.resolvePath(join(resolvedDbPath, "external-ingestion-state.json")),
+      logger: api.logger,
+      onCandidates: async (items: ExternalCaptureCandidate[]) => {
+        for (const item of items) {
+          try {
+            await persistCapturedText({
+              text: item.text,
+              scope: externalDefaultScope,
+              sourceApp: item.sourceApp,
+              sourceRole: item.role,
+              sourceProvider: item.sourceProvider,
+              sourcePath: item.sourcePath,
+              sourceSessionId: item.sourceSessionId,
+              sourceModel: item.sourceModel,
+              sourceWorkspace: item.sourceWorkspace,
+              occurredAt: item.occurredAt,
+              ingestionMode: "external-ingestion",
+              confirmed: item.role === "user",
+            });
+          } catch (error) {
+            api.logger.warn(
+              `memory-lancedb-pro: external ingestion persist failed for ${item.sourceApp}: ${String(error)}`,
+            );
+          }
+        }
+      },
+    });
 
     // ========================================================================
     // Register Tools
@@ -2014,6 +2300,8 @@ const memoryLanceDBProPlugin = {
         agentId: undefined, // Will be determined at runtime from context
         workspaceDir: getDefaultWorkspaceDir(),
         mdMirror,
+        captureIngress,
+        captureValidator,
         workspaceBoundary: config.workspaceBoundary,
       },
       {
@@ -2897,22 +3185,8 @@ const memoryLanceDBProPlugin = {
 
           const mappedReflectionMemories = extractInjectableReflectionMappedMemoryItems(reflectionText);
           for (const mapped of mappedReflectionMemories) {
-            const vector = await embedder.embedPassage(mapped.text);
-            let existing: Awaited<ReturnType<typeof store.vectorSearch>> = [];
-            try {
-              existing = await store.vectorSearch(vector, 1, 0.1, [targetScope]);
-            } catch (err) {
-              api.logger.warn(
-                `memory-reflection: mapped memory duplicate pre-check failed, continue store: ${String(err)}`,
-              );
-            }
-
-            if (existing.length > 0 && existing[0].score > 0.95) {
-              continue;
-            }
-
             const importance = mapped.category === "decision" ? 0.85 : 0.8;
-            const metadata = JSON.stringify(buildReflectionMappedMetadata({
+            const reflectionMetadata = buildReflectionMappedMetadata({
               mappedItem: mapped,
               eventId: reflectionEventId,
               agentId: sourceAgentId,
@@ -2922,23 +3196,23 @@ const memoryLanceDBProPlugin = {
               usedFallback: reflectionGenerated.usedFallback,
               toolErrorSignals,
               sourceReflectionPath: relPath,
-            }));
+            });
 
-            const storedEntry = await store.store({
+            await persistCapturedText({
               text: mapped.text,
-              vector,
               importance,
               category: mapped.category,
               scope: targetScope,
-              metadata,
+              sourceApp: "openclaw",
+              sourceRole: "assistant",
+              scoringRole: "assistant",
+              ingestionMode: `reflection:${mapped.heading}`,
+              explicitWrite: true,
+              confirmed: true,
+              occurredAt: nowTs,
+              agentId: sourceAgentId,
+              additionalMetadata: reflectionMetadata,
             });
-
-            if (mdMirror) {
-              await mdMirror(
-                { text: mapped.text, category: mapped.category, scope: targetScope, timestamp: storedEntry.timestamp },
-                { source: `reflection:${mapped.heading}`, agentId: sourceAgentId },
-              );
-            }
           }
 
           if (reflectionStoreToLanceDB) {
@@ -3266,12 +3540,14 @@ const memoryLanceDBProPlugin = {
         // Run initial backup after a short delay, then schedule daily
         setTimeout(() => void runBackup(), 60_000); // 1 min after start
         backupTimer = setInterval(() => void runBackup(), BACKUP_INTERVAL_MS);
+        await externalIngestionManager.start();
       },
       stop: async () => {
         if (backupTimer) {
           clearInterval(backupTimer);
           backupTimer = null;
         }
+        await externalIngestionManager.stop().catch(() => {});
         api.logger.info("memory-lancedb-pro: stopped");
       },
     });
@@ -3324,6 +3600,24 @@ export function parsePluginConfig(value: unknown): PluginConfig {
   const workspaceBoundaryRaw = typeof cfg.workspaceBoundary === "object" && cfg.workspaceBoundary !== null
     ? cfg.workspaceBoundary as Record<string, unknown>
     : null;
+  const capturePolicyRaw = typeof cfg.capturePolicy === "object" && cfg.capturePolicy !== null
+    ? cfg.capturePolicy as Record<string, unknown>
+    : null;
+  const externalIngestionRaw = typeof cfg.externalIngestion === "object" && cfg.externalIngestion !== null
+    ? cfg.externalIngestion as Record<string, unknown>
+    : null;
+  const externalSourcesRaw = typeof externalIngestionRaw?.sources === "object" && externalIngestionRaw.sources !== null
+    ? externalIngestionRaw.sources as Record<string, unknown>
+    : null;
+  const externalClaudeRaw = typeof externalSourcesRaw?.claude === "object" && externalSourcesRaw.claude !== null
+    ? externalSourcesRaw.claude as Record<string, unknown>
+    : null;
+  const externalCodexRaw = typeof externalSourcesRaw?.codex === "object" && externalSourcesRaw.codex !== null
+    ? externalSourcesRaw.codex as Record<string, unknown>
+    : null;
+  const externalWechatRaw = typeof externalSourcesRaw?.wechat === "object" && externalSourcesRaw.wechat !== null
+    ? externalSourcesRaw.wechat as Record<string, unknown>
+    : null;
   const userMdExclusiveRaw = typeof workspaceBoundaryRaw?.userMdExclusive === "object" && workspaceBoundaryRaw.userMdExclusive !== null
     ? workspaceBoundaryRaw.userMdExclusive as Record<string, unknown>
     : null;
@@ -3346,6 +3640,18 @@ export function parsePluginConfig(value: unknown): PluginConfig {
   const reflectionStoreToLanceDB =
     sessionStrategy === "memoryReflection" &&
     (memoryReflectionRaw?.storeToLanceDB !== false);
+  const captureCandidateMinScore = Math.max(
+    0,
+    Math.min(10, parseNonNegativeNumber(capturePolicyRaw?.candidateMinScore) ?? DEFAULT_CAPTURE_POLICY.candidateMinScore),
+  );
+  const captureFormalMinScore = Math.max(
+    captureCandidateMinScore,
+    Math.min(10, parseNonNegativeNumber(capturePolicyRaw?.formalMinScore) ?? DEFAULT_CAPTURE_POLICY.formalMinScore),
+  );
+  const captureAssistantMaxScore = Math.max(
+    0,
+    Math.min(captureFormalMinScore, parseNonNegativeNumber(capturePolicyRaw?.assistantMaxScore) ?? DEFAULT_CAPTURE_POLICY.assistantMaxScore),
+  );
 
   return {
     embedding: {
@@ -3386,7 +3692,36 @@ export function parsePluginConfig(value: unknown): PluginConfig {
     autoRecallMinLength: parsePositiveInt(cfg.autoRecallMinLength),
     autoRecallMinRepeated: parsePositiveInt(cfg.autoRecallMinRepeated),
     captureAssistant: cfg.captureAssistant === true,
+    capturePolicy: {
+      candidateMinScore: captureCandidateMinScore,
+      formalMinScore: captureFormalMinScore,
+      assistantMaxScore: captureAssistantMaxScore,
+      includeCandidateInRecall: capturePolicyRaw?.includeCandidateInRecall === true,
+    },
     retrieval: typeof cfg.retrieval === "object" && cfg.retrieval !== null ? cfg.retrieval as any : undefined,
+    externalIngestion: {
+      enabled: externalIngestionRaw?.enabled === true,
+      scanIntervalMs: parsePositiveInt(externalIngestionRaw?.scanIntervalMs),
+      inactivityWindowMs: parsePositiveInt(externalIngestionRaw?.inactivityWindowMs),
+      sources: {
+        claude: {
+          enabled: externalClaudeRaw?.enabled === true,
+          roots: parseStringArray(externalClaudeRaw?.roots),
+          includeSubagents: externalClaudeRaw?.includeSubagents !== false,
+          maxFilesPerScan: parsePositiveInt(externalClaudeRaw?.maxFilesPerScan),
+        },
+        codex: {
+          enabled: externalCodexRaw?.enabled === true,
+          roots: parseStringArray(externalCodexRaw?.roots),
+          maxFilesPerScan: parsePositiveInt(externalCodexRaw?.maxFilesPerScan),
+        },
+        wechat: {
+          enabled: externalWechatRaw?.enabled === true,
+          roots: parseStringArray(externalWechatRaw?.roots),
+          placeholder: externalWechatRaw?.placeholder !== false,
+        },
+      },
+    },
     decay: typeof cfg.decay === "object" && cfg.decay !== null ? cfg.decay as any : undefined,
     tier: typeof cfg.tier === "object" && cfg.tier !== null ? cfg.tier as any : undefined,
     // Smart extraction config (Phase 1)

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -127,6 +127,138 @@
         "default": 8000,
         "description": "Maximum conversation characters sent to the smart extraction LLM."
       },
+      "capturePolicy": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "candidateMinScore": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10,
+            "default": 4,
+            "description": "Minimum score to write a candidate memory. 0-10 scale."
+          },
+          "formalMinScore": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10,
+            "default": 8,
+            "description": "Minimum score to promote a memory into the formal tier. 0-10 scale."
+          },
+          "assistantMaxScore": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10,
+            "default": 5,
+            "description": "Unconfirmed assistant summaries are capped at this score to keep them in the candidate pool by default."
+          },
+          "includeCandidateInRecall": {
+            "type": "boolean",
+            "default": false,
+            "description": "Allow candidate-tier memories to participate in auto-recall. Recommended: keep disabled."
+          }
+        }
+      },
+      "externalIngestion": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable standalone transcript ingestion outside the OpenClaw chat window."
+          },
+          "scanIntervalMs": {
+            "type": "integer",
+            "minimum": 60000,
+            "default": 600000,
+            "description": "Fallback full scan interval. Real-time capture prefers filesystem watchers."
+          },
+          "inactivityWindowMs": {
+            "type": "integer",
+            "minimum": 60000,
+            "default": 180000,
+            "description": "Only finalize transcript files after they stay unchanged for at least this long."
+          },
+          "sources": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "claude": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "roots": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Directories containing Claude JSONL conversation logs."
+                  },
+                  "includeSubagents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "maxFilesPerScan": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 500,
+                    "default": 40
+                  }
+                }
+              },
+              "codex": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "roots": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Directories containing Codex rollout JSONL sessions."
+                  },
+                  "maxFilesPerScan": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 500,
+                    "default": 40
+                  }
+                }
+              },
+              "wechat": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "roots": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Reserved placeholder roots for future WeChat capture."
+                  },
+                  "placeholder": {
+                    "type": "boolean",
+                    "default": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "retrieval": {
         "type": "object",
         "additionalProperties": false,
@@ -150,6 +282,11 @@
             "minimum": 0,
             "maximum": 1,
             "default": 0.3
+          },
+          "queryExpansion": {
+            "type": "boolean",
+            "default": true,
+            "description": "Expand manual and CLI BM25 queries with a small synonym dictionary. Does not affect vector search or auto-recall."
           },
           "minScore": {
             "type": "number",
@@ -620,7 +757,92 @@
     },
     "captureAssistant": {
       "label": "Capture Assistant Messages",
-      "help": "Also auto-capture assistant messages (default false to reduce memory pollution)",
+      "help": "Allow assistant-side capture. Unconfirmed assistant summaries are still capped into the candidate pool by the scoring policy.",
+      "advanced": true
+    },
+    "capturePolicy.candidateMinScore": {
+      "label": "Candidate Score Threshold",
+      "help": "Minimum 0-10 score required to write a candidate memory.",
+      "advanced": true
+    },
+    "capturePolicy.formalMinScore": {
+      "label": "Formal Score Threshold",
+      "help": "Minimum 0-10 score required to promote a formal memory.",
+      "advanced": true
+    },
+    "capturePolicy.assistantMaxScore": {
+      "label": "Assistant Score Cap",
+      "help": "Unconfirmed assistant summaries cannot score above this cap.",
+      "advanced": true
+    },
+    "capturePolicy.includeCandidateInRecall": {
+      "label": "Recall Candidate Tier",
+      "help": "Whether candidate-tier memories can join generic auto-recall.",
+      "advanced": true
+    },
+    "externalIngestion.enabled": {
+      "label": "Enable External Ingestion",
+      "help": "Scan standalone Claude/Codex transcripts and feed them into the same memory pipeline.",
+      "advanced": true
+    },
+    "externalIngestion.scanIntervalMs": {
+      "label": "External Scan Interval",
+      "help": "Fallback full-scan interval in milliseconds. File watchers handle near-real-time updates.",
+      "advanced": true
+    },
+    "externalIngestion.inactivityWindowMs": {
+      "label": "External Idle Window",
+      "help": "Only finalize transcript files after they stay unchanged for this many milliseconds.",
+      "advanced": true
+    },
+    "externalIngestion.sources.claude.enabled": {
+      "label": "Capture Claude",
+      "help": "Capture standalone Claude JSONL conversations.",
+      "advanced": true
+    },
+    "externalIngestion.sources.claude.roots": {
+      "label": "Claude Roots",
+      "help": "Directories containing Claude project transcripts.",
+      "advanced": true
+    },
+    "externalIngestion.sources.claude.includeSubagents": {
+      "label": "Claude Subagents",
+      "help": "Include Claude subagent JSONL logs as well.",
+      "advanced": true
+    },
+    "externalIngestion.sources.claude.maxFilesPerScan": {
+      "label": "Claude File Limit",
+      "help": "Maximum number of Claude transcript files to inspect per scan.",
+      "advanced": true
+    },
+    "externalIngestion.sources.codex.enabled": {
+      "label": "Capture Codex",
+      "help": "Capture standalone Codex rollout sessions.",
+      "advanced": true
+    },
+    "externalIngestion.sources.codex.roots": {
+      "label": "Codex Roots",
+      "help": "Directories containing Codex rollout JSONL files.",
+      "advanced": true
+    },
+    "externalIngestion.sources.codex.maxFilesPerScan": {
+      "label": "Codex File Limit",
+      "help": "Maximum number of Codex rollout files to inspect per scan.",
+      "advanced": true
+    },
+    "externalIngestion.sources.wechat.enabled": {
+      "label": "WeChat Placeholder",
+      "help": "Reserved switch for future WeChat capture. Currently logs a placeholder only.",
+      "advanced": true
+    },
+    "externalIngestion.sources.wechat.roots": {
+      "label": "WeChat Roots",
+      "help": "Reserved directories for future WeChat capture.",
+      "advanced": true
+    },
+    "externalIngestion.sources.wechat.placeholder": {
+      "label": "Keep WeChat Placeholder",
+      "help": "Keeps the WeChat source slot visible while the collector is not implemented.",
       "advanced": true
     },
     "retrieval.mode": {
@@ -636,6 +858,11 @@
     "retrieval.bm25Weight": {
       "label": "BM25 Search Weight",
       "help": "Weight for BM25 keyword search in hybrid search (0-1)",
+      "advanced": true
+    },
+    "retrieval.queryExpansion": {
+      "label": "BM25 Query Expansion",
+      "help": "Expand manual and CLI BM25 queries with a small local synonym dictionary. Does not affect auto-recall.",
       "advanced": true
     },
     "retrieval.minScore": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@lancedb/lancedb": "^0.26.2",
         "@sinclair/typebox": "0.34.48",
         "apache-arrow": "18.1.0",
+        "json5": "^2.2.3",
         "openai": "^6.21.0"
       },
       "devDependencies": {
@@ -395,6 +396,18 @@
       "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@lancedb/lancedb": "^0.26.2",
     "@sinclair/typebox": "0.34.48",
     "apache-arrow": "18.1.0",
+    "json5": "^2.2.3",
     "openai": "^6.21.0"
   },
   "openclaw": {

--- a/src/adaptive-retrieval.ts
+++ b/src/adaptive-retrieval.ts
@@ -5,6 +5,30 @@
  * Saves embedding API calls and reduces noise injection.
  */
 
+// Control/system prompts that should never trigger retrieval.
+const CONTROL_PROMPT_SKIP_PATTERNS = [
+  /A new session was started via \/new or \/reset/i,
+  /Execute your Session Startup sequence now/i,
+  /(^|\n)\s*\/note\b/i,
+  /(^|\n)\s*NO_REPLY\s*$/i,
+  /(^|\n)\s*HEARTBEAT_OK\s*$/i,
+];
+
+// Weak continuation prompts that often rely on prior session context.
+const WEAK_CONTINUATION_PATTERNS = [
+  /^(?:那|那就|那你|你|请|請)?\s*(?:go ahead|continue|proceed|resume|carry on|keep going|do it|start|begin|next)\s*[.!?]?$/i,
+  /^(?:那|那就|那你|你|请|請)?\s*(?:继续|繼續|继续吧|繼續吧|接着|接著|接着来|接著來|然后|然後|然后呢|然後呢|下一步|开始|開始|开始吧|開始吧|往下|接下去|接下來)\s*[.!?？]*$/i,
+  /^[?？]+$/,
+];
+
+// Slightly broader than WEAK_CONTINUATION_PATTERNS, but used only for
+// continuity fallback.
+const WEAK_CARRY_FORWARD_PATTERNS = [
+  /^(?:嗯|嗯嗯|唔|呃|哦|噢)\s*[.!?？]*$/i,
+  /^(?:好|好的|好的呀|好吧|可以|行|行吧|ok|okay|sure|alright|got it)\s*[.!?？]*$/i,
+  /^[\p{Emoji}\s]+$/u,
+];
+
 // Queries that are clearly NOT memory-retrieval candidates
 const SKIP_PATTERNS = [
   // Greetings & pleasantries
@@ -61,6 +85,19 @@ function normalizeQuery(query: string): string {
   return result;
 }
 
+export function isWeakContinuationPrompt(query: string): boolean {
+  const trimmed = normalizeQuery(query);
+  if (!trimmed) return false;
+  return WEAK_CONTINUATION_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+export function shouldAttemptContinuityFallback(query: string): boolean {
+  const trimmed = normalizeQuery(query);
+  if (!trimmed) return false;
+  if (isWeakContinuationPrompt(trimmed)) return true;
+  return WEAK_CARRY_FORWARD_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
 /**
  * Determine if a query should skip memory retrieval.
  * Returns true if retrieval should be skipped.
@@ -69,6 +106,10 @@ function normalizeQuery(query: string): string {
  */
 export function shouldSkipRetrieval(query: string, minLength?: number): boolean {
   const trimmed = normalizeQuery(query);
+
+  if (CONTROL_PROMPT_SKIP_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+    return true;
+  }
 
   // Force retrieve if query has memory-related intent (checked FIRST,
   // before length check, so short CJK queries like "你记得吗" aren't skipped)

--- a/src/capture-pipeline.ts
+++ b/src/capture-pipeline.ts
@@ -1,0 +1,420 @@
+import type { MemoryEntry } from "./store.js";
+
+export type CaptureRole = "user" | "assistant";
+export type CaptureSourceApp = "openclaw" | "claude" | "codex" | "wechat" | "unknown";
+export type CaptureTier = "discard" | "candidate" | "formal";
+
+export interface CapturePolicyConfig {
+  candidateMinScore: number;
+  formalMinScore: number;
+  assistantMaxScore: number;
+  includeCandidateInRecall: boolean;
+}
+
+export interface CaptureScoreInput {
+  text: string;
+  role: CaptureRole;
+  sourceApp: CaptureSourceApp;
+  sourceProvider?: string;
+  confirmed?: boolean;
+  hasExistingSimilar?: boolean;
+  repetitionCount?: number;
+  captureAssistant?: boolean;
+}
+
+export interface CaptureScoreBreakdown {
+  intent: number;
+  stability: number;
+  evidence: number;
+  validation: number;
+  futureReuse: number;
+  noisePenalty: number;
+}
+
+export interface CaptureScoreResult {
+  score: number;
+  tier: CaptureTier;
+  category: MemoryEntry["category"] extends "reflection"
+    ? never
+    : Exclude<MemoryEntry["category"], "reflection">;
+  normalizedKey: string;
+  reasons: string[];
+  breakdown: CaptureScoreBreakdown;
+  rejectedReason?: string;
+}
+
+export interface CaptureMetadataPayload {
+  memoryTier: Exclude<CaptureTier, "discard">;
+  captureScore: number;
+  captureReasons: string[];
+  normalizedKey: string;
+  sourceApp: CaptureSourceApp;
+  sourceRole: CaptureRole;
+  sourceProvider?: string;
+  sourcePath?: string;
+  sourceSessionId?: string;
+  sourceModel?: string;
+  sourceWorkspace?: string;
+  ingestionMode?: string;
+  confirmed?: boolean;
+  occurredAt?: number;
+}
+
+export interface CaptureMetadata extends CaptureMetadataPayload {
+  captureVersion: number;
+  firstSeenAt?: number;
+  lastSeenAt?: number;
+  occurrences?: number;
+}
+
+export const DEFAULT_CAPTURE_POLICY: CapturePolicyConfig = {
+  candidateMinScore: 4,
+  formalMinScore: 8,
+  assistantMaxScore: 5,
+  includeCandidateInRecall: false,
+};
+
+const MEMORY_MANAGEMENT_PATTERNS = [
+  /\b(memory-pro|memory_store|memory_recall|memory_forget|memory_update)\b/i,
+  /\bopenclaw\s+memory-pro\b/i,
+  /\b(delete|remove|forget|purge|cleanup|clean up|clear)\b.*\b(memory|memories|entry|entries)\b/i,
+  /\b(memory|memories)\b.*\b(delete|remove|forget|purge|cleanup|clean up|clear)\b/i,
+  /(删除|刪除|清理|清除).{0,12}(记忆|記憶|memory)/i,
+];
+
+const SECRET_PATTERNS = [
+  /Bearer\s+[A-Za-z0-9\-._~+/]+=*/g,
+  /\bsk-[A-Za-z0-9]{20,}\b/g,
+  /\bsk-proj-[A-Za-z0-9\-_]{20,}\b/g,
+  /\bsk-ant-[A-Za-z0-9\-_]{20,}\b/g,
+  /\bgh[pousr]_[A-Za-z0-9]{20,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{22,}\b/g,
+  /\b(?:token|api[_-]?key|secret|password)\s*[:=]\s*["']?[^\s"',;)}\]]{6,}["']?\b/gi,
+  /-----BEGIN\s+(?:RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----[\s\S]*?-----END\s+(?:RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----/g,
+];
+
+const EXPLICIT_REMEMBER_PATTERNS = [
+  /zapamatuj si|pamatuj|remember/i,
+  /記住|记住|記一下|记一下|別忘了|别忘了|備註|备注|存檔|存档|存起來|存起来|存一下/i,
+  /make a note|note this|save this|keep this|store this|remember this/i,
+];
+
+const PREFERENCE_PATTERNS = [
+  /preferuji|radši|prefer|like|love|hate|want|need|care/i,
+  /偏好|喜好|喜歡|喜欢|討厭|讨厌|不喜歡|不喜欢|愛用|爱用|習慣|习惯|倾向/i,
+  /主模型|备用模型|備用模型|默认模型|默認模型|默认用|優先用|优先用/i,
+];
+
+const DECISION_PATTERNS = [
+  /rozhodli jsme|budeme používat/i,
+  /\b(we )?decided\b|we'?ll use|we will use|switch(ed)? to|migrate(d)? to|going forward|from now on/i,
+  /決定|决定|選擇了|选择了|改用|換成|换成|以後用|以后用|流程|规则|規則|SOP|约定|約定/i,
+  /captureassistant|candidate|formal|候选|候選|正式记忆|正式記憶/i,
+];
+
+const ENTITY_PATTERNS = [
+  /\+\d{10,}/,
+  /[\w.-]+@[\w.-]+\.\w+/,
+  /můj\s+\w+\s+je|je\s+můj/i,
+  /my\s+\w+\s+is|is\s+my/i,
+  /我的\S+是|叫我|稱呼|称呼|我叫|名字是/i,
+];
+
+const STABLE_FACT_PATTERNS = [
+  /always|never|important|habit|default|normally|usually/i,
+  /總是|总是|從不|从不|一直|每次都|老是|重要|关键|關鍵|默认|默認|长期|長期/i,
+];
+
+const LONG_TERM_PATTERNS = [
+  /from now on|going forward|always|never|default|habit|standard|policy|workflow/i,
+  /以后|以後|长期|長期|固定|默认|默認|习惯|習慣|流程|规则|規則|约定|約定|主模型|备用模型|備用模型/i,
+];
+
+const TEMPORARY_NOISE_PATTERNS = [
+  /\b(today|tomorrow|tonight|this time|for now|temporary|temporarily|one-off|just once|later)\b/i,
+  /今天|明天|今晚|刚刚|剛剛|先这样|先這樣|暂时|暫時|临时|臨時|一次性|待会|待會|稍后|稍後|本次|这次|這次/i,
+  /这个对话|這個對話|this chat|this conversation|当前任务|當前任務/i,
+];
+
+const SYSTEM_NOISE_PATTERNS = [
+  /<relevant-memories>/i,
+  /BEGIN UNTRUSTED DATA|END UNTRUSTED DATA/i,
+  /^(Conversation info|Sender) \(untrusted metadata\):/im,
+  /^# AGENTS\.md instructions/m,
+  /^<environment_context>/m,
+  /^You are a coding agent running in the Codex CLI/m,
+  /^\s*\{\s*"timestamp":/m,
+];
+
+const ASSISTANT_MEMORY_PATTERNS = [
+  /总结|總結|结论|結論|建议|建議|已设置|已設置|规则|規則|流程|偏好|决定|決定|以后|以後/i,
+  /summary|decision|preference|workflow|rule|policy|set to|configured|we should|recommend/i,
+];
+
+const ASSISTANT_CONFIRMATION_PATTERNS = [
+  /根据你的要求|按你的要求|你明确要求|你已确认|用户确认|已验证|执行结果显示/i,
+  /based on your request|you asked|user confirmed|validated|verified by execution/i,
+];
+
+function hasPattern(patterns: RegExp[], text: string): boolean {
+  return patterns.some((pattern) => {
+    pattern.lastIndex = 0;
+    return pattern.test(text);
+  });
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeScore(value: number): number {
+  return Math.round(clamp(value, 0, 10) * 10) / 10;
+}
+
+function normalizeRecallTextKey(text: string): string {
+  return String(text)
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+}
+
+function isTooShort(text: string): boolean {
+  const hasCJK = /[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/.test(text);
+  const minLen = hasCJK ? 4 : 10;
+  return text.length < minLen;
+}
+
+function containsSecretLikeContent(text: string): boolean {
+  return hasPattern(SECRET_PATTERNS, text);
+}
+
+function containsMostlyCodeFence(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed.includes("```")) return false;
+  const withoutFences = trimmed.replace(/```[\s\S]*?```/g, "").trim();
+  return withoutFences.length < Math.max(24, trimmed.length * 0.2);
+}
+
+function isAssistantMemoryLike(text: string): boolean {
+  return hasPattern(ASSISTANT_MEMORY_PATTERNS, text) ||
+    hasPattern(EXPLICIT_REMEMBER_PATTERNS, text) ||
+    hasPattern(PREFERENCE_PATTERNS, text) ||
+    hasPattern(DECISION_PATTERNS, text) ||
+    hasPattern(STABLE_FACT_PATTERNS, text);
+}
+
+export function detectMemoryCategory(
+  text: string,
+): Exclude<MemoryEntry["category"], "reflection"> {
+  const lower = String(text || "").toLowerCase();
+  if (hasPattern(PREFERENCE_PATTERNS, lower)) {
+    return "preference";
+  }
+  if (hasPattern(DECISION_PATTERNS, lower)) {
+    return "decision";
+  }
+  if (hasPattern(ENTITY_PATTERNS, lower)) {
+    return "entity";
+  }
+  if (hasPattern(STABLE_FACT_PATTERNS, lower)) {
+    return "fact";
+  }
+  return "other";
+}
+
+export function scoreMemoryCandidate(
+  input: CaptureScoreInput,
+  policy: CapturePolicyConfig = DEFAULT_CAPTURE_POLICY,
+): CaptureScoreResult {
+  const text = String(input.text || "").trim();
+  const normalizedKey = normalizeRecallTextKey(text);
+  const category = detectMemoryCategory(text);
+  const reasons: string[] = [];
+  const breakdown: CaptureScoreBreakdown = {
+    intent: 0,
+    stability: 0,
+    evidence: 0,
+    validation: 0,
+    futureReuse: 0,
+    noisePenalty: 0,
+  };
+
+  const reject = (reason: string): CaptureScoreResult => ({
+    score: 0,
+    tier: "discard",
+    category,
+    normalizedKey,
+    reasons: [],
+    breakdown,
+    rejectedReason: reason,
+  });
+
+  if (!text) return reject("empty");
+  if (isTooShort(text)) return reject("too-short");
+  if (text.length > 1200) return reject("too-long");
+  if (hasPattern(MEMORY_MANAGEMENT_PATTERNS, text)) return reject("memory-management");
+  if (hasPattern(SYSTEM_NOISE_PATTERNS, text)) return reject("system-noise");
+  if (containsMostlyCodeFence(text)) return reject("code-block-only");
+  if (containsSecretLikeContent(text)) return reject("secret-like-content");
+  if (input.role === "assistant" && input.captureAssistant !== true) {
+    return reject("assistant-capture-disabled");
+  }
+  if (input.role === "assistant" && !isAssistantMemoryLike(text)) {
+    return reject("assistant-not-memory-like");
+  }
+
+  if (hasPattern(EXPLICIT_REMEMBER_PATTERNS, text)) {
+    breakdown.intent = 4;
+    reasons.push("explicit-remember");
+  } else if (hasPattern(PREFERENCE_PATTERNS, text) || hasPattern(DECISION_PATTERNS, text)) {
+    breakdown.intent = 3;
+    reasons.push(hasPattern(DECISION_PATTERNS, text) ? "decision-or-workflow" : "preference");
+  } else if (hasPattern(ENTITY_PATTERNS, text) || hasPattern(STABLE_FACT_PATTERNS, text)) {
+    breakdown.intent = 2;
+    reasons.push(category === "entity" ? "entity" : "stable-fact");
+  } else if (input.role === "assistant" && isAssistantMemoryLike(text)) {
+    breakdown.intent = 1.5;
+    reasons.push("assistant-summary");
+  }
+
+  if (hasPattern(LONG_TERM_PATTERNS, text)) {
+    breakdown.stability = 2;
+    reasons.push("long-term");
+  } else if (category === "preference" || category === "decision" || category === "entity") {
+    breakdown.stability = 1.5;
+  } else if (category === "fact") {
+    breakdown.stability = 1;
+  } else if (input.role === "assistant") {
+    breakdown.stability = 0.5;
+  }
+
+  if ((input.repetitionCount ?? 0) > 1) {
+    breakdown.evidence = 2;
+    reasons.push("repeated");
+  } else if (input.hasExistingSimilar) {
+    breakdown.evidence = 2;
+    reasons.push("matched-existing");
+  } else if (hasPattern(STABLE_FACT_PATTERNS, text)) {
+    breakdown.evidence = 1;
+  }
+
+  if (input.role === "user" || input.confirmed === true || hasPattern(ASSISTANT_CONFIRMATION_PATTERNS, text)) {
+    breakdown.validation = 1;
+  }
+
+  if (category === "preference" || category === "decision" || category === "entity") {
+    breakdown.futureReuse = 1;
+  } else if (category === "fact" || hasPattern(ASSISTANT_MEMORY_PATTERNS, text)) {
+    breakdown.futureReuse = 0.5;
+  }
+
+  if (hasPattern(TEMPORARY_NOISE_PATTERNS, text)) {
+    breakdown.noisePenalty = 5;
+    reasons.push("temporary-noise");
+  }
+
+  let total = breakdown.intent +
+    breakdown.stability +
+    breakdown.evidence +
+    breakdown.validation +
+    breakdown.futureReuse -
+    breakdown.noisePenalty;
+
+  if (input.role === "assistant" && input.confirmed !== true) {
+    total = Math.min(total, policy.assistantMaxScore);
+  }
+
+  const score = normalizeScore(total);
+  const tier: CaptureTier = score >= policy.formalMinScore
+    ? "formal"
+    : score >= policy.candidateMinScore
+      ? "candidate"
+      : "discard";
+
+  return {
+    score,
+    tier,
+    category,
+    normalizedKey,
+    reasons: [...new Set(reasons)].slice(0, 6),
+    breakdown,
+    rejectedReason: tier === "discard" ? "below-threshold" : undefined,
+  };
+}
+
+export function parseCaptureMetadata(metadataRaw: string | undefined): Record<string, unknown> {
+  if (!metadataRaw) return {};
+  try {
+    const parsed = JSON.parse(metadataRaw);
+    return parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+export function getCaptureTier(metadataRaw: string | undefined): Exclude<CaptureTier, "discard"> | undefined {
+  const parsed = parseCaptureMetadata(metadataRaw);
+  const tier = parsed.memoryTier;
+  return tier === "candidate" || tier === "formal" ? tier : undefined;
+}
+
+export function mergeCaptureMetadata(
+  existingMetadataRaw: string | undefined,
+  incoming: CaptureMetadataPayload,
+): string {
+  const existing = parseCaptureMetadata(existingMetadataRaw);
+  const previousTier = existing.memoryTier === "formal" || existing.memoryTier === "candidate"
+    ? existing.memoryTier
+    : undefined;
+  const previousReasons = Array.isArray(existing.captureReasons)
+    ? existing.captureReasons.filter((item): item is string => typeof item === "string")
+    : [];
+  const previousOccurrences = typeof existing.occurrences === "number" && Number.isFinite(existing.occurrences)
+    ? Math.max(0, Math.floor(existing.occurrences))
+    : 0;
+  const previousFirstSeenAt = typeof existing.firstSeenAt === "number" && Number.isFinite(existing.firstSeenAt)
+    ? existing.firstSeenAt
+    : undefined;
+
+  const merged: CaptureMetadata = {
+    ...existing,
+    captureVersion: 1,
+    memoryTier: previousTier === "formal" || incoming.memoryTier === "formal"
+      ? "formal"
+      : "candidate",
+    captureScore: Math.max(
+      typeof existing.captureScore === "number" && Number.isFinite(existing.captureScore)
+        ? existing.captureScore
+        : 0,
+      incoming.captureScore,
+    ),
+    captureReasons: [...new Set([...previousReasons, ...incoming.captureReasons])].slice(0, 8),
+    normalizedKey: incoming.normalizedKey,
+    sourceApp: incoming.sourceApp,
+    sourceRole: incoming.sourceRole,
+    sourceProvider: incoming.sourceProvider,
+    sourcePath: incoming.sourcePath,
+    sourceSessionId: incoming.sourceSessionId,
+    sourceModel: incoming.sourceModel,
+    sourceWorkspace: incoming.sourceWorkspace,
+    ingestionMode: incoming.ingestionMode,
+    confirmed: Boolean(existing.confirmed) || incoming.confirmed === true,
+    occurredAt: incoming.occurredAt,
+    firstSeenAt: previousFirstSeenAt ?? incoming.occurredAt ?? Date.now(),
+    lastSeenAt: incoming.occurredAt ?? Date.now(),
+    occurrences: previousOccurrences + 1,
+  };
+
+  return JSON.stringify(merged);
+}
+
+export function isRecallEligibleMemory(
+  entry: Pick<MemoryEntry, "metadata">,
+  includeCandidateInRecall = false,
+): boolean {
+  const tier = getCaptureTier(entry.metadata);
+  if (!tier) return true;
+  if (tier === "formal") return true;
+  return includeCandidateInRecall === true;
+}

--- a/src/external-ingestion.ts
+++ b/src/external-ingestion.ts
@@ -1,0 +1,633 @@
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { watch, type FSWatcher } from "node:fs";
+
+import type { CaptureRole, CaptureSourceApp } from "./capture-pipeline.js";
+
+export interface ClaudeExternalSourceConfig {
+  enabled?: boolean;
+  roots?: string[];
+  includeSubagents?: boolean;
+  maxFilesPerScan?: number;
+}
+
+export interface CodexExternalSourceConfig {
+  enabled?: boolean;
+  roots?: string[];
+  maxFilesPerScan?: number;
+}
+
+export interface WechatExternalSourceConfig {
+  enabled?: boolean;
+  roots?: string[];
+  placeholder?: boolean;
+}
+
+export interface ExternalIngestionConfig {
+  enabled?: boolean;
+  scanIntervalMs?: number;
+  inactivityWindowMs?: number;
+  sources?: {
+    claude?: ClaudeExternalSourceConfig;
+    codex?: CodexExternalSourceConfig;
+    wechat?: WechatExternalSourceConfig;
+  };
+}
+
+export interface ExternalCaptureCandidate {
+  text: string;
+  role: CaptureRole;
+  sourceApp: CaptureSourceApp;
+  sourcePath: string;
+  sourceSessionId?: string;
+  sourceProvider?: string;
+  sourceModel?: string;
+  sourceWorkspace?: string;
+  occurredAt?: number;
+}
+
+interface ExternalIngestionLogger {
+  info?: (message: string) => void;
+  warn: (message: string) => void;
+}
+
+interface FileCursorState {
+  lineCount: number;
+  size: number;
+  mtimeMs: number;
+  sourceSessionId?: string;
+  sourceProvider?: string;
+  sourceModel?: string;
+  sourceWorkspace?: string;
+}
+
+interface ExternalIngestionState {
+  version: number;
+  files: Record<string, FileCursorState>;
+}
+
+interface ExternalIngestionManagerOptions {
+  config?: ExternalIngestionConfig;
+  stateFilePath: string;
+  logger: ExternalIngestionLogger;
+  onCandidates: (items: ExternalCaptureCandidate[]) => Promise<void>;
+}
+
+interface ParsedSourceBatch {
+  candidates: ExternalCaptureCandidate[];
+  cursorPatch?: Partial<FileCursorState>;
+}
+
+interface JsonlLineEnvelope {
+  timestamp?: string;
+  type?: string;
+  payload?: Record<string, unknown>;
+  message?: Record<string, unknown>;
+  sessionId?: string;
+  cwd?: string;
+}
+
+const DEFAULT_SCAN_INTERVAL_MS = 10 * 60_000;
+const DEFAULT_INACTIVITY_WINDOW_MS = 3 * 60_000;
+const DEFAULT_MAX_FILES_PER_SCAN = 40;
+
+function resolveHomePath(value: string): string {
+  if (!value.startsWith("~/")) return value;
+  return join(homedir(), value.slice(2));
+}
+
+function asArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const parsed = value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => resolveHomePath(item.trim()))
+    .filter((item) => item.length > 0);
+  return parsed.length > 0 ? parsed : undefined;
+}
+
+function asText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value > 1_000_000_000_000 ? value : value * 1000;
+  }
+  if (typeof value === "string") {
+    const asNumber = Number(value);
+    if (Number.isFinite(asNumber)) {
+      return asNumber > 1_000_000_000_000 ? asNumber : asNumber * 1000;
+    }
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function extractClaudeTextContent(content: unknown): string | undefined {
+  if (typeof content === "string") {
+    const trimmed = content.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (!Array.isArray(content)) return undefined;
+  const texts = content
+    .filter((block) => block && typeof block === "object")
+    .map((block) => block as Record<string, unknown>)
+    .filter((block) => block.type === "text" && typeof block.text === "string")
+    .map((block) => String(block.text).trim())
+    .filter((text) => text.length > 0);
+  if (texts.length === 0) return undefined;
+  return texts.join("\n");
+}
+
+function extractCodexAssistantText(content: unknown): string | undefined {
+  if (!Array.isArray(content)) return undefined;
+  const texts = content
+    .filter((block) => block && typeof block === "object")
+    .map((block) => block as Record<string, unknown>)
+    .filter((block) => block.type === "output_text" && typeof block.text === "string")
+    .map((block) => String(block.text).trim())
+    .filter((text) => text.length > 0);
+  if (texts.length === 0) return undefined;
+  return texts.join("\n");
+}
+
+async function walkJsonlFiles(
+  root: string,
+  options?: { includeSubagents?: boolean; fileNameMatcher?: (name: string) => boolean },
+): Promise<string[]> {
+  const out: string[] = [];
+  const stack = [root];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+
+    let entries;
+    try {
+      entries = await readdir(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const nextPath = join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (options?.includeSubagents === false && entry.name === "subagents") {
+          continue;
+        }
+        stack.push(nextPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith(".jsonl")) continue;
+      if (options?.fileNameMatcher && !options.fileNameMatcher(entry.name)) continue;
+      out.push(nextPath);
+    }
+  }
+
+  return out;
+}
+
+async function sortFilesByMtimeDesc(filePaths: string[]): Promise<Array<{ path: string; size: number; mtimeMs: number }>> {
+  const withStats = await Promise.all(
+    filePaths.map(async (filePath) => {
+      try {
+        const st = await stat(filePath);
+        return { path: filePath, size: st.size, mtimeMs: st.mtimeMs };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return withStats
+    .filter((item): item is { path: string; size: number; mtimeMs: number } => item !== null)
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+function splitJsonlLines(raw: string): string[] {
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+async function readNewJsonlLines(
+  filePath: string,
+  currentSize: number,
+  currentMtimeMs: number,
+  cursor: FileCursorState | undefined,
+): Promise<{ lines: string[]; nextCursor: FileCursorState }> {
+  const raw = await readFile(filePath, "utf-8");
+  const lines = splitJsonlLines(raw);
+
+  const previousLineCount = cursor && cursor.size <= currentSize ? cursor.lineCount : 0;
+  const nextLines = lines.slice(previousLineCount);
+
+  return {
+    lines: nextLines,
+    nextCursor: {
+      ...cursor,
+      lineCount: lines.length,
+      size: currentSize,
+      mtimeMs: currentMtimeMs,
+    },
+  };
+}
+
+export function parseClaudeJsonlLines(
+  filePath: string,
+  lines: string[],
+  cursor?: FileCursorState,
+): ParsedSourceBatch {
+  const candidates: ExternalCaptureCandidate[] = [];
+  const cursorPatch: Partial<FileCursorState> = {};
+
+  for (const line of lines) {
+    let parsed: JsonlLineEnvelope;
+    try {
+      parsed = JSON.parse(line) as JsonlLineEnvelope;
+    } catch {
+      continue;
+    }
+
+    const message = parsed.message;
+    if (!message || typeof message !== "object") continue;
+
+    const role = asText(message.role);
+    if (role !== "user" && role !== "assistant") continue;
+
+    const text = extractClaudeTextContent(message.content);
+    if (!text) continue;
+
+    const occurredAt = parseTimestamp(parsed.timestamp);
+    const sourceModel = asText(message.model);
+
+    cursorPatch.sourceSessionId = asText(parsed.sessionId) ?? cursor?.sourceSessionId;
+    cursorPatch.sourceModel = sourceModel ?? cursor?.sourceModel;
+    cursorPatch.sourceWorkspace = asText(parsed.cwd) ?? cursor?.sourceWorkspace;
+
+    candidates.push({
+      text,
+      role,
+      sourceApp: "claude",
+      sourcePath: filePath,
+      sourceSessionId: cursorPatch.sourceSessionId,
+      sourceProvider: sourceModel,
+      sourceModel,
+      sourceWorkspace: cursorPatch.sourceWorkspace,
+      occurredAt,
+    });
+  }
+
+  return { candidates, cursorPatch };
+}
+
+export function parseCodexJsonlLines(
+  filePath: string,
+  lines: string[],
+  cursor?: FileCursorState,
+): ParsedSourceBatch {
+  const candidates: ExternalCaptureCandidate[] = [];
+  const cursorPatch: Partial<FileCursorState> = {
+    sourceSessionId: cursor?.sourceSessionId,
+    sourceProvider: cursor?.sourceProvider,
+    sourceWorkspace: cursor?.sourceWorkspace,
+  };
+
+  for (const line of lines) {
+    let parsed: JsonlLineEnvelope;
+    try {
+      parsed = JSON.parse(line) as JsonlLineEnvelope;
+    } catch {
+      continue;
+    }
+
+    if (parsed.type === "session_meta" && parsed.payload && typeof parsed.payload === "object") {
+      cursorPatch.sourceSessionId = asText(parsed.payload.id) ?? cursorPatch.sourceSessionId;
+      cursorPatch.sourceProvider = asText(parsed.payload.model_provider) ?? cursorPatch.sourceProvider;
+      cursorPatch.sourceWorkspace = asText(parsed.payload.cwd) ?? cursorPatch.sourceWorkspace;
+      continue;
+    }
+
+    if (parsed.type === "event_msg" && parsed.payload?.type === "user_message") {
+      const text = asText(parsed.payload.message);
+      if (!text) continue;
+
+      candidates.push({
+        text,
+        role: "user",
+        sourceApp: "codex",
+        sourcePath: filePath,
+        sourceSessionId: cursorPatch.sourceSessionId,
+        sourceProvider: cursorPatch.sourceProvider,
+        sourceWorkspace: cursorPatch.sourceWorkspace,
+        occurredAt: parseTimestamp(parsed.timestamp),
+      });
+      continue;
+    }
+
+    if (parsed.type === "response_item" && parsed.payload?.type === "message" && parsed.payload.role === "assistant") {
+      const phase = asText(parsed.payload.phase);
+      if (phase && phase !== "final_answer") continue;
+
+      const text = extractCodexAssistantText(parsed.payload.content);
+      if (!text) continue;
+
+      candidates.push({
+        text,
+        role: "assistant",
+        sourceApp: "codex",
+        sourcePath: filePath,
+        sourceSessionId: cursorPatch.sourceSessionId,
+        sourceProvider: cursorPatch.sourceProvider,
+        sourceWorkspace: cursorPatch.sourceWorkspace,
+        occurredAt: parseTimestamp(parsed.timestamp),
+      });
+    }
+  }
+
+  return { candidates, cursorPatch };
+}
+
+async function loadState(filePath: string): Promise<ExternalIngestionState> {
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as ExternalIngestionState;
+    if (parsed && typeof parsed === "object" && parsed.version === 1 && parsed.files && typeof parsed.files === "object") {
+      return parsed;
+    }
+  } catch {
+    // ignore
+  }
+  return { version: 1, files: {} };
+}
+
+async function saveState(filePath: string, state: ExternalIngestionState): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true }).catch(() => {});
+  await writeFile(filePath, JSON.stringify(state, null, 2), "utf-8");
+}
+
+export function normalizeExternalIngestionConfig(config: ExternalIngestionConfig | undefined): Required<ExternalIngestionConfig> {
+  const claudeRoots = asArray(config?.sources?.claude?.roots) ?? [join(homedir(), ".claude", "projects")];
+  const codexRoots = asArray(config?.sources?.codex?.roots) ?? [join(homedir(), ".codex", "sessions")];
+  const wechatRoots = asArray(config?.sources?.wechat?.roots) ?? [];
+
+  return {
+    enabled: config?.enabled === true,
+    scanIntervalMs: Math.max(60_000, Math.floor(config?.scanIntervalMs ?? DEFAULT_SCAN_INTERVAL_MS)),
+    inactivityWindowMs: Math.max(60_000, Math.floor(config?.inactivityWindowMs ?? DEFAULT_INACTIVITY_WINDOW_MS)),
+    sources: {
+      claude: {
+        enabled: config?.sources?.claude?.enabled === true,
+        roots: claudeRoots,
+        includeSubagents: config?.sources?.claude?.includeSubagents !== false,
+        maxFilesPerScan: Math.max(1, Math.floor(config?.sources?.claude?.maxFilesPerScan ?? DEFAULT_MAX_FILES_PER_SCAN)),
+      },
+      codex: {
+        enabled: config?.sources?.codex?.enabled === true,
+        roots: codexRoots,
+        maxFilesPerScan: Math.max(1, Math.floor(config?.sources?.codex?.maxFilesPerScan ?? DEFAULT_MAX_FILES_PER_SCAN)),
+      },
+      wechat: {
+        enabled: config?.sources?.wechat?.enabled === true,
+        roots: wechatRoots,
+        placeholder: config?.sources?.wechat?.placeholder !== false,
+      },
+    },
+  };
+}
+
+export function createExternalIngestionManager(options: ExternalIngestionManagerOptions) {
+  const config = normalizeExternalIngestionConfig(options.config);
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let running = false;
+  let warnedWechatPlaceholder = false;
+  const watchers: FSWatcher[] = [];
+  const finalizeTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const statePromise = loadState(options.stateFilePath);
+
+  const parserBySourceApp: Record<Extract<CaptureSourceApp, "claude" | "codex">, (filePath: string, lines: string[], cursor?: FileCursorState) => ParsedSourceBatch> = {
+    claude: parseClaudeJsonlLines,
+    codex: parseCodexJsonlLines,
+  };
+
+  function isRelevantSourceFile(
+    sourceApp: Extract<CaptureSourceApp, "claude" | "codex">,
+    filePath: string,
+  ): boolean {
+    if (!filePath.endsWith(".jsonl")) return false;
+    if (sourceApp === "codex") return basename(filePath).startsWith("rollout-");
+    if (sourceApp === "claude" && config.sources.claude.includeSubagents === false && filePath.includes(`${join("", "subagents")}`)) {
+      return false;
+    }
+    return true;
+  }
+
+  async function processSourceFile(
+    sourceApp: Extract<CaptureSourceApp, "claude" | "codex">,
+    filePath: string,
+    reason: "watch-finalize" | "fallback-scan",
+  ): Promise<number> {
+    if (!isRelevantSourceFile(sourceApp, filePath)) return 0;
+
+    let currentStat;
+    try {
+      currentStat = await stat(filePath);
+    } catch {
+      return 0;
+    }
+
+    const ageMs = Date.now() - currentStat.mtimeMs;
+    if (ageMs < config.inactivityWindowMs) {
+      const remainingMs = Math.max(1_000, config.inactivityWindowMs - ageMs + 500);
+      scheduleFinalize(sourceApp, filePath, remainingMs);
+      return 0;
+    }
+
+    const state = await statePromise;
+    const stateKey = `${sourceApp}:${filePath}`;
+    const previousCursor = state.files[stateKey];
+    if (previousCursor && previousCursor.size === currentStat.size && previousCursor.mtimeMs === currentStat.mtimeMs) {
+      return 0;
+    }
+
+    let nextCursor: FileCursorState;
+    let newLines: string[];
+    try {
+      const readResult = await readNewJsonlLines(filePath, currentStat.size, currentStat.mtimeMs, previousCursor);
+      nextCursor = readResult.nextCursor;
+      newLines = readResult.lines;
+    } catch (error) {
+      options.logger.warn(`memory-lancedb-pro: failed to read ${sourceApp} transcript ${filePath}: ${String(error)}`);
+      return 0;
+    }
+
+    if (newLines.length === 0) {
+      state.files[stateKey] = nextCursor;
+      await saveState(options.stateFilePath, state);
+      return 0;
+    }
+
+    const parsed = parserBySourceApp[sourceApp](filePath, newLines, previousCursor);
+    nextCursor = { ...nextCursor, ...parsed.cursorPatch };
+    state.files[stateKey] = nextCursor;
+    await saveState(options.stateFilePath, state);
+
+    if (parsed.candidates.length > 0) {
+      await options.onCandidates(parsed.candidates);
+      options.logger.info?.(
+        `memory-lancedb-pro: ${sourceApp} finalized ${parsed.candidates.length} message(s) via ${reason}`,
+      );
+      return parsed.candidates.length;
+    }
+
+    return 0;
+  }
+
+  function finalizeKey(sourceApp: Extract<CaptureSourceApp, "claude" | "codex">, filePath: string): string {
+    return `${sourceApp}:${filePath}`;
+  }
+
+  function scheduleFinalize(
+    sourceApp: Extract<CaptureSourceApp, "claude" | "codex">,
+    filePath: string,
+    delayMs = config.inactivityWindowMs,
+  ): void {
+    if (!isRelevantSourceFile(sourceApp, filePath)) return;
+
+    const key = finalizeKey(sourceApp, filePath);
+    const existing = finalizeTimers.get(key);
+    if (existing) clearTimeout(existing);
+
+    const timeout = setTimeout(() => {
+      finalizeTimers.delete(key);
+      void processSourceFile(sourceApp, filePath, "watch-finalize");
+    }, Math.max(1_000, delayMs));
+
+    finalizeTimers.set(key, timeout);
+  }
+
+  function registerWatcher(
+    sourceApp: Extract<CaptureSourceApp, "claude" | "codex">,
+    root: string,
+  ): void {
+    try {
+      const watcher = watch(root, { recursive: true }, (_eventType, filename) => {
+        const relativePath = typeof filename === "string" ? filename.trim() : "";
+        if (!relativePath) return;
+        const filePath = join(root, relativePath);
+        scheduleFinalize(sourceApp, filePath);
+      });
+      watcher.on("error", (error) => {
+        options.logger.warn(`memory-lancedb-pro: ${sourceApp} watcher failed for ${root}: ${String(error)}`);
+      });
+      watchers.push(watcher);
+    } catch (error) {
+      options.logger.warn(`memory-lancedb-pro: cannot start ${sourceApp} watcher on ${root}: ${String(error)}`);
+    }
+  }
+
+  const scanSourceFiles = async (
+    sourceApp: Extract<CaptureSourceApp, "claude" | "codex">,
+    filePaths: Array<{ path: string; size: number; mtimeMs: number }>,
+  ): Promise<number> => {
+    let captured = 0;
+
+    for (const file of filePaths) {
+      captured += await processSourceFile(sourceApp, file.path, "fallback-scan");
+    }
+    return captured;
+  };
+
+  const scanNow = async (): Promise<void> => {
+    if (!config.enabled || running) return;
+    running = true;
+    try {
+      let totalCaptured = 0;
+
+      if (config.sources.claude.enabled) {
+        const claudeFiles = await sortFilesByMtimeDesc(
+          (await Promise.all(
+            config.sources.claude.roots.map((root) =>
+              walkJsonlFiles(root, { includeSubagents: config.sources.claude.includeSubagents }),
+            ),
+          )).flat(),
+        );
+        totalCaptured += await scanSourceFiles(
+          "claude",
+          claudeFiles.slice(0, config.sources.claude.maxFilesPerScan),
+        );
+      }
+
+      if (config.sources.codex.enabled) {
+        const codexFiles = await sortFilesByMtimeDesc(
+          (await Promise.all(
+            config.sources.codex.roots.map((root) =>
+              walkJsonlFiles(root, { fileNameMatcher: (name) => name.startsWith("rollout-") }),
+            ),
+          )).flat(),
+        );
+        totalCaptured += await scanSourceFiles(
+          "codex",
+          codexFiles.slice(0, config.sources.codex.maxFilesPerScan),
+        );
+      }
+
+      if (config.sources.wechat.enabled && !warnedWechatPlaceholder) {
+        warnedWechatPlaceholder = true;
+        options.logger.info?.("memory-lancedb-pro: WeChat capture is reserved as a placeholder; no active collector is running yet");
+      }
+
+      if (totalCaptured > 0) {
+        options.logger.info?.(`memory-lancedb-pro: external ingestion captured ${totalCaptured} candidate message(s)`);
+      }
+    } catch (error) {
+      options.logger.warn(`memory-lancedb-pro: external ingestion scan failed: ${String(error)}`);
+    } finally {
+      running = false;
+    }
+  };
+
+  return {
+    enabled: config.enabled,
+    async start(): Promise<void> {
+      if (!config.enabled) return;
+      if (config.sources.claude.enabled) {
+        for (const root of config.sources.claude.roots) {
+          registerWatcher("claude", root);
+        }
+      }
+      if (config.sources.codex.enabled) {
+        for (const root of config.sources.codex.roots) {
+          registerWatcher("codex", root);
+        }
+      }
+      setTimeout(() => void scanNow(), 15_000);
+      timer = setInterval(() => void scanNow(), config.scanIntervalMs);
+    },
+    async stop(): Promise<void> {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+      for (const timeout of finalizeTimers.values()) {
+        clearTimeout(timeout);
+      }
+      finalizeTimers.clear();
+      for (const watcher of watchers) {
+        watcher.close();
+      }
+      watchers.length = 0;
+      const state = await statePromise;
+      await saveState(options.stateFilePath, state).catch(() => {});
+    },
+    scanNow,
+  };
+}
+
+export { DEFAULT_INACTIVITY_WINDOW_MS, DEFAULT_SCAN_INTERVAL_MS };

--- a/src/store.ts
+++ b/src/store.ts
@@ -421,6 +421,63 @@ export class MemoryStore {
     };
   }
 
+  async resolveByIdOrPrefix(id: string): Promise<MemoryEntry | null> {
+    await this.ensureInitialized();
+
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const prefixRegex = /^[0-9a-f]{8,}$/i;
+    const isFullId = uuidRegex.test(id);
+    const isPrefix = !isFullId && prefixRegex.test(id);
+
+    if (!isFullId && !isPrefix) {
+      throw new Error(`Invalid memory ID format: ${id}`);
+    }
+
+    let rows: any[];
+    if (isFullId) {
+      const safeId = escapeSqlLiteral(id);
+      rows = await this.table!.query()
+        .where(`id = '${safeId}'`)
+        .limit(1)
+        .toArray();
+    } else {
+      const all = await this.table!.query()
+        .select([
+          "id",
+          "text",
+          "vector",
+          "category",
+          "scope",
+          "importance",
+          "timestamp",
+          "metadata",
+        ])
+        .limit(1000)
+        .toArray();
+      rows = all.filter((row: any) => (row.id as string).startsWith(id));
+      if (rows.length > 1) {
+        throw new Error(
+          `Ambiguous prefix "${id}" matches ${rows.length} memories. Use a longer prefix or full ID.`,
+        );
+      }
+    }
+
+    if (rows.length === 0) return null;
+
+    const row = rows[0];
+    return {
+      id: row.id as string,
+      text: row.text as string,
+      vector: Array.from(row.vector as Iterable<number>),
+      category: row.category as MemoryEntry["category"],
+      scope: (row.scope as string | undefined) ?? "global",
+      importance: Number(row.importance),
+      timestamp: Number(row.timestamp),
+      metadata: (row.metadata as string) || "{}",
+    };
+  }
+
   async vectorSearch(vector: number[], limit = 5, minScore = 0.3, scopeFilter?: string[], options?: { excludeInactive?: boolean }): Promise<MemorySearchResult[]> {
     await this.ensureInitialized();
 
@@ -1014,10 +1071,23 @@ export class MemoryStore {
     return this._lastFtsError;
   }
 
+  set lastFtsError(value: string | null) {
+    this._lastFtsError = typeof value === "string" && value.trim().length > 0
+      ? value
+      : null;
+  }
+
   /** Get FTS index health status */
-  getFtsStatus(): { available: boolean; lastError: string | null } {
+  getFtsStatus(): {
+    available: boolean;
+    supported: boolean;
+    indexExists: boolean;
+    lastError: string | null;
+  } {
     return {
       available: this.ftsIndexCreated,
+      supported: this.ftsSupported,
+      indexExists: this.ftsIndexCreated,
       lastError: this._lastFtsError,
     };
   }
@@ -1038,7 +1108,7 @@ export class MemoryStore {
         }
       }
       // Recreate
-      await this.createFtsIndex(this.table!);
+      await (this as any).createFtsIndex(this.table!, true);
       this.ftsIndexCreated = true;
       this._lastFtsError = null;
       return { success: true };

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -9,10 +9,16 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { MemoryRetriever, RetrievalResult } from "./retriever.js";
-import type { MemoryStore } from "./store.js";
+import type { MemoryEntry, MemoryStore } from "./store.js";
 import { isNoise } from "./noise-filter.js";
 import { isSystemBypassId, resolveScopeFilter, parseAgentIdFromSessionKey, type MemoryScopeManager } from "./scopes.js";
 import type { Embedder } from "./embedder.js";
+import {
+  mergeCaptureMetadata,
+  type CaptureMetadataPayload,
+  type CaptureRole,
+  type CaptureSourceApp,
+} from "./capture-pipeline.js";
 import {
   appendRelation,
   buildSmartMetadata,
@@ -42,6 +48,14 @@ export const MEMORY_CATEGORIES = [
   "other",
 ] as const;
 
+const WRITABLE_MEMORY_CATEGORIES = [
+  "preference",
+  "fact",
+  "decision",
+  "entity",
+  "other",
+] as const;
+
 function stringEnum<T extends readonly [string, ...string[]]>(values: T) {
   return Type.Unsafe<T[number]>({
     type: "string",
@@ -53,6 +67,60 @@ export type MdMirrorWriter = (
   meta?: { source?: string; agentId?: string },
 ) => Promise<void>;
 
+export interface CaptureIngressParams {
+  text: string;
+  scope: string;
+  agentId?: string;
+  importance?: number;
+  category?: Exclude<MemoryEntry["category"], "reflection">;
+  sourceApp: CaptureSourceApp;
+  sourceRole: CaptureRole;
+  scoringRole?: CaptureRole;
+  ingestionMode: string;
+  explicitWrite?: boolean;
+  confirmed?: boolean;
+  occurredAt?: number;
+}
+
+export interface CaptureIngressResult {
+  action: "stored" | "updated" | "skipped";
+  reason?: string;
+  entry?: MemoryEntry;
+  matchedExisting?: {
+    id: string;
+    text: string;
+    scope: string;
+    similarity: number;
+  };
+}
+
+export type CaptureIngressWriter = (
+  params: CaptureIngressParams,
+) => Promise<CaptureIngressResult>;
+
+export interface CaptureValidationParams {
+  text: string;
+  sourceApp: CaptureSourceApp;
+  sourceRole: CaptureRole;
+  scoringRole?: CaptureRole;
+  sourceProvider?: string;
+  repetitionCount?: number;
+  ingestionMode?: string;
+  explicitWrite?: boolean;
+  confirmed?: boolean;
+}
+
+export interface CaptureValidationResult {
+  accepted: boolean;
+  reason?: string;
+  text: string;
+  metadataPayload?: CaptureMetadataPayload;
+}
+
+export type CaptureIngressValidator = (
+  params: CaptureValidationParams,
+) => Promise<CaptureValidationResult>;
+
 interface ToolContext {
   retriever: MemoryRetriever;
   store: MemoryStore;
@@ -61,6 +129,8 @@ interface ToolContext {
   agentId?: string;
   workspaceDir?: string;
   mdMirror?: MdMirrorWriter | null;
+  captureIngress?: CaptureIngressWriter | null;
+  captureValidator?: CaptureIngressValidator | null;
   workspaceBoundary?: WorkspaceBoundaryConfig;
 }
 
@@ -174,6 +244,58 @@ function resolveWorkspaceDir(toolCtx: unknown, fallback?: string): string {
 
 function escapeRegExp(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function describeIngressSkipReason(reason?: string): string {
+  switch (reason) {
+    case "empty":
+      return "empty text";
+    case "too-short":
+      return "text too short to persist safely";
+    case "too-long":
+      return "text too long to store as a single memory";
+    case "memory-management":
+      return "memory-management/control text";
+    case "system-noise":
+      return "system/control text";
+    case "code-block-only":
+      return "code-only content without durable memory signal";
+    case "secret-like-content":
+      return "secret-like content";
+    case "assistant-capture-disabled":
+      return "assistant capture disabled";
+    case "assistant-not-memory-like":
+      return "assistant text does not look memory-worthy";
+    case "below-threshold":
+      return "insufficient durable memory signal";
+    case "low-signal":
+      return "insufficient durable memory signal";
+    default:
+      return reason ? `filtered by ingress policy (${reason})` : "filtered by ingress policy";
+  }
+}
+
+function isProtectedWriteCategory(category?: string): boolean {
+  return category === "reflection";
+}
+
+function buildProtectedCategoryResult(category: string) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Category '${category}' is reserved for internal reflection storage.`,
+      },
+    ],
+    details: {
+      error: "protected_category",
+      category,
+    },
+  };
+}
+
+function isProtectedEntry(entry: Pick<MemoryEntry, "category"> | null | undefined): boolean {
+  return Boolean(entry && isProtectedWriteCategory(entry.category));
 }
 
 export function registerSelfImprovementLogTool(api: OpenClawPluginApi, context: ToolContext) {
@@ -455,13 +577,14 @@ export function registerMemoryRecallTool(
           scope?: string;
           category?: string;
         };
+        const safeLimit = clampInt(limit, 1, 20);
+        let scopeFilter: string[] | undefined;
 
         try {
-          const safeLimit = clampInt(limit, 1, 20);
           const agentId = runtimeContext.agentId;
 
           // Determine accessible scopes
-          let scopeFilter = resolveScopeFilter(runtimeContext.scopeManager, agentId);
+          scopeFilter = resolveScopeFilter(runtimeContext.scopeManager, agentId);
           if (scope) {
             if (runtimeContext.scopeManager.isAccessible(scope, agentId)) {
               scopeFilter = [scope];
@@ -485,28 +608,26 @@ export function registerMemoryRecallTool(
             category,
             source: "manual",
           }), runtimeContext.workspaceBoundary);
+          const diagnostics =
+            typeof runtimeContext.retriever.getLastDiagnostics === "function"
+              ? runtimeContext.retriever.getLastDiagnostics()
+              : null;
+          const retrievalMode = runtimeContext.retriever.getConfig().mode;
 
           if (results.length === 0) {
             return {
               content: [{ type: "text", text: "No relevant memories found." }],
-              details: { count: 0, query, scopes: scopeFilter },
+              details: {
+                count: 0,
+                query,
+                limit: safeLimit,
+                category,
+                scopes: scopeFilter,
+                retrievalMode,
+                ...(diagnostics ? { diagnostics } : {}),
+              },
             };
           }
-
-          const now = Date.now();
-          await Promise.allSettled(
-            results.map((result) => {
-              const meta = parseSmartMetadata(result.entry.metadata, result.entry);
-              return runtimeContext.store.patchMetadata(
-                result.entry.id,
-                {
-                  access_count: meta.access_count + 1,
-                  last_accessed_at: now,
-                },
-                scopeFilter,
-              );
-            }),
-          );
 
           const text = results
             .map((r, i) => {
@@ -526,11 +647,19 @@ export function registerMemoryRecallTool(
               count: results.length,
               memories: sanitizeMemoryForSerialization(results),
               query,
+              limit: safeLimit,
+              category,
               scopes: scopeFilter,
-              retrievalMode: runtimeContext.retriever.getConfig().mode,
+              retrievalMode,
+              ...(diagnostics ? { diagnostics } : {}),
             },
           };
         } catch (error) {
+          const diagnostics =
+            typeof runtimeContext.retriever.getLastDiagnostics === "function"
+              ? runtimeContext.retriever.getLastDiagnostics()
+              : null;
+          const retrievalMode = runtimeContext.retriever.getConfig().mode;
           return {
             content: [
               {
@@ -538,7 +667,16 @@ export function registerMemoryRecallTool(
                 text: `Memory recall failed: ${error instanceof Error ? error.message : String(error)}`,
               },
             ],
-            details: { error: "recall_failed", message: String(error) },
+            details: {
+              error: "recall_failed",
+              message: String(error),
+              query,
+              limit: safeLimit,
+              category,
+              scopes: scopeFilter,
+              retrievalMode,
+              ...(diagnostics ? { diagnostics } : {}),
+            },
           };
         }
       },
@@ -565,7 +703,7 @@ export function registerMemoryStoreTool(
         importance: Type.Optional(
           Type.Number({ description: "Importance score 0-1 (default: 0.7)" }),
         ),
-        category: Type.Optional(stringEnum(MEMORY_CATEGORIES)),
+        category: Type.Optional(stringEnum(WRITABLE_MEMORY_CATEGORIES)),
         scope: Type.Optional(
           Type.String({
             description: "Memory scope (optional, defaults to agent scope)",
@@ -587,6 +725,9 @@ export function registerMemoryStoreTool(
 
         try {
           const agentId = runtimeContext.agentId;
+          if (isProtectedWriteCategory(category)) {
+            return buildProtectedCategoryResult(category);
+          }
           // Determine target scope
           let targetScope = scope;
           if (!targetScope) {
@@ -657,6 +798,60 @@ export function registerMemoryStoreTool(
           }
 
           const safeImportance = clamp01(importance, 0.7);
+          if (context.captureIngress) {
+            const captureResult = await context.captureIngress({
+              text,
+              scope: targetScope,
+              importance: safeImportance,
+              category: category as Exclude<MemoryEntry["category"], "reflection">,
+              sourceApp: "openclaw",
+              sourceRole: "assistant",
+              scoringRole: "user",
+              ingestionMode: "memory_store",
+              explicitWrite: true,
+              confirmed: true,
+              agentId,
+            });
+
+            if (captureResult.action === "skipped") {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `Skipped: ${describeIngressSkipReason(captureResult.reason)}`,
+                  },
+                ],
+                details: {
+                  action: "skipped",
+                  reason: captureResult.reason || "filtered",
+                  scope: targetScope,
+                },
+              };
+            }
+
+            const persisted = captureResult.entry;
+            const verb = captureResult.action === "updated"
+              ? "Updated similar memory"
+              : "Stored";
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `${verb}: "${text.slice(0, 100)}${text.length > 100 ? "..." : ""}" in scope '${targetScope}'`,
+                },
+              ],
+              details: {
+                action: captureResult.action,
+                id: persisted?.id,
+                scope: persisted?.scope || targetScope,
+                category: persisted?.category || category,
+                importance: persisted?.importance ?? safeImportance,
+                existingId: captureResult.matchedExisting?.id,
+                similarity: captureResult.matchedExisting?.similarity,
+              },
+            };
+          }
+
           const vector = await runtimeContext.embedder.embedPassage(text);
 
           // Check for duplicates using raw vector similarity (bypasses importance/recency weighting)
@@ -807,6 +1002,22 @@ export function registerMemoryForgetTool(
           }
 
           if (memoryId) {
+            const existing = await context.store.resolveByIdOrPrefix(memoryId);
+            if (!existing || !scopeFilter.includes(existing.scope)) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `Memory ${memoryId} not found or access denied.`,
+                  },
+                ],
+                details: { error: "not_found", id: memoryId },
+              };
+            }
+            if (isProtectedEntry(existing)) {
+              return buildProtectedCategoryResult(existing.category);
+            }
+
             const deleted = await context.store.delete(memoryId, scopeFilter);
             if (deleted) {
               return {
@@ -834,19 +1045,24 @@ export function registerMemoryForgetTool(
               limit: 5,
               scopeFilter,
             });
+            const editableResults = results.filter((row) => !isProtectedEntry(row.entry));
 
-            if (results.length === 0) {
+            if (editableResults.length === 0) {
               return {
                 content: [
-                  { type: "text", text: "No matching memories found." },
+                  { type: "text", text: "No matching editable memories found." },
                 ],
-                details: { found: 0, query },
+                details: {
+                  found: 0,
+                  query,
+                  protectedFiltered: results.length,
+                },
               };
             }
 
-            if (results.length === 1 && results[0].score > 0.9) {
+            if (editableResults.length === 1 && editableResults[0].score > 0.9) {
               const deleted = await context.store.delete(
-                results[0].entry.id,
+                editableResults[0].entry.id,
                 scopeFilter,
               );
               if (deleted) {
@@ -854,15 +1070,15 @@ export function registerMemoryForgetTool(
                   content: [
                     {
                       type: "text",
-                      text: `Forgotten: "${results[0].entry.text}"`,
+                      text: `Forgotten: "${editableResults[0].entry.text}"`,
                     },
                   ],
-                  details: { action: "deleted", id: results[0].entry.id },
+                  details: { action: "deleted", id: editableResults[0].entry.id },
                 };
               }
             }
 
-            const list = results
+            const list = editableResults
               .map(
                 (r) =>
                   `- [${r.entry.id.slice(0, 8)}] ${r.entry.text.slice(0, 60)}${r.entry.text.length > 60 ? "..." : ""}`,
@@ -873,12 +1089,13 @@ export function registerMemoryForgetTool(
               content: [
                 {
                   type: "text",
-                  text: `Found ${results.length} candidates. Specify memoryId to delete:\n${list}`,
+                  text: `Found ${editableResults.length} candidates. Specify memoryId to delete:\n${list}`,
                 },
               ],
               details: {
                 action: "candidates",
-                candidates: sanitizeMemoryForSerialization(results),
+                candidates: sanitizeMemoryForSerialization(editableResults),
+                protectedFiltered: results.length - editableResults.length,
               },
             };
           }
@@ -950,6 +1167,9 @@ export function registerMemoryUpdateTool(
         };
 
         try {
+          if (isProtectedWriteCategory(category)) {
+            return buildProtectedCategoryResult(category);
+          }
           if (!text && importance === undefined && !category) {
             return {
               content: [
@@ -968,6 +1188,7 @@ export function registerMemoryUpdateTool(
 
           // Resolve memoryId: if it doesn't look like a UUID, try search
           let resolvedId = memoryId;
+          let resolvedEntry: MemoryEntry | null = null;
           const uuidLike = /^[0-9a-f]{8}(-[0-9a-f]{4}){0,4}/i.test(memoryId);
           if (!uuidLike) {
             // Treat as search query
@@ -989,6 +1210,7 @@ export function registerMemoryUpdateTool(
             }
             if (results.length === 1 || results[0].score > 0.85) {
               resolvedId = results[0].entry.id;
+              resolvedEntry = results[0].entry;
             } else {
               const list = results
                 .map(
@@ -1013,8 +1235,58 @@ export function registerMemoryUpdateTool(
 
           // If text changed, re-embed; reject noise
           let newVector: number[] | undefined;
+          let nextText = text;
+          let nextMetadata: string | undefined;
+          if (!resolvedEntry) {
+            resolvedEntry = await context.store.resolveByIdOrPrefix(resolvedId);
+          }
+          if (!resolvedEntry || !scopeFilter.includes(resolvedEntry.scope)) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Memory ${resolvedId.slice(0, 8)}... not found or access denied.`,
+                },
+              ],
+              details: { error: "not_found", id: resolvedId },
+            };
+          }
+          if (isProtectedEntry(resolvedEntry)) {
+            return buildProtectedCategoryResult(resolvedEntry.category);
+          }
           if (text) {
-            if (isNoise(text)) {
+            if (context.captureValidator) {
+              const validation = await context.captureValidator({
+                text,
+                sourceApp: "openclaw",
+                sourceRole: "assistant",
+                scoringRole: "user",
+                ingestionMode: "memory_update",
+                explicitWrite: true,
+                confirmed: true,
+              });
+              if (!validation.accepted) {
+                return {
+                  content: [
+                    {
+                      type: "text",
+                      text: `Skipped: ${describeIngressSkipReason(validation.reason)}`,
+                    },
+                  ],
+                  details: {
+                    action: "skipped",
+                    reason: validation.reason || "filtered",
+                  },
+                };
+              }
+              nextText = validation.text;
+              if (validation.metadataPayload) {
+                nextMetadata = mergeCaptureMetadata(
+                  resolvedEntry.metadata,
+                  validation.metadataPayload,
+                );
+              }
+            } else if (isNoise(text)) {
               return {
                 content: [
                   {
@@ -1025,28 +1297,28 @@ export function registerMemoryUpdateTool(
                 details: { action: "noise_filtered" },
               };
             }
-            newVector = await context.embedder.embedPassage(text);
+            newVector = await context.embedder.embedPassage(nextText);
           }
 
           // --- Temporal supersede guard ---
           // For temporal-versioned categories (preferences/entities), changing
           // text must go through supersede to preserve the history chain.
           if (text && newVector) {
-            const existing = await context.store.getById(resolvedId, scopeFilter);
+            const existing = resolvedEntry;
             if (existing) {
               const meta = parseSmartMetadata(existing.metadata, existing);
               if (TEMPORAL_VERSIONED_CATEGORIES.has(meta.memory_category)) {
                 const now = Date.now();
                 const factKey =
-                  meta.fact_key ?? deriveFactKey(meta.memory_category, text);
+                  meta.fact_key ?? deriveFactKey(meta.memory_category, nextText);
 
                 // Create new superseding record
                 const newMeta = buildSmartMetadata(
-                  { text, category: existing.category },
+                  { text: nextText, category: existing.category },
                   {
-                    l0_abstract: text,
+                    l0_abstract: nextText,
                     l1_overview: meta.l1_overview,
-                    l2_content: text,
+                    l2_content: nextText,
                     memory_category: meta.memory_category,
                     tier: meta.tier,
                     access_count: 0,
@@ -1062,7 +1334,7 @@ export function registerMemoryUpdateTool(
                 );
 
                 const newEntry = await context.store.store({
-                  text,
+                  text: nextText,
                   vector: newVector,
                   category: category ? (category as any) : existing.category,
                   scope: existing.scope,
@@ -1100,7 +1372,7 @@ export function registerMemoryUpdateTool(
                   content: [
                     {
                       type: "text",
-                      text: `Superseded memory ${resolvedId.slice(0, 8)}... → new version ${newEntry.id.slice(0, 8)}...: "${text.slice(0, 80)}${text.length > 80 ? "..." : ""}"`,
+                      text: `Superseded memory ${resolvedId.slice(0, 8)}... → new version ${newEntry.id.slice(0, 8)}...: "${nextText.slice(0, 80)}${nextText.length > 80 ? "..." : ""}"`,
                     },
                   ],
                   details: {
@@ -1116,8 +1388,9 @@ export function registerMemoryUpdateTool(
           // --- End temporal supersede guard ---
 
           const updates: Record<string, any> = {};
-          if (text) updates.text = text;
+          if (text) updates.text = nextText;
           if (newVector) updates.vector = newVector;
+          if (text && nextMetadata) updates.metadata = nextMetadata;
           if (importance !== undefined)
             updates.importance = clamp01(importance, 0.7);
           if (category) updates.category = category;

--- a/test/capture-pipeline.test.mjs
+++ b/test/capture-pipeline.test.mjs
@@ -1,0 +1,79 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const {
+  DEFAULT_CAPTURE_POLICY,
+  isRecallEligibleMemory,
+  mergeCaptureMetadata,
+  scoreMemoryCandidate,
+} = jiti("../src/capture-pipeline.ts");
+
+describe("capture pipeline scoring", () => {
+  it("promotes explicit user preference/decision to formal memory", () => {
+    const result = scoreMemoryCandidate({
+      text: "记住：以后 OpenAI 中转作为主模型，MiniMax 只做备用模型。",
+      role: "user",
+      sourceApp: "openclaw",
+      captureAssistant: true,
+    }, DEFAULT_CAPTURE_POLICY);
+
+    assert.equal(result.tier, "formal");
+    assert.ok(result.score >= 8);
+  });
+
+  it("caps unconfirmed assistant summaries into candidate tier", () => {
+    const result = scoreMemoryCandidate({
+      text: "总结：用户以后优先使用 OpenAI 中转，MiniMax 仅作备用。",
+      role: "assistant",
+      sourceApp: "codex",
+      captureAssistant: true,
+    }, DEFAULT_CAPTURE_POLICY);
+
+    assert.equal(result.tier, "candidate");
+    assert.ok(result.score <= 5);
+  });
+
+  it("rejects secret-like content", () => {
+    const result = scoreMemoryCandidate({
+      text: "这是我的 key：sk-abcdefghijklmnopqrstuvwxyz1234567890",
+      role: "user",
+      sourceApp: "openclaw",
+      captureAssistant: true,
+    }, DEFAULT_CAPTURE_POLICY);
+
+    assert.equal(result.tier, "discard");
+    assert.equal(result.rejectedReason, "secret-like-content");
+  });
+});
+
+describe("capture metadata recall gating", () => {
+  it("excludes candidate memories from recall by default", () => {
+    const candidateMetadata = mergeCaptureMetadata(undefined, {
+      memoryTier: "candidate",
+      captureScore: 5,
+      captureReasons: ["assistant-summary"],
+      normalizedKey: "user prefers openai relay",
+      sourceApp: "codex",
+      sourceRole: "assistant",
+    });
+
+    assert.equal(isRecallEligibleMemory({ metadata: candidateMetadata }, false), false);
+    assert.equal(isRecallEligibleMemory({ metadata: candidateMetadata }, true), true);
+  });
+
+  it("always allows formal memories in recall", () => {
+    const formalMetadata = mergeCaptureMetadata(undefined, {
+      memoryTier: "formal",
+      captureScore: 9,
+      captureReasons: ["explicit-remember"],
+      normalizedKey: "openai relay primary model",
+      sourceApp: "openclaw",
+      sourceRole: "user",
+    });
+
+    assert.equal(isRecallEligibleMemory({ metadata: formalMetadata }, false), true);
+  });
+});
+

--- a/test/cli-delete-protection.test.mjs
+++ b/test/cli-delete-protection.test.mjs
@@ -1,0 +1,155 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Command } from "commander";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+
+const { createMemoryCLI } = jiti("../cli.ts");
+
+async function runDeleteCommand({ id, scope, storeOverrides = {} }) {
+  const resolveCalls = [];
+  const deleteCalls = [];
+  const logs = [];
+  const errors = [];
+  const exitCalls = [];
+
+  const context = {
+    store: {
+      async resolveByIdOrPrefix(value) {
+        resolveCalls.push(value);
+        return {
+          id: "12345678-1234-1234-1234-1234567890ab",
+          text: "editable memory",
+          vector: [0.1, 0.2, 0.3],
+          category: "other",
+          scope: "scope-main",
+          importance: 0.7,
+          timestamp: 1700000000000,
+          metadata: "{}",
+        };
+      },
+      async delete(value, scopes) {
+        deleteCalls.push({ id: value, scopes });
+        return true;
+      },
+      ...storeOverrides,
+    },
+    retriever: {},
+    scopeManager: {},
+    migrator: {},
+  };
+
+  const program = new Command();
+  program.exitOverride();
+  createMemoryCLI(context)({ program });
+
+  const argv = ["node", "openclaw", "memory-pro", "delete", id];
+  if (scope) {
+    argv.push("--scope", scope);
+  }
+
+  const origLog = console.log;
+  const origError = console.error;
+  const origExit = process.exit;
+  console.log = (...args) => logs.push(args.join(" "));
+  console.error = (...args) => errors.push(args.join(" "));
+  process.exit = ((code = 0) => {
+    exitCalls.push(Number(code));
+    throw new Error(`__TEST_EXIT__${code}`);
+  });
+
+  try {
+    await program.parseAsync(argv);
+    return {
+      resolveCalls,
+      deleteCalls,
+      logs,
+      errors,
+      exitCalls,
+      exitCode: null,
+    };
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("__TEST_EXIT__")) {
+      return {
+        resolveCalls,
+        deleteCalls,
+        logs,
+        errors,
+        exitCalls,
+        exitCode: exitCalls.at(-1) ?? null,
+      };
+    }
+    throw error;
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+    process.exit = origExit;
+  }
+}
+
+describe("cli delete protection", () => {
+  it("rejects deleting protected reflection entries", async () => {
+    const resolveCalls = [];
+    const result = await runDeleteCommand({
+      id: "12345678-1234-1234-1234-1234567890ab",
+      storeOverrides: {
+        async resolveByIdOrPrefix(value) {
+          resolveCalls.push(value);
+          return {
+            id: "12345678-1234-1234-1234-1234567890ab",
+            text: "reflection row",
+            vector: [0.1, 0.2, 0.3],
+            category: "reflection",
+            scope: "scope-main",
+            importance: 0.8,
+            timestamp: 1700000000000,
+            metadata: JSON.stringify({ type: "memory-reflection-item" }),
+          };
+        },
+      },
+    });
+
+    assert.deepEqual(resolveCalls, ["12345678-1234-1234-1234-1234567890ab"]);
+    assert.equal(result.deleteCalls.length, 0);
+    assert.equal(result.exitCode, 1);
+    assert.match(
+      result.logs.join("\n"),
+      /protected category "reflection" and cannot be deleted/i,
+    );
+  });
+
+  it("keeps prefix-id deletion support for editable memories", async () => {
+    const resolveCalls = [];
+    const result = await runDeleteCommand({
+      id: "12345678",
+      storeOverrides: {
+        async resolveByIdOrPrefix(value) {
+          resolveCalls.push(value);
+          return {
+            id: "12345678-1234-1234-1234-1234567890ab",
+            text: "editable memory",
+            vector: [0.1, 0.2, 0.3],
+            category: "other",
+            scope: "scope-main",
+            importance: 0.7,
+            timestamp: 1700000000000,
+            metadata: "{}",
+          };
+        },
+      },
+    });
+
+    assert.deepEqual(resolveCalls, ["12345678"]);
+    assert.equal(result.exitCode, null);
+    assert.equal(result.deleteCalls.length, 1);
+    assert.equal(
+      result.deleteCalls[0].id,
+      "12345678-1234-1234-1234-1234567890ab",
+    );
+    assert.match(
+      result.logs.join("\n"),
+      /Memory 12345678-1234-1234-1234-1234567890ab deleted successfully/i,
+    );
+  });
+});

--- a/test/external-ingestion.test.mjs
+++ b/test/external-ingestion.test.mjs
@@ -1,0 +1,96 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const {
+  parseClaudeJsonlLines,
+  parseCodexJsonlLines,
+} = jiti("../src/external-ingestion.ts");
+
+describe("Claude external ingestion parsing", () => {
+  it("keeps user/text assistant messages and skips non-text assistant blocks", () => {
+    const lines = [
+      JSON.stringify({
+        sessionId: "claude-s1",
+        cwd: "/Users/qingshan/project",
+        type: "user",
+        timestamp: "2026-03-09T10:00:00.000Z",
+        message: { role: "user", content: "记住：以后用 OpenAI 中转。" },
+      }),
+      JSON.stringify({
+        sessionId: "claude-s1",
+        cwd: "/Users/qingshan/project",
+        type: "assistant",
+        timestamp: "2026-03-09T10:00:05.000Z",
+        message: {
+          role: "assistant",
+          model: "Claude-3.7",
+          content: [
+            { type: "thinking", thinking: "hidden" },
+            { type: "text", text: "总结：用户偏好 OpenAI 中转为主。" },
+            { type: "tool_use", name: "Bash" },
+          ],
+        },
+      }),
+    ];
+
+    const parsed = parseClaudeJsonlLines("/tmp/claude.jsonl", lines);
+    assert.equal(parsed.candidates.length, 2);
+    assert.equal(parsed.candidates[0].role, "user");
+    assert.equal(parsed.candidates[1].role, "assistant");
+    assert.equal(parsed.candidates[1].sourceProvider, "Claude-3.7");
+  });
+});
+
+describe("Codex external ingestion parsing", () => {
+  it("captures user events and final assistant answers only", () => {
+    const lines = [
+      JSON.stringify({
+        timestamp: "2026-03-09T10:00:00.000Z",
+        type: "session_meta",
+        payload: {
+          id: "codex-s1",
+          cwd: "/Users/qingshan",
+          model_provider: "custom",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-09T10:00:01.000Z",
+        type: "event_msg",
+        payload: {
+          type: "user_message",
+          message: "记住：MiniMax 只作备用模型。",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-09T10:00:02.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "assistant",
+          phase: "commentary",
+          content: [{ type: "output_text", text: "我先查配置。" }],
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-03-09T10:00:10.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "assistant",
+          phase: "final_answer",
+          content: [{ type: "output_text", text: "已设置：OpenAI 中转主模型，MiniMax 备用。" }],
+        },
+      }),
+    ];
+
+    const parsed = parseCodexJsonlLines("/tmp/codex.jsonl", lines);
+    assert.equal(parsed.candidates.length, 2);
+    assert.equal(parsed.candidates[0].role, "user");
+    assert.equal(parsed.candidates[1].role, "assistant");
+    assert.equal(parsed.candidates[1].sourceProvider, "custom");
+    assert.equal(parsed.cursorPatch.sourceSessionId, "codex-s1");
+  });
+});
+

--- a/test/helpers/openclaw-extension-api-stub.mjs
+++ b/test/helpers/openclaw-extension-api-stub.mjs
@@ -1,0 +1,40 @@
+export async function runEmbeddedPiAgent(params = {}) {
+  return {
+    payloads: [
+      {
+        text: [
+          "## Context (session background)",
+          "- Current session reflection test fixture.",
+          `- Runner workspace: ${String(params?.workspaceDir || "(unknown)")}`,
+          "",
+          "## Decisions (durable)",
+          "- (none captured)",
+          "",
+          "## User model deltas (about the human)",
+          "- (none captured)",
+          "",
+          "## Agent model deltas (about the assistant/system)",
+          "- (none captured)",
+          "",
+          "## Lessons & pitfalls (symptom / cause / fix / prevention)",
+          "- (none captured)",
+          "",
+          "## Learning governance candidates (.learnings / promotion / skill extraction)",
+          "- (none captured)",
+          "",
+          "## Open loops / next actions",
+          "- Verify current reflection handoff after reset.",
+          "",
+          "## Retrieval tags / keywords",
+          "- memory-reflection",
+          "",
+          "## Invariants",
+          "- Keep inherited-rules in before_prompt_build only.",
+          "",
+          "## Derived",
+          "- Fresh derived line from this run.",
+        ].join("\n"),
+      },
+    ],
+  };
+}

--- a/test/memory-forget-protection.test.mjs
+++ b/test/memory-forget-protection.test.mjs
@@ -1,0 +1,238 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginSdkStubPath = path.resolve(testDir, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+
+const { registerMemoryForgetTool } = jiti("../src/tools.ts");
+
+function createHarness(overrides = {}) {
+  const factories = new Map();
+  const deleteCalls = [];
+  const resolveByIdCalls = [];
+  const retrieveCalls = [];
+
+  const api = {
+    registerTool(factory, meta) {
+      factories.set(meta?.name || "", factory);
+    },
+  };
+
+  const context = {
+    retriever: {
+      async retrieve(params) {
+        retrieveCalls.push(params);
+        return [];
+      },
+      ...(overrides.retriever || {}),
+    },
+    store: {
+      async resolveByIdOrPrefix(id) {
+        resolveByIdCalls.push(id);
+        return {
+          id,
+          text: "editable memory",
+          vector: [0.1, 0.2, 0.3],
+          category: "other",
+          scope: "scope-main",
+          importance: 0.7,
+          timestamp: 1700000000000,
+          metadata: "{}",
+        };
+      },
+      async delete(id, scopes) {
+        deleteCalls.push({ id, scopes });
+        return true;
+      },
+      ...(overrides.store || {}),
+    },
+    scopeManager: {
+      getAccessibleScopes() {
+        return ["scope-main"];
+      },
+      isAccessible() {
+        return true;
+      },
+      ...(overrides.scopeManager || {}),
+    },
+    agentId: overrides.agentId,
+  };
+
+  registerMemoryForgetTool(api, context);
+
+  return {
+    tool(toolCtx = {}) {
+      const factory = factories.get("memory_forget");
+      assert.ok(factory, "memory_forget tool should be registered");
+      return factory(toolCtx);
+    },
+    deleteCalls,
+    resolveByIdCalls,
+    retrieveCalls,
+  };
+}
+
+describe("memory_forget protection", () => {
+  it("rejects direct deletion of internal reflection entries", async () => {
+    const reflectionResolveCalls = [];
+    const harness = createHarness({
+      store: {
+        async resolveByIdOrPrefix(id) {
+          reflectionResolveCalls.push(id);
+          return {
+            id: "12345678-1234-1234-1234-1234567890ab",
+            text: "reflection row",
+            vector: [0.1, 0.2, 0.3],
+            category: "reflection",
+            scope: "scope-main",
+            importance: 0.8,
+            timestamp: 1700000000000,
+            metadata: JSON.stringify({ type: "memory-reflection-item" }),
+          };
+        },
+      },
+    });
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-protected-id", {
+      memoryId: "12345678-1234-1234-1234-1234567890ab",
+    });
+
+    assert.equal(reflectionResolveCalls.length, 1);
+    assert.equal(harness.deleteCalls.length, 0);
+    assert.match(result.content[0].text, /reserved for internal reflection storage/i);
+    assert.equal(result.details.error, "protected_category");
+    assert.equal(result.details.category, "reflection");
+  });
+
+  it("keeps prefix-id deletion support while protecting reflection rows", async () => {
+    const resolveCalls = [];
+    const harness = createHarness({
+      store: {
+        async resolveByIdOrPrefix(id) {
+          resolveCalls.push(id);
+          return {
+            id: "12345678-1234-1234-1234-1234567890ab",
+            text: "editable memory",
+            vector: [0.1, 0.2, 0.3],
+            category: "other",
+            scope: "scope-main",
+            importance: 0.7,
+            timestamp: 1700000000000,
+            metadata: "{}",
+          };
+        },
+      },
+    });
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-prefix-id", {
+      memoryId: "12345678",
+    });
+
+    assert.deepEqual(resolveCalls, ["12345678"]);
+    assert.equal(harness.deleteCalls.length, 1);
+    assert.equal(harness.deleteCalls[0].id, "12345678");
+    assert.equal(result.details.action, "deleted");
+  });
+
+  it("filters reflection rows out of query-based delete candidates", async () => {
+    const harness = createHarness({
+      retriever: {
+        async retrieve(params) {
+          harness.retrieveCalls.push(params);
+          return [
+            {
+              entry: {
+                id: "reflection-1",
+                text: "Reflection invariant row",
+                vector: [0.1, 0.2, 0.3],
+                category: "reflection",
+                scope: "scope-main",
+                importance: 0.8,
+                timestamp: 1700000000000,
+                metadata: JSON.stringify({ type: "memory-reflection-item" }),
+              },
+              score: 0.95,
+              sources: {},
+            },
+            {
+              entry: {
+                id: "memory-1",
+                text: "User prefers concise answers",
+                vector: [0.3, 0.2, 0.1],
+                category: "preference",
+                scope: "scope-main",
+                importance: 0.7,
+                timestamp: 1700000001000,
+                metadata: "{}",
+              },
+              score: 0.7,
+              sources: {},
+            },
+          ];
+        },
+      },
+    });
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-query-filter", {
+      query: "preference",
+    });
+
+    assert.equal(harness.retrieveCalls.length, 1);
+    assert.equal(harness.deleteCalls.length, 0);
+    assert.match(result.content[0].text, /Found 1 candidates/i);
+    assert.match(result.content[0].text, /User prefers concise answers/);
+    assert.doesNotMatch(result.content[0].text, /Reflection invariant row/);
+    assert.equal(result.details.protectedFiltered, 1);
+    assert.equal(result.details.candidates.length, 1);
+    assert.equal(result.details.candidates[0].id, "memory-1");
+  });
+
+  it("returns no editable matches when a query only finds protected reflection rows", async () => {
+    const harness = createHarness({
+      retriever: {
+        async retrieve(params) {
+          harness.retrieveCalls.push(params);
+          return [
+            {
+              entry: {
+                id: "reflection-1",
+                text: "Reflection invariant row",
+                vector: [0.1, 0.2, 0.3],
+                category: "reflection",
+                scope: "scope-main",
+                importance: 0.8,
+                timestamp: 1700000000000,
+                metadata: JSON.stringify({ type: "memory-reflection-item" }),
+              },
+              score: 0.95,
+              sources: {},
+            },
+          ];
+        },
+      },
+    });
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-query-protected-only", {
+      query: "reflection",
+    });
+
+    assert.equal(harness.retrieveCalls.length, 1);
+    assert.equal(harness.deleteCalls.length, 0);
+    assert.match(result.content[0].text, /No matching editable memories found/i);
+    assert.equal(result.details.found, 0);
+    assert.equal(result.details.protectedFiltered, 1);
+  });
+});

--- a/test/memory-recall-diagnostics.test.mjs
+++ b/test/memory-recall-diagnostics.test.mjs
@@ -1,0 +1,312 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginSdkStubPath = path.resolve(testDir, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+
+const { registerMemoryRecallTool } = jiti("../src/tools.ts");
+
+function buildResult(id = "memory-1", text = "服务崩溃 error") {
+  return {
+    entry: {
+      id,
+      text,
+      vector: [0.1, 0.2, 0.3],
+      category: "other",
+      scope: "scope-main",
+      importance: 0.7,
+      timestamp: 1700000000000,
+      metadata: "{}",
+    },
+    score: 0.9,
+    sources: {
+      vector: { score: 0.9, rank: 1 },
+      bm25: { score: 0.8, rank: 1 },
+      fused: { score: 0.9 },
+    },
+  };
+}
+
+function createHarness(overrides = {}) {
+  const factories = new Map();
+  const retrieveCalls = [];
+
+  const api = {
+    registerTool(factory, meta) {
+      factories.set(meta?.name || "", factory);
+    },
+  };
+
+  const context = {
+    retriever: {
+      async retrieve(params) {
+        retrieveCalls.push(params);
+        return [buildResult()];
+      },
+      getConfig() {
+        return { mode: "hybrid" };
+      },
+      getLastDiagnostics() {
+        return {
+          source: "manual",
+          mode: "hybrid",
+          originalQuery: "服务挂了",
+          bm25Query: "服务挂了 崩溃 crash error 报错 宕机",
+          queryExpanded: true,
+          limit: 5,
+          scopeFilter: ["scope-main"],
+          category: undefined,
+          vectorResultCount: 1,
+          bm25ResultCount: 1,
+          fusedResultCount: 1,
+          finalResultCount: 1,
+          stageCounts: {
+            afterMinScore: 1,
+            rerankInput: 1,
+            afterRerank: 1,
+            afterRecency: 1,
+            afterImportance: 1,
+            afterLengthNorm: 1,
+            afterTimeDecay: 1,
+            afterHardMinScore: 1,
+            afterNoiseFilter: 1,
+            afterDiversity: 1,
+          },
+          dropSummary: [],
+        };
+      },
+      ...(overrides.retriever || {}),
+    },
+    scopeManager: {
+      getAccessibleScopes() {
+        return ["scope-main"];
+      },
+      isAccessible() {
+        return true;
+      },
+      ...(overrides.scopeManager || {}),
+    },
+    agentId: overrides.agentId,
+  };
+
+  registerMemoryRecallTool(api, context);
+
+  return {
+    tool(toolCtx = {}) {
+      const factory = factories.get("memory_recall");
+      assert.ok(factory, "memory_recall tool should be registered");
+      return factory(toolCtx);
+    },
+    retrieveCalls,
+  };
+}
+
+describe("memory_recall diagnostics", () => {
+  it("attaches retrieval diagnostics to successful recall details", async () => {
+    const harness = createHarness();
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-memory-recall-hit", {
+      query: "服务挂了",
+      limit: 5,
+    });
+
+    assert.equal(harness.retrieveCalls.length, 1);
+    assert.equal(harness.retrieveCalls[0].source, "manual");
+    assert.equal(result.details.count, 1);
+    assert.equal(result.details.limit, 5);
+    assert.equal(result.details.category, undefined);
+    assert.equal(result.details.retrievalMode, "hybrid");
+    assert.deepEqual(result.details.diagnostics, {
+      source: "manual",
+      mode: "hybrid",
+      originalQuery: "服务挂了",
+      bm25Query: "服务挂了 崩溃 crash error 报错 宕机",
+      queryExpanded: true,
+      limit: 5,
+      scopeFilter: ["scope-main"],
+      category: undefined,
+      vectorResultCount: 1,
+      bm25ResultCount: 1,
+      fusedResultCount: 1,
+      finalResultCount: 1,
+      stageCounts: {
+        afterMinScore: 1,
+        rerankInput: 1,
+        afterRerank: 1,
+        afterRecency: 1,
+        afterImportance: 1,
+        afterLengthNorm: 1,
+        afterTimeDecay: 1,
+        afterHardMinScore: 1,
+        afterNoiseFilter: 1,
+        afterDiversity: 1,
+      },
+      dropSummary: [],
+    });
+  });
+
+  it("attaches diagnostics to zero-result recall details", async () => {
+    const harness = createHarness({
+      retriever: {
+        async retrieve() {
+          return [];
+        },
+        getLastDiagnostics() {
+          return {
+            source: "manual",
+            mode: "hybrid",
+            originalQuery: "无结果查询",
+            bm25Query: "无结果查询",
+            queryExpanded: false,
+            limit: 3,
+            scopeFilter: ["scope-main"],
+            category: undefined,
+            vectorResultCount: 0,
+            bm25ResultCount: 0,
+            fusedResultCount: 0,
+            finalResultCount: 0,
+            stageCounts: {
+              afterMinScore: 0,
+              rerankInput: 0,
+              afterRerank: 0,
+              afterRecency: 0,
+              afterImportance: 0,
+              afterLengthNorm: 0,
+              afterTimeDecay: 0,
+              afterHardMinScore: 0,
+              afterNoiseFilter: 0,
+              afterDiversity: 0,
+            },
+            dropSummary: [],
+          };
+        },
+      },
+    });
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-memory-recall-empty", {
+      query: "无结果查询",
+      limit: 3,
+    });
+
+    assert.equal(result.details.count, 0);
+    assert.equal(result.details.limit, 3);
+    assert.equal(result.details.category, undefined);
+    assert.equal(result.details.retrievalMode, "hybrid");
+    assert.deepEqual(result.details.diagnostics, {
+      source: "manual",
+      mode: "hybrid",
+      originalQuery: "无结果查询",
+      bm25Query: "无结果查询",
+      queryExpanded: false,
+      limit: 3,
+      scopeFilter: ["scope-main"],
+      category: undefined,
+      vectorResultCount: 0,
+      bm25ResultCount: 0,
+      fusedResultCount: 0,
+      finalResultCount: 0,
+      stageCounts: {
+        afterMinScore: 0,
+        rerankInput: 0,
+        afterRerank: 0,
+        afterRecency: 0,
+        afterImportance: 0,
+        afterLengthNorm: 0,
+        afterTimeDecay: 0,
+        afterHardMinScore: 0,
+        afterNoiseFilter: 0,
+        afterDiversity: 0,
+      },
+      dropSummary: [],
+    });
+    assert.match(result.content[0].text, /No relevant memories found/i);
+  });
+
+  it("keeps memory_recall compatible when diagnostics are unavailable", async () => {
+    const harness = createHarness({
+      retriever: {
+        getLastDiagnostics: undefined,
+      },
+    });
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-memory-recall-no-diag", {
+      query: "服务挂了",
+    });
+
+    assert.equal(result.details.count, 1);
+    assert.equal(result.details.retrievalMode, "hybrid");
+    assert.equal("diagnostics" in result.details, false);
+  });
+
+  it("attaches failure diagnostics when recall errors after retriever diagnostics are available", async () => {
+    const harness = createHarness({
+      retriever: {
+        async retrieve() {
+          throw new Error("simulated retrieval failure");
+        },
+        getLastDiagnostics() {
+          return {
+            source: "manual",
+            mode: "hybrid",
+            originalQuery: "服务挂了",
+            bm25Query: "服务挂了 崩溃 crash error 报错 宕机",
+            queryExpanded: true,
+            limit: 5,
+            scopeFilter: ["scope-main"],
+            category: undefined,
+            vectorResultCount: 0,
+            bm25ResultCount: 0,
+            fusedResultCount: 0,
+            finalResultCount: 0,
+            stageCounts: {
+              afterMinScore: 0,
+              rerankInput: 0,
+              afterRerank: 0,
+              afterRecency: 0,
+              afterImportance: 0,
+              afterLengthNorm: 0,
+              afterTimeDecay: 0,
+              afterHardMinScore: 0,
+              afterNoiseFilter: 0,
+              afterDiversity: 0,
+            },
+            dropSummary: [],
+            failureStage: "hybrid.embedQuery",
+            errorMessage: "simulated retrieval failure",
+          };
+        },
+      },
+    });
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-memory-recall-fail-diag", {
+      query: "服务挂了",
+      limit: 5,
+    });
+
+    assert.equal(result.details.error, "recall_failed");
+    assert.equal(result.details.query, "服务挂了");
+    assert.equal(result.details.limit, 5);
+    assert.equal(result.details.category, undefined);
+    assert.deepEqual(result.details.scopes, ["scope-main"]);
+    assert.equal(result.details.retrievalMode, "hybrid");
+    assert.equal(result.details.diagnostics.failureStage, "hybrid.embedQuery");
+    assert.equal(
+      result.details.diagnostics.errorMessage,
+      "simulated retrieval failure",
+    );
+    assert.match(result.content[0].text, /simulated retrieval failure/i);
+  });
+});

--- a/test/memory-store-ingress.test.mjs
+++ b/test/memory-store-ingress.test.mjs
@@ -1,0 +1,243 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginSdkStubPath = path.resolve(testDir, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+
+const { registerMemoryStoreTool } = jiti("../src/tools.ts");
+
+function createHarness(overrides = {}) {
+  const factories = new Map();
+  const embedCalls = [];
+  const storeCalls = [];
+  const mirrorCalls = [];
+  const ingressCalls = [];
+
+  const api = {
+    registerTool(factory, meta) {
+      factories.set(meta?.name || "", factory);
+    },
+  };
+
+  const context = {
+    retriever: {},
+    store: {
+      async store(entry) {
+        storeCalls.push(entry);
+        return {
+          id: "stored-1",
+          timestamp: 1700000000000,
+          metadata: undefined,
+          ...entry,
+        };
+      },
+      async vectorSearch() {
+        return [];
+      },
+      ...(overrides.store || {}),
+    },
+    scopeManager: {
+      getDefaultScope() {
+        return "scope-main";
+      },
+      isAccessible() {
+        return true;
+      },
+      ...(overrides.scopeManager || {}),
+    },
+    embedder: {
+      async embedPassage(text) {
+        embedCalls.push(text);
+        return [0.1, 0.2, 0.3];
+      },
+      ...(overrides.embedder || {}),
+    },
+    agentId: overrides.agentId,
+    workspaceDir: overrides.workspaceDir,
+    mdMirror: async (entry, meta) => {
+      mirrorCalls.push({ entry, meta });
+    },
+  };
+
+  if (Object.prototype.hasOwnProperty.call(overrides, "captureIngress")) {
+    context.captureIngress = overrides.captureIngress === null
+      ? null
+      : async (params) => {
+        ingressCalls.push(params);
+        return await overrides.captureIngress(params);
+      };
+  } else {
+    context.captureIngress = async (params) => {
+      ingressCalls.push(params);
+      return {
+        action: "stored",
+        entry: {
+          id: "ingress-1",
+          text: params.text,
+          vector: [],
+          category: params.category || "other",
+          scope: params.scope,
+          importance: params.importance ?? 0.7,
+          timestamp: 1700000000000,
+          metadata: "{}",
+        },
+      };
+    };
+  }
+
+  registerMemoryStoreTool(api, context);
+
+  return {
+    tool(toolCtx = {}) {
+      const factory = factories.get("memory_store");
+      assert.ok(factory, "memory_store tool should be registered");
+      return factory(toolCtx);
+    },
+    embedCalls,
+    storeCalls,
+    mirrorCalls,
+    ingressCalls,
+  };
+}
+
+describe("memory_store ingress integration", () => {
+  it("routes explicit tool writes through shared ingress when available", async () => {
+    const harness = createHarness();
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-1", {
+      text: "Use zsh for shell-related instructions.",
+      importance: 0.9,
+      category: "fact",
+    });
+
+    assert.equal(harness.ingressCalls.length, 1);
+    assert.deepEqual(harness.ingressCalls[0], {
+      text: "Use zsh for shell-related instructions.",
+      scope: "scope-main",
+      importance: 0.9,
+      category: "fact",
+      sourceApp: "openclaw",
+      sourceRole: "assistant",
+      scoringRole: "user",
+      ingestionMode: "memory_store",
+      explicitWrite: true,
+      confirmed: true,
+      agentId: "agent-main",
+    });
+    assert.equal(harness.embedCalls.length, 0);
+    assert.equal(harness.storeCalls.length, 0);
+    assert.match(result.content[0].text, /Stored:/);
+    assert.equal(result.details.action, "stored");
+    assert.equal(result.details.id, "ingress-1");
+  });
+
+  it("surfaces ingress skip reasons instead of falling back to direct store", async () => {
+    const harness = createHarness({
+      async captureIngress(params) {
+        return {
+          action: "skipped",
+          reason: "system-noise",
+        };
+      },
+    });
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-2", {
+      text: "<relevant-memories> internal wrapper",
+      category: "other",
+    });
+
+    assert.equal(harness.ingressCalls.length, 1);
+    assert.equal(harness.embedCalls.length, 0);
+    assert.equal(harness.storeCalls.length, 0);
+    assert.match(result.content[0].text, /system\/control text/i);
+    assert.equal(result.details.action, "skipped");
+    assert.equal(result.details.reason, "system-noise");
+  });
+
+  it("surfaces refreshed duplicates as updated similar memories", async () => {
+    const harness = createHarness({
+      async captureIngress(params) {
+        return {
+          action: "updated",
+          entry: {
+            id: "existing-1",
+            text: params.text,
+            vector: [],
+            category: "decision",
+            scope: params.scope,
+            importance: 0.88,
+            timestamp: 1700000000000,
+            metadata: "{}",
+          },
+          matchedExisting: {
+            id: "existing-1",
+            text: "We use zsh for shell tasks.",
+            scope: params.scope,
+            similarity: 0.991,
+          },
+        };
+      },
+    });
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-3", {
+      text: "We use zsh for shell tasks.",
+      importance: 0.8,
+      category: "decision",
+    });
+
+    assert.equal(harness.ingressCalls.length, 1);
+    assert.match(result.content[0].text, /Updated similar memory:/);
+    assert.equal(result.details.action, "updated");
+    assert.equal(result.details.id, "existing-1");
+    assert.equal(result.details.existingId, "existing-1");
+    assert.equal(result.details.similarity, 0.991);
+  });
+
+  it("rejects the reserved reflection category before calling ingress", async () => {
+    const harness = createHarness();
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-protected-category", {
+      text: "Internal reflection row should not be stored manually.",
+      category: "reflection",
+    });
+
+    assert.equal(harness.ingressCalls.length, 0);
+    assert.equal(harness.embedCalls.length, 0);
+    assert.equal(harness.storeCalls.length, 0);
+    assert.match(result.content[0].text, /reserved for internal reflection storage/i);
+    assert.equal(result.details.error, "protected_category");
+    assert.equal(result.details.category, "reflection");
+  });
+
+  it("keeps the legacy fallback path when shared ingress is unavailable", async () => {
+    const fallbackHarness = createHarness({
+      captureIngress: null,
+    });
+    const fallbackTool = fallbackHarness.tool({ agentId: "agent-main" });
+
+    const result = await fallbackTool.execute("tc-4", {
+      text: "User prefers concise direct answers for technical tasks.",
+      importance: 0.8,
+      category: "preference",
+    });
+
+    assert.equal(fallbackHarness.ingressCalls.length, 0);
+    assert.equal(fallbackHarness.embedCalls.length, 1);
+    assert.equal(fallbackHarness.storeCalls.length, 1);
+    assert.equal(fallbackHarness.mirrorCalls.length, 1);
+    assert.equal(result.details.action, "created");
+  });
+});

--- a/test/memory-update-ingress.test.mjs
+++ b/test/memory-update-ingress.test.mjs
@@ -1,0 +1,268 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginSdkStubPath = path.resolve(testDir, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+
+const { registerMemoryUpdateTool } = jiti("../src/tools.ts");
+
+function createHarness(overrides = {}) {
+  const factories = new Map();
+  const embedCalls = [];
+  const updateCalls = [];
+  const validatorCalls = [];
+  const retrieveCalls = [];
+  const resolveByIdCalls = [];
+
+  const api = {
+    registerTool(factory, meta) {
+      factories.set(meta?.name || "", factory);
+    },
+  };
+
+  const context = {
+    retriever: {
+      async retrieve(params) {
+        retrieveCalls.push(params);
+        return [];
+      },
+      ...(overrides.retriever || {}),
+    },
+    store: {
+      async update(id, updates, scopes) {
+        updateCalls.push({ id, updates, scopes });
+        return {
+          id,
+          text: updates.text || "existing text",
+          vector: updates.vector || [],
+          category: updates.category || "other",
+          scope: "scope-main",
+          importance: updates.importance ?? 0.7,
+          timestamp: 1700000000000,
+          metadata: "{}",
+        };
+      },
+      async resolveByIdOrPrefix(id) {
+        resolveByIdCalls.push(id);
+        return {
+          id,
+          text: "existing text",
+          vector: [0.2, 0.2, 0.2],
+          category: "other",
+          scope: "scope-main",
+          importance: 0.7,
+          timestamp: 1700000000000,
+          metadata: JSON.stringify({
+            custom: "keep-me",
+            memoryTier: "candidate",
+            captureScore: 5,
+            captureReasons: ["existing-reason"],
+            normalizedKey: "existing-key",
+            firstSeenAt: 111,
+            occurrences: 1,
+          }),
+        };
+      },
+      ...(overrides.store || {}),
+    },
+    scopeManager: {
+      getAccessibleScopes() {
+        return ["scope-main"];
+      },
+      ...(overrides.scopeManager || {}),
+    },
+    embedder: {
+      async embedPassage(text) {
+        embedCalls.push(text);
+        return [0.1, 0.2, 0.3];
+      },
+      ...(overrides.embedder || {}),
+    },
+    agentId: overrides.agentId,
+    captureValidator: async (params) => {
+      validatorCalls.push(params);
+      if (overrides.captureValidator) return await overrides.captureValidator(params);
+      return {
+        accepted: true,
+        text: String(params.text || "").trim(),
+      };
+    },
+  };
+
+  if (Object.prototype.hasOwnProperty.call(overrides, "captureValidator") && overrides.captureValidator === null) {
+    context.captureValidator = null;
+  }
+
+  registerMemoryUpdateTool(api, context);
+
+  return {
+    tool(toolCtx = {}) {
+      const factory = factories.get("memory_update");
+      assert.ok(factory, "memory_update tool should be registered");
+      return factory(toolCtx);
+    },
+    embedCalls,
+    updateCalls,
+    validatorCalls,
+    retrieveCalls,
+    resolveByIdCalls,
+  };
+}
+
+describe("memory_update ingress validation", () => {
+  it("uses shared ingress validation for updated text and surfaces skip reasons", async () => {
+    const harness = createHarness({
+      async captureValidator(params) {
+        return {
+          accepted: false,
+          reason: "system-noise",
+          text: String(params.text || "").trim(),
+        };
+      },
+    });
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-1", {
+      memoryId: "12345678-1234-1234-1234-1234567890ab",
+      text: "<relevant-memories> wrapper",
+    });
+
+    assert.equal(harness.validatorCalls.length, 1);
+    assert.equal(harness.embedCalls.length, 0);
+    assert.equal(harness.updateCalls.length, 0);
+    assert.match(result.content[0].text, /system\/control text/i);
+    assert.equal(result.details.action, "skipped");
+    assert.equal(result.details.reason, "system-noise");
+  });
+
+  it("embeds and updates the sanitized validated text", async () => {
+    const harness = createHarness({
+      async captureValidator(params) {
+        return {
+          accepted: true,
+          text: "Validated durable memory text.",
+          metadataPayload: {
+            memoryTier: "candidate",
+            captureScore: 7,
+            captureReasons: ["explicit-tool-request"],
+            normalizedKey: "validated-durable-memory-text",
+            sourceApp: "openclaw",
+            sourceRole: "assistant",
+            ingestionMode: "memory_update",
+            confirmed: true,
+          },
+        };
+      },
+    });
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-2", {
+      memoryId: "12345678-1234-1234-1234-1234567890ab",
+      text: "  raw text that should be normalized  ",
+      importance: 0.9,
+      category: "decision",
+    });
+
+    assert.equal(harness.validatorCalls.length, 1);
+    assert.deepEqual(harness.embedCalls, ["Validated durable memory text."]);
+    assert.equal(harness.resolveByIdCalls.length, 1);
+    assert.equal(harness.updateCalls.length, 1);
+    assert.equal(harness.updateCalls[0].updates.text, "Validated durable memory text.");
+    assert.deepEqual(harness.updateCalls[0].updates.vector, [0.1, 0.2, 0.3]);
+    assert.equal(harness.updateCalls[0].updates.category, "decision");
+    assert.equal(harness.updateCalls[0].updates.importance, 0.9);
+    const mergedMetadata = JSON.parse(harness.updateCalls[0].updates.metadata);
+    assert.equal(mergedMetadata.custom, "keep-me");
+    assert.equal(mergedMetadata.captureScore, 7);
+    assert.equal(mergedMetadata.normalizedKey, "validated-durable-memory-text");
+    assert.deepEqual(
+      mergedMetadata.captureReasons,
+      ["existing-reason", "explicit-tool-request"],
+    );
+    assert.equal(mergedMetadata.firstSeenAt, 111);
+    assert.equal(mergedMetadata.occurrences, 2);
+    assert.equal(mergedMetadata.confirmed, true);
+    assert.equal(mergedMetadata.ingestionMode, "memory_update");
+    assert.equal(result.details.action, "updated");
+    assert.equal(result.details.id, "12345678-1234-1234-1234-1234567890ab");
+  });
+
+  it("rejects updates to existing internal reflection entries", async () => {
+    const reflectionResolveCalls = [];
+    const harness = createHarness({
+      store: {
+        async resolveByIdOrPrefix(id) {
+          reflectionResolveCalls.push(id);
+          return {
+            id: "12345678-1234-1234-1234-1234567890ab",
+            text: "reflection row",
+            vector: [0.3, 0.3, 0.3],
+            category: "reflection",
+            scope: "scope-main",
+            importance: 0.8,
+            timestamp: 1700000000000,
+            metadata: JSON.stringify({ type: "memory-reflection-item" }),
+          };
+        },
+      },
+    });
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-protected-existing-reflection", {
+      memoryId: "12345678-1234-1234-1234-1234567890ab",
+      text: "Do not allow editing this internal row.",
+    });
+
+    assert.equal(reflectionResolveCalls.length, 1);
+    assert.equal(harness.validatorCalls.length, 0);
+    assert.equal(harness.embedCalls.length, 0);
+    assert.equal(harness.updateCalls.length, 0);
+    assert.match(result.content[0].text, /reserved for internal reflection storage/i);
+    assert.equal(result.details.error, "protected_category");
+    assert.equal(result.details.category, "reflection");
+  });
+
+  it("rejects changing a memory into the reserved reflection category", async () => {
+    const harness = createHarness();
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-protected-category", {
+      memoryId: "12345678-1234-1234-1234-1234567890ab",
+      category: "reflection",
+    });
+
+    assert.equal(harness.validatorCalls.length, 0);
+    assert.equal(harness.embedCalls.length, 0);
+    assert.equal(harness.updateCalls.length, 0);
+    assert.match(result.content[0].text, /reserved for internal reflection storage/i);
+    assert.equal(result.details.error, "protected_category");
+    assert.equal(result.details.category, "reflection");
+  });
+
+  it("keeps the legacy fallback path when shared validation is unavailable", async () => {
+    const harness = createHarness({
+      captureValidator: null,
+    });
+    const tool = harness.tool({ agentId: "agent-main" });
+
+    const result = await tool.execute("tc-3", {
+      memoryId: "12345678-1234-1234-1234-1234567890ab",
+      text: "Keep concise direct answers for technical tasks.",
+    });
+
+    assert.equal(harness.validatorCalls.length, 0);
+    assert.equal(harness.resolveByIdCalls.length, 1);
+    assert.deepEqual(harness.embedCalls, ["Keep concise direct answers for technical tasks."]);
+    assert.equal(harness.updateCalls.length, 1);
+    assert.equal(result.details.action, "updated");
+  });
+});

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -270,9 +270,9 @@ try {
       text: longText,
       scope: "global",
     });
-    assert.equal(
-      chunkingOnResult.details.action,
-      "created",
+    assert.ok(
+      chunkingOnResult.details.action === "created" ||
+      chunkingOnResult.details.action === "stored",
       "embedding.chunking=true should recover from long-document embedding errors",
     );
   } finally {

--- a/test/reflection-mapped-ingress.test.mjs
+++ b/test/reflection-mapped-ingress.test.mjs
@@ -1,0 +1,294 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginSdkStubPath = path.resolve(testDir, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+
+const pluginModule = jiti("../index.ts");
+const memoryLanceDBProPlugin = pluginModule.default || pluginModule;
+const { MemoryStore } = jiti("../src/store.ts");
+
+function messageLine(role, text, ts) {
+  return JSON.stringify({
+    type: "message",
+    timestamp: ts,
+    message: {
+      role,
+      content: [{ type: "text", text }],
+    },
+  });
+}
+
+function createPluginApiHarness({ pluginConfig, resolveRoot, runtimeConfig }) {
+  const eventHandlers = new Map();
+  const commandHooks = new Map();
+  const logs = [];
+
+  const api = {
+    pluginConfig,
+    config: runtimeConfig || {},
+    resolvePath(target) {
+      if (typeof target !== "string") return target;
+      if (path.isAbsolute(target)) return target;
+      return path.join(resolveRoot, target);
+    },
+    logger: {
+      info(message) {
+        logs.push({ level: "info", message: String(message) });
+      },
+      warn(message) {
+        logs.push({ level: "warn", message: String(message) });
+      },
+      debug(message) {
+        logs.push({ level: "debug", message: String(message) });
+      },
+    },
+    registerTool() {},
+    registerCli() {},
+    registerService() {},
+    on(eventName, handler, meta) {
+      const list = eventHandlers.get(eventName) || [];
+      list.push({ handler, meta });
+      eventHandlers.set(eventName, list);
+    },
+    registerHook(hookName, handler, meta) {
+      const list = commandHooks.get(hookName) || [];
+      list.push({ handler, meta });
+      commandHooks.set(hookName, list);
+    },
+  };
+
+  return {
+    api,
+    eventHandlers,
+    commandHooks,
+    logs,
+  };
+}
+
+function buildDeterministicEmbedding(text) {
+  let seed = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    seed = (seed * 131 + text.charCodeAt(i)) >>> 0;
+  }
+  const vector = [];
+  let state = seed || 1;
+  for (let i = 0; i < 1024; i += 1) {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    vector.push(((state / 0xffffffff) * 2) - 1);
+  }
+  return vector;
+}
+
+describe("reflection mapped ingress integration", () => {
+  let sourceWorkspaceDir;
+  let reflectionWorkspaceDir;
+  let runtimeWorkspaceDir;
+  let dbPath;
+  let sessionFile;
+  let extensionStubFile;
+  let embedServer;
+  let embedBaseURL;
+  let originalExtensionApiPath;
+  let runtimeConfig;
+  let harness;
+
+  beforeEach(async () => {
+    sourceWorkspaceDir = mkdtempSync(path.join(tmpdir(), "reflection-mapped-source-"));
+    reflectionWorkspaceDir = mkdtempSync(path.join(tmpdir(), "reflection-mapped-runner-"));
+    runtimeWorkspaceDir = mkdtempSync(path.join(tmpdir(), "reflection-mapped-runtime-"));
+    dbPath = path.join(sourceWorkspaceDir, "mapped-memory-db");
+
+    const sessionsDir = path.join(sourceWorkspaceDir, "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+    sessionFile = path.join(sessionsDir, "s-mapped.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        messageLine("user", "Keep the reflected durable context.", 1),
+        messageLine("assistant", "Acknowledged. I will keep the durable context.", 2),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    extensionStubFile = path.join(sourceWorkspaceDir, "extension-api-mapped-stub.mjs");
+    writeFileSync(
+      extensionStubFile,
+      [
+        "export async function runEmbeddedPiAgent(params = {}) {",
+        "  return {",
+        "    payloads: [{",
+        "      text: [",
+        "        \"## Context (session background)\",",
+        "        \"- Reflection mapped memory ingress test.\",",
+        "        `- Runner workspace: ${String(params?.workspaceDir || \"(unknown)\")}`,",
+        "        \"\",",
+        "        \"## Decisions (durable)\",",
+        "        \"- Always attach file evidence before reporting completion.\",",
+        "        \"\",",
+        "        \"## User model deltas (about the human)\",",
+        "        \"- Prefers concise direct answers without confirmation loops.\",",
+        "        \"\",",
+        "        \"## Agent model deltas (about the assistant/system)\",",
+        "        \"- (none captured)\",",
+        "        \"\",",
+        "        \"## Lessons & pitfalls (symptom / cause / fix / prevention)\",",
+        "        \"- Always classify empty-state behavior before calling it a failure.\",",
+        "        \"\",",
+        "        \"## Learning governance candidates (.learnings / promotion / skill extraction)\",",
+        "        \"- (none captured)\",",
+        "        \"\",",
+        "        \"## Open loops / next actions\",",
+        "        \"- Verify mapped memories inherit provenance metadata.\",",
+        "        \"\",",
+        "        \"## Retrieval tags / keywords\",",
+        "        \"- memory-reflection\",",
+        "        \"\",",
+        "        \"## Invariants\",",
+        "        \"- Keep inherited-rules in before_prompt_build only.\",",
+        "        \"\",",
+        "        \"## Derived\",",
+        "        \"- Fresh derived line from this run.\"",
+        "      ].join(\"\\n\"),",
+        "    }],",
+        "  };",
+        "}",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    embedServer = http.createServer(async (req, res) => {
+      if (req.url === "/v1/embeddings" && req.method === "POST") {
+        const chunks = [];
+        for await (const chunk of req) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+        const payload = JSON.parse(Buffer.concat(chunks).toString("utf-8") || "{}");
+        const input = Array.isArray(payload.input) ? String(payload.input[0] || "") : String(payload.input || "");
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({
+          data: [{ embedding: buildDeterministicEmbedding(input) }],
+        }));
+        return;
+      }
+      res.writeHead(404);
+      res.end("not found");
+    });
+    await new Promise((resolve) => embedServer.listen(0, "127.0.0.1", resolve));
+    const address = embedServer.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    embedBaseURL = `http://127.0.0.1:${port}/v1`;
+
+    originalExtensionApiPath = process.env.OPENCLAW_EXTENSION_API_PATH;
+    process.env.OPENCLAW_EXTENSION_API_PATH = extensionStubFile;
+
+    runtimeConfig = {
+      agents: {
+        defaults: { workspace: sourceWorkspaceDir },
+        list: [
+          { id: "main" },
+          { id: "reflector", workspace: reflectionWorkspaceDir },
+        ],
+      },
+    };
+
+    harness = createPluginApiHarness({
+      resolveRoot: sourceWorkspaceDir,
+      runtimeConfig,
+      pluginConfig: {
+        embedding: {
+          apiKey: "test-api-key",
+          baseURL: embedBaseURL,
+          model: "jina-embeddings-v5-text-small",
+          dimensions: 1024,
+        },
+        dbPath,
+        autoCapture: false,
+        autoRecall: false,
+        sessionStrategy: "memoryReflection",
+        selfImprovement: {
+          enabled: true,
+          beforeResetNote: true,
+          ensureLearningFiles: false,
+        },
+        memoryReflection: {
+          agentId: "reflector",
+          injectMode: "inheritance+derived",
+          storeToLanceDB: false,
+        },
+      },
+    });
+    memoryLanceDBProPlugin.register(harness.api);
+  });
+
+  afterEach(async () => {
+    if (typeof originalExtensionApiPath === "string") {
+      process.env.OPENCLAW_EXTENSION_API_PATH = originalExtensionApiPath;
+    } else {
+      delete process.env.OPENCLAW_EXTENSION_API_PATH;
+    }
+    if (embedServer) {
+      await new Promise((resolve) => embedServer.close(resolve));
+    }
+    rmSync(sourceWorkspaceDir, { recursive: true, force: true });
+    rmSync(reflectionWorkspaceDir, { recursive: true, force: true });
+    rmSync(runtimeWorkspaceDir, { recursive: true, force: true });
+  });
+
+  it("stores mapped memories through shared ingress while preserving reflection provenance metadata", async () => {
+    const commandNewHooks = harness.commandHooks.get("command:new") || [];
+    const reflectionHook = commandNewHooks.find((item) =>
+      item?.meta?.name === "memory-lancedb-pro.memory-reflection.command-new",
+    );
+    assert.ok(reflectionHook, "expected memory-reflection command:new hook");
+
+    const timestamp = Date.UTC(2026, 2, 8, 13, 12, 34);
+    await reflectionHook.handler({
+      action: "new",
+      sessionKey: "agent:main:session:s-mapped",
+      timestamp,
+      messages: [],
+      context: {
+        cfg: runtimeConfig,
+        workspaceDir: runtimeWorkspaceDir,
+        commandSource: "cli",
+        previousSessionEntry: {
+          sessionId: "s-mapped",
+          sessionFile,
+        },
+      },
+    });
+
+    const verifyStore = new MemoryStore({ dbPath, vectorDim: 1024 });
+    const storedEntries = await verifyStore.list(undefined, undefined, 10, 0);
+
+    assert.equal(storedEntries.length, 3);
+    const categories = storedEntries.map((entry) => entry.category).sort();
+    assert.deepEqual(categories, ["decision", "fact", "preference"]);
+
+    for (const entry of storedEntries) {
+      const metadata = JSON.parse(entry.metadata || "{}");
+      assert.equal(metadata.type, "memory-reflection-mapped");
+      assert.equal(metadata.captureVersion, 1);
+      assert.ok(metadata.memoryTier === "candidate" || metadata.memoryTier === "formal");
+      assert.equal(metadata.sourceApp, "openclaw");
+      assert.equal(metadata.sourceRole, "assistant");
+      assert.match(String(metadata.ingestionMode || ""), /^reflection:/);
+      assert.equal(metadata.sessionId, "s-mapped");
+      assert.equal(metadata.agentId, "main");
+    }
+  });
+});

--- a/test/store-regression.test.mjs
+++ b/test/store-regression.test.mjs
@@ -1,0 +1,224 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const { MemoryStore } = jiti("../src/store.ts");
+const TEST_ID = "11111111-1111-1111-1111-111111111111";
+
+function makeEntry(overrides = {}) {
+  return {
+    id: TEST_ID,
+    text: "original memory",
+    vector: [1, 0, 0, 0],
+    category: "fact",
+    scope: "global",
+    importance: 0.7,
+    timestamp: 1700000000000,
+    metadata: "{}",
+    ...overrides,
+  };
+}
+
+function createMockQueryTable(state, hooks = {}) {
+  return {
+    query() {
+      let whereClause = "";
+      return {
+        where(clause) {
+          whereClause = clause;
+          return this;
+        },
+        select() {
+          return this;
+        },
+        limit() {
+          return this;
+        },
+        async toArray() {
+          hooks.onQuery?.(whereClause);
+          const idMatch = /id = '([^']+)'/.exec(whereClause);
+          if (idMatch) {
+            const id = idMatch[1].replace(/''/g, "'");
+            return state.has(id) ? [{ ...state.get(id) }] : [];
+          }
+          return [...state.values()].map((row) => ({ ...row }));
+        },
+      };
+    },
+    async delete(whereClause) {
+      hooks.onDelete?.(whereClause);
+      const idMatch = /id = '([^']+)'/.exec(whereClause);
+      if (idMatch) {
+        const id = idMatch[1].replace(/''/g, "'");
+        state.delete(id);
+      }
+    },
+    async add(entries) {
+      const [entry] = entries;
+      if (hooks.onAdd) {
+        await hooks.onAdd(entry);
+      }
+      state.set(entry.id, { ...entry });
+    },
+    async listIndices() {
+      return [];
+    },
+  };
+}
+
+function makeStore(table) {
+  const store = new MemoryStore({ dbPath: "/tmp/memory-lancedb-pro-test", vectorDim: 4 });
+  store.table = table;
+  return store;
+}
+
+describe("MemoryStore regressions", () => {
+  it("uses cosine distance for vector search", async () => {
+    let receivedDistanceType = null;
+    let receivedWhereClause = null;
+    let receivedLimit = null;
+
+    const chain = {
+      distanceType(value) {
+        receivedDistanceType = value;
+        return this;
+      },
+      limit(value) {
+        receivedLimit = value;
+        return this;
+      },
+      where(value) {
+        receivedWhereClause = value;
+        return this;
+      },
+      async toArray() {
+        return [makeEntry({ _distance: 0.1 })];
+      },
+    };
+
+    const table = {
+      vectorSearch(vector) {
+        assert.deepEqual(vector, [1, 0, 0, 0]);
+        return chain;
+      },
+    };
+
+    const store = makeStore(table);
+    const results = await store.vectorSearch([1, 0, 0, 0], 1, 0.1, ["global"]);
+
+    assert.equal(receivedDistanceType, "cosine");
+    assert.equal(receivedLimit, 10);
+    assert.match(receivedWhereClause, /scope = 'global'/);
+    assert.equal(results.length, 1);
+  });
+
+  it("restores the latest available record when update add fails after delete", async () => {
+    const state = new Map([[TEST_ID, makeEntry()]]);
+    let addCount = 0;
+
+    const table = createMockQueryTable(state, {
+      onAdd(entry) {
+        addCount += 1;
+        if (addCount === 1) {
+          throw new Error(`simulated add failure for ${entry.text}`);
+        }
+      },
+    });
+
+    const store = makeStore(table);
+
+    await assert.rejects(
+      store.update(TEST_ID, { text: "updated memory" }),
+      /latest available record restored/,
+    );
+
+    assert.equal(addCount, 2, "expected one failed write and one rollback write");
+    assert.equal(state.get(TEST_ID)?.text, "original memory");
+  });
+
+  it("serializes concurrent updates to avoid stale rollback races", async () => {
+    const state = new Map([[TEST_ID, makeEntry()]]);
+    let deleteCount = 0;
+    let firstAddRelease;
+    let firstAddPending = true;
+    let resolveFirstDelete;
+    let resolveFirstAddBlocked;
+    const firstDeleteSeen = new Promise((resolve) => {
+      resolveFirstDelete = resolve;
+    });
+    const firstAddBlocked = new Promise((resolve) => {
+      resolveFirstAddBlocked = resolve;
+    });
+
+    const table = createMockQueryTable(state, {
+      onDelete() {
+        deleteCount += 1;
+        if (deleteCount === 1) {
+          resolveFirstDelete();
+        }
+      },
+      async onAdd(entry) {
+        if (firstAddPending) {
+          firstAddPending = false;
+          resolveFirstAddBlocked();
+          await new Promise((resolve) => {
+            firstAddRelease = resolve;
+          });
+        }
+        state.set(entry.id, { ...entry });
+      },
+    });
+
+    const store = makeStore(table);
+    const first = store.update(TEST_ID, { text: "first update" });
+    const second = store.update(TEST_ID, { text: "second update" });
+
+    await firstDeleteSeen;
+    assert.equal(deleteCount, 1, "second update should wait for the first serialized update");
+
+    await firstAddBlocked;
+    firstAddRelease();
+    const [, secondResult] = await Promise.all([first, second]);
+
+    assert.equal(deleteCount, 2);
+    assert.equal(secondResult?.text, "second update");
+    assert.equal(state.get(TEST_ID)?.text, "second update");
+  });
+
+  it("reports FTS status and can rebuild the index", async () => {
+    let droppedIndex = null;
+    let forcedRebuild = false;
+
+    const table = {
+      async listIndices() {
+        return [{ name: "memories_text_fts_idx", indexType: "FTS", columns: ["text"] }];
+      },
+      async dropIndex(name) {
+        droppedIndex = name;
+      },
+    };
+
+    const store = makeStore(table);
+    store.ftsSupported = true;
+    store.ftsIndexCreated = false;
+    store.lastFtsError = "previous failure";
+    store.createFtsIndex = async (_table, force = false) => {
+      forcedRebuild = force;
+    };
+
+    assert.deepEqual(store.getFtsStatus(), {
+      available: false,
+      supported: true,
+      indexExists: false,
+      lastError: "previous failure",
+    });
+
+    const result = await store.rebuildFtsIndex();
+    assert.deepEqual(result, { success: true });
+    assert.equal(droppedIndex, "memories_text_fts_idx");
+    assert.equal(forcedRebuild, true);
+    assert.equal(store.ftsIndexCreated, true);
+    assert.equal(store.lastFtsError, null);
+  });
+});


### PR DESCRIPTION
## Summary

This is **PR 2/4** in a series that extends `memory-lancedb-pro` in layered steps.

This PR focuses on **memory write quality and ingestion safety**.

It adds:

1. a scored capture pipeline
2. candidate vs formal memory tiers
3. shared ingress validation for memory tools and mapped reflection writes
4. standalone Claude / Codex transcript ingestion routed through the same pipeline

## Why

The plugin already stores long-term memory well, but writes benefit from a unified ingress policy:

- not every candidate should become a formal recallable memory
- assistant summaries should be treated more cautiously than confirmed user decisions
- secret-like text should be rejected before it reaches LanceDB
- explicit tool writes and mapped reflection writes should follow the same validation semantics

## Scope and safety

- candidate memories stay out of generic recall by default
- internal reflection rows are protected from unsafe edits / deletes
- explicit writes, reflection-mapped writes, and external transcript ingestion share one validation path
- focused tests cover scoring, parsing, ingress validation, diagnostics, and storage regressions

## Companion PRs in this series

- PR 1/4: retrieval ergonomics and diagnostics
- PR 3/4: standalone runtime and MCP surface
- PR 4/4: Claude / Codex host integrations

## Validation

```bash
node --test test/capture-pipeline.test.mjs
node --test test/external-ingestion.test.mjs
node --test test/memory-store-ingress.test.mjs
node --test test/memory-update-ingress.test.mjs
node --test test/memory-forget-protection.test.mjs
node --test test/memory-recall-diagnostics.test.mjs
node --test test/reflection-mapped-ingress.test.mjs
node --test test/store-regression.test.mjs
```

All passed locally.
