### PR TITLE
fix: support omitDimensions for local embedding models

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -76,6 +76,7 @@ interface PluginConfig {
     model?: string;
     baseURL?: string;
     dimensions?: number;
+    omitDimensions?: boolean;
     taskQuery?: string;
     taskPassage?: string;
     normalized?: boolean;
@@ -1692,6 +1693,7 @@ const memoryLanceDBProPlugin = {
       model: config.embedding.model || "text-embedding-3-small",
       baseURL: config.embedding.baseURL,
       dimensions: config.embedding.dimensions,
+      omitDimensions: config.embedding.omitDimensions,
       taskQuery: config.embedding.taskQuery,
       taskPassage: config.embedding.taskPassage,
       normalized: config.embedding.normalized,
@@ -3617,6 +3619,10 @@ export function parsePluginConfig(value: unknown): PluginConfig {
       // Accept number, numeric string, or env-var string (e.g. "${EMBED_DIM}").
       // Also accept legacy top-level `dimensions` for convenience.
       dimensions: parsePositiveInt(embedding.dimensions ?? cfg.dimensions),
+      omitDimensions:
+        typeof embedding.omitDimensions === "boolean"
+          ? embedding.omitDimensions
+          : undefined,
       taskQuery:
         typeof embedding.taskQuery === "string"
           ? embedding.taskQuery

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -46,6 +46,10 @@
             "type": "integer",
             "minimum": 1
           },
+          "omitDimensions": {
+            "type": "boolean",
+            "description": "When true, omit the dimensions parameter from embedding requests even if dimensions is configured"
+          },
           "taskQuery": {
             "type": "string",
             "description": "Embedding task for queries (provider-specific, e.g. Jina: retrieval.query)"
@@ -762,6 +766,11 @@
       "label": "Vector Dimensions",
       "placeholder": "auto-detected from model",
       "help": "Override vector dimensions for custom models not in the built-in lookup table",
+      "advanced": true
+    },
+    "embedding.omitDimensions": {
+      "label": "Omit Request Dimensions",
+      "help": "Do not send the dimensions parameter to the embedding API even if embedding.dimensions is configured. Useful for local models like Qwen3-Embedding that reject the field.",
       "advanced": true
     },
     "embedding.taskQuery": {

--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -98,6 +98,9 @@ export interface EmbeddingConfig {
   taskPassage?: string;
   /** Optional flag to request normalized embeddings (provider-dependent, e.g. Jina v5) */
   normalized?: boolean;
+  /** When true, omit the dimensions parameter from embedding requests even if dimensions is set.
+   *  Use this for local models that reject the dimensions parameter with "matryoshka representation" errors. */
+  omitDimensions?: boolean;
   /** Enable automatic chunking for documents exceeding context limits (default: true) */
   chunking?: boolean;
 }
@@ -410,6 +413,8 @@ export class Embedder {
 
   /** Optional requested dimensions to pass through to the embedding provider (OpenAI-compatible). */
   private readonly _requestDimensions?: number;
+  /** When true, omit the dimensions parameter even if _requestDimensions is set. */
+  private readonly _omitDimensions: boolean;
   /** Enable automatic chunking for long documents (default: true) */
   private readonly _autoChunk: boolean;
 
@@ -424,6 +429,7 @@ export class Embedder {
     this._taskPassage = config.taskPassage;
     this._normalized = config.normalized;
     this._requestDimensions = config.dimensions;
+    this._omitDimensions = config.omitDimensions === true;
     // Enable auto-chunking by default for better handling of long documents
     this._autoChunk = config.chunking !== false;
     const profile = detectEmbeddingProviderProfile(this._baseURL, this._model);
@@ -641,8 +647,9 @@ export class Embedder {
     }
 
     // Output dimension: field name is provider-defined.
-    // Only sent when explicitly configured to avoid breaking providers that reject unknown fields.
-    if (this._capabilities.dimensionsField && this._requestDimensions && this._requestDimensions > 0) {
+    // Only sent when explicitly configured, unless omitDimensions is enabled for
+    // local or provider-compatible models that reject the dimensions field.
+    if (!this._omitDimensions && this._capabilities.dimensionsField && this._requestDimensions && this._requestDimensions > 0) {
       payload[this._capabilities.dimensionsField] = this._requestDimensions;
     }
 

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -105,6 +105,11 @@ assert.equal(
   "embedding.chunking schema default should match runtime default",
 );
 assert.equal(
+  manifest.configSchema.properties.embedding.properties.omitDimensions?.type,
+  "boolean",
+  "embedding.omitDimensions should be declared in the plugin schema",
+);
+assert.equal(
   manifest.configSchema.properties.sessionMemory.properties.enabled.default,
   false,
   "sessionMemory.enabled schema default should match runtime default",
@@ -127,6 +132,7 @@ assert.equal(
 
 const workDir = mkdtempSync(path.join(tmpdir(), "memory-plugin-regression-"));
 const services = [];
+const embeddingRequests = [];
 
 try {
   const api = createMockApi(
@@ -204,6 +210,7 @@ try {
     const chunks = [];
     for await (const chunk of req) chunks.push(chunk);
     const payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    embeddingRequests.push(payload);
     const inputs = Array.isArray(payload.input) ? payload.input : [payload.input];
 
     if (inputs.some((input) => String(input).length > threshold)) {
@@ -292,6 +299,65 @@ try {
       chunkingOnResult.details.action,
       "created",
       "embedding.chunking=true should recover from long-document embedding errors",
+    );
+
+    const withDimensionsApi = createMockApi({
+      dbPath: path.join(workDir, "db-with-dimensions"),
+      autoCapture: false,
+      autoRecall: false,
+      embedding: {
+        provider: "openai-compatible",
+        apiKey: "dummy",
+        model: "text-embedding-3-small",
+        baseURL: embeddingBaseURL,
+        dimensions: 4,
+      },
+    });
+    plugin.register(withDimensionsApi);
+    const withDimensionsTool = withDimensionsApi.toolFactories.memory_store({
+      agentId: "main",
+      sessionKey: "agent:main:test",
+    });
+    const requestCountBeforeWithDimensions = embeddingRequests.length;
+    await withDimensionsTool.execute("tool-3", {
+      text: "dimensions should be sent by default",
+      scope: "global",
+    });
+    const withDimensionsRequest = embeddingRequests.at(requestCountBeforeWithDimensions);
+    assert.equal(
+      withDimensionsRequest?.dimensions,
+      4,
+      "embedding.dimensions should be forwarded by default",
+    );
+
+    const omitDimensionsApi = createMockApi({
+      dbPath: path.join(workDir, "db-omit-dimensions"),
+      autoCapture: false,
+      autoRecall: false,
+      embedding: {
+        provider: "openai-compatible",
+        apiKey: "dummy",
+        model: "text-embedding-3-small",
+        baseURL: embeddingBaseURL,
+        dimensions: 4,
+        omitDimensions: true,
+      },
+    });
+    plugin.register(omitDimensionsApi);
+    const omitDimensionsTool = omitDimensionsApi.toolFactories.memory_store({
+      agentId: "main",
+      sessionKey: "agent:main:test",
+    });
+    const requestCountBeforeOmitDimensions = embeddingRequests.length;
+    await omitDimensionsTool.execute("tool-4", {
+      text: "dimensions should be omitted when configured",
+      scope: "global",
+    });
+    const omitDimensionsRequest = embeddingRequests.at(requestCountBeforeOmitDimensions);
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(omitDimensionsRequest, "dimensions"),
+      false,
+      "embedding.omitDimensions=true should omit dimensions from embedding requests",
     );
   } finally {
     await new Promise((resolve) => embeddingServer.close(resolve));


### PR DESCRIPTION
## Summary

This PR is a clean replacement for #264 and keeps only the `omitDimensions` compatibility fix for local embedding models such as Qwen3/vLLM/Ollama.

## What changed

- add `embedding.omitDimensions` to the plugin config schema and UI metadata
- parse and pass `embedding.omitDimensions` through plugin config loading
- omit the `dimensions` field from embedding requests when `omitDimensions: true`
- add a regression test to ensure the plugin manifest/schema stays in sync

## Why

Some OpenAI-compatible local embedding endpoints reject requests that include the `dimensions` parameter. This makes the existing `omitDimensions` configuration necessary for compatibility, but it must be wired through config parsing and request construction to actually work.

## Testing

- `node test/embedder-error-hints.test.mjs`
- `node test/plugin-manifest-regression.mjs`

## Notes

- This intentionally does **not** include the unrelated extra changes currently mixed into #264.
- `upstream/master` currently has an unrelated failing regression in `test/cjk-recursion-regression.test.mjs`; this PR does not modify that area.
