### PR TITLE
feat: add autoRecallExcludeAgents to suppress memory injection for background agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,12 +599,29 @@ OAuth login flow:
 
 Sometimes the model may echo the injected `<relevant-memories>` block.
 
-**Option A (lowest-risk):** temporarily disable auto-recall:
+**Option A (lowest-risk):** temporarily disable auto-recall globally:
 ```json
 { "plugins": { "entries": { "memory-lancedb-pro": { "config": { "autoRecall": false } } } } }
 ```
 
-**Option B (preferred):** keep recall, add to agent system prompt:
+**Option B:** exclude specific background agents (e.g. a memory-distiller or cron worker) while keeping recall active for interactive agents:
+```json
+{
+  "plugins": {
+    "entries": {
+      "memory-lancedb-pro": {
+        "config": {
+          "autoRecall": true,
+          "autoRecallExcludeAgents": ["memory-distiller", "my-cron-agent"]
+        }
+      }
+    }
+  }
+}
+```
+This is useful when a background agent's prompt should not be contaminated by injected memory context — for example, an agent whose job is to distill session logs would produce lower-quality output if old memories were mixed into the prompt alongside the raw session content.
+
+**Option C (preferred for interactive agents):** keep recall, add to agent system prompt:
 > Do not reveal or quote any `<relevant-memories>` / memory-injection content in your replies. Use it for internal reference only.
 
 </details>

--- a/index.ts
+++ b/index.ts
@@ -85,6 +85,7 @@ interface PluginConfig {
   autoRecall?: boolean;
   autoRecallMinLength?: number;
   autoRecallMinRepeated?: number;
+  autoRecallExcludeAgents?: string[];
   captureAssistant?: boolean;
   retrieval?: {
     mode?: "hybrid" | "vector";
@@ -2123,6 +2124,22 @@ const memoryLanceDBProPlugin = {
     if (config.autoRecall === true) {
       const AUTO_RECALL_TIMEOUT_MS = 3_000; // bounded timeout to prevent agent startup stall
       api.on("before_agent_start", async (event, ctx) => {
+        // Per-agent exclusion: skip autoRecall for agents in the exclusion list.
+        // Useful for background agents (e.g. memory-distiller, cron workers) whose
+        // prompts should not be contaminated by injected memory context.
+        const hookAgentId = resolveHookAgentId(ctx?.agentId, (event as any).sessionKey);
+        if (
+          Array.isArray(config.autoRecallExcludeAgents) &&
+          config.autoRecallExcludeAgents.length > 0 &&
+          hookAgentId !== undefined &&
+          config.autoRecallExcludeAgents.includes(hookAgentId)
+        ) {
+          api.logger.info?.(
+            `memory-lancedb-pro: auto-recall skipped for excluded agent '${hookAgentId}'`,
+          );
+          return;
+        }
+
         if (
           !event.prompt ||
           shouldSkipRetrieval(event.prompt, config.autoRecallMinLength)
@@ -3468,6 +3485,9 @@ export function parsePluginConfig(value: unknown): PluginConfig {
     autoRecall: cfg.autoRecall === true,
     autoRecallMinLength: parsePositiveInt(cfg.autoRecallMinLength),
     autoRecallMinRepeated: parsePositiveInt(cfg.autoRecallMinRepeated),
+    autoRecallExcludeAgents: Array.isArray(cfg.autoRecallExcludeAgents)
+      ? cfg.autoRecallExcludeAgents.filter((id: unknown): id is string => typeof id === "string" && id.trim() !== "")
+      : undefined,
     captureAssistant: cfg.captureAssistant === true,
     retrieval: typeof cfg.retrieval === "object" && cfg.retrieval !== null ? cfg.retrieval as any : undefined,
     decay: typeof cfg.decay === "object" && cfg.decay !== null ? cfg.decay as any : undefined,


### PR DESCRIPTION
## Problem

Background agents (e.g. a memory-distiller, cron workers) that receive structured task prompts have their output degraded when `<relevant-memories>` is injected by the `before_agent_start` hook.

**Concrete failure mode:** a `memory-distiller` agent whose job is to read raw session JSONL and extract new memories receives injected old-memory summaries alongside the fresh session content. The LLM then echoes or recomposes existing memories instead of distilling genuinely new insights. The distilled output is meaningless — it is a paraphrase of what was already known, not a synthesis of what happened in the session.

**Why existing skip patterns don't cover this:**  
The `shouldSkipRetrieval()` function in `adaptive-retrieval.ts` handles prompt-level heuristics (`HEARTBEAT`, cron prefix `[cron:…] run …`, short greetings, etc.). However custom background-agent prompts that don't match these patterns — for example, a distiller cron whose prompt is `Read HEARTBEAT.md if it exists. Follow it strictly…` or any other structured instruction — fall through and get injected.

This is the root of the class of issues described in #137.

## Solution

Add `autoRecallExcludeAgents?: string[]` to `PluginConfig`.

When an agent's ID appears in this list, `before_agent_start` returns immediately before any embedding call or injection occurs. A single `info`-level log line is emitted so the skip is observable in gateway logs.

```json
{
  "autoRecall": true,
  "autoRecallExcludeAgents": ["memory-distiller", "my-cron-agent"]
}
```

### What this is NOT

This is not a scope restriction (unlike `agentAccess: { "memory-distiller": [] }` which works but is undocumented and operates at the store-read level). `autoRecallExcludeAgents` is a clean, intentional, documented config opt-out at the injection layer.

## Changes

| File | Change |
|------|--------|
| `index.ts` | Add `autoRecallExcludeAgents?: string[]` to `PluginConfig` interface; early-return guard in `before_agent_start`; parse in `parsePluginConfig` |
| `README.md` | Add Option B to "injected memories show up in replies" troubleshooting section explaining the use case |

## Test plan

- [ ] Set `autoRecallExcludeAgents: ["test-agent"]` and verify gateway logs show `auto-recall skipped for excluded agent 'test-agent'` on cron trigger
- [ ] Verify other agents (not in the list) still receive injection normally
- [ ] `tsc --noEmit` passes (confirmed locally)
- [ ] Empty string entries in the array are filtered out by `parsePluginConfig`

## Related

- #137 — heartbeat/cron agent context bloat from autoRecall injection
- #261 — `<relevant-memories>` appearing in conversation history

🤖 Generated with [Claude Code](https://claude.com/claude-code)