### PR TITLE
feat: add autoRecallTimeoutMs config for auto-recall timeout

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -89,6 +89,7 @@ interface PluginConfig {
   autoRecallMaxItems?: number;
   autoRecallMaxChars?: number;
   autoRecallPerItemMaxChars?: number;
+  autoRecallTimeoutMs?: number;
   captureAssistant?: boolean;
   retrieval?: {
     mode?: "hybrid" | "vector";
@@ -2162,7 +2163,7 @@ const memoryLanceDBProPlugin = {
         if (text) lastRawUserMessage.set(cacheKey, text);
       });
 
-      const AUTO_RECALL_TIMEOUT_MS = 3_000; // bounded timeout to prevent agent startup stall
+      const AUTO_RECALL_TIMEOUT_MS = config.autoRecallTimeoutMs ?? 3_000; // bounded timeout to prevent agent startup stall
       api.on("before_prompt_build", async (event: any, ctx: any) => {
         // Manually increment turn counter for this session
         const sessionId = ctx?.sessionId || "default";

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -228,23 +228,78 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "utility": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.1 },
-              "confidence": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.1 },
-              "novelty": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.1 },
-              "recency": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.1 },
-              "typePrior": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.6 }
+              "utility": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.1
+              },
+              "confidence": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.1
+              },
+              "novelty": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.1
+              },
+              "recency": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.1
+              },
+              "typePrior": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.6
+              }
             }
           },
           "typePriors": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "profile": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.95 },
-              "preferences": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.9 },
-              "entities": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.75 },
-              "events": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.45 },
-              "cases": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.8 },
-              "patterns": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.85 }
+              "profile": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.95
+              },
+              "preferences": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.9
+              },
+              "entities": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.75
+              },
+              "events": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.45
+              },
+              "cases": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.8
+              },
+              "patterns": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.85
+              }
             }
           }
         }
@@ -734,6 +789,13 @@
             }
           }
         }
+      },
+      "autoRecallTimeoutMs": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 120000,
+        "default": 3000,
+        "description": "Timeout in ms for auto-recall search before skipping injection. Prevents agent startup stall when embedding/rerank is slow."
       }
     },
     "required": [


### PR DESCRIPTION
## Summary

Make the hardcoded `AUTO_RECALL_TIMEOUT_MS` (3000ms) in `index.ts` configurable via the `autoRecallTimeoutMs` plugin config option.

## Problem

Issue #323 reported that auto-recall timeout errors are silent in the CMD because they were logged at `debug` level. While beta.10 addressed the logging level, users with slow embedding backends (e.g. Ollama running on local hardware) still encounter the 3-second timeout frequently, causing the "auto-recall timed out after 3000ms; skipping memory injection" message.

## Solution

1. **`index.ts`**: Add `autoRecallTimeoutMs?: number` to the `PluginConfig` interface and change the hardcoded `3000` to `config.autoRecallTimeoutMs ?? 3000`.
2. **`openclaw.plugin.json`**: Add `autoRecallTimeoutMs` to `configSchema.properties` so OpenClaw's config validation accepts the new setting.

## Config usage

```json
{
  "plugins": {
    "entries": {
      "memory-lancedb-pro": {
        "config": {
          "autoRecallTimeoutMs": 30000
        }
      }
    }
  }
}
```

**Note**: `autoRecallTimeoutMs` must be added to `configSchema.properties` in `openclaw.plugin.json` for the config to be accepted — the runtime code change alone is not sufficient (config validation will reject unknown fields).

## Files changed

| File | Change |
|------|--------|
| `index.ts` | `PluginConfig` interface: added `autoRecallTimeoutMs?: number`; line ~2166: `3000` → `config.autoRecallTimeoutMs ?? 3000` |
| `openclaw.plugin.json` | Added `autoRecallTimeoutMs` to `configSchema.properties` (type: integer, range: 1000–120000ms, default: 3000) |

## Testing

- [x] `openclaw status` shows no Invalid config errors
- [x] Plugin registers successfully with `autoRecallTimeoutMs: 30000` in config
- [x] No `auto-recall timed out` messages on sessions with Ollama backend

---

Related issue: #323
