### PR TITLE
fix: align agentId resolution to prevent scope mismatch (#231)

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -787,7 +787,7 @@ export function registerMemoryForgetTool(
         };
 
         try {
-          const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
+          const agentId = runtimeContext.agentId;
           // Determine accessible scopes
           let scopeFilter = resolveScopeFilter(runtimeContext.scopeManager, agentId);
           if (scope) {
@@ -963,7 +963,7 @@ export function registerMemoryUpdateTool(
           }
 
           // Determine accessible scopes
-          const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
+          const agentId = runtimeContext.agentId;
           const scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
 
           // Resolve memoryId: if it doesn't look like a UUID, try search
@@ -1200,7 +1200,7 @@ export function registerMemoryStatsTool(
         const { scope } = params as { scope?: string };
 
         try {
-          const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
+          const agentId = runtimeContext.agentId;
           // Determine accessible scopes
           let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
           if (scope) {
@@ -1315,7 +1315,7 @@ export function registerMemoryListTool(
         try {
           const safeLimit = clampInt(limit, 1, 50);
           const safeOffset = clampInt(offset, 0, 1000);
-          const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
+          const agentId = runtimeContext.agentId;
 
           // Determine accessible scopes
           let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);


### PR DESCRIPTION
## Summary

- **Root cause**: `memory_update`, `memory_forget`, `memory_stats`, and `memory_list` used `resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx)` in their execute functions, which re-resolves agentId from the execute-time `runtimeCtx`. When the execute-time context provides a different agentId than the definition-time `runtimeContext.agentId`, this causes "Memory is outside accessible scopes" errors because the scope filter is built from a different agentId than what `memory_store` used.
- **Fix**: Replace `resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx)` with `runtimeContext.agentId` in all 4 tools, aligning them with `memory_store`'s pattern of using the stable definition-time agentId.
- PR #270 partially addressed agentId resolution but the `runtimeCtx` override path remained in these 4 tools.

Fixes #231

## Test plan

- [x] All existing tests pass (`npm test` — 0 failures)
- [ ] Verify that memory_store + memory_update/forget/stats/list use consistent agentId when execute-time context differs from definition-time context

🤖 Generated with [Claude Code](https://claude.com/claude-code)