### PR TITLE
fix(self-improvement): skip note inject on Discord channel /new to avoid startup race

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2789,9 +2789,11 @@ const memoryLanceDBProPlugin = {
             // to avoid contributing to the post-reset startup race on Discord channels.
             // Discord thread resets are handled separately by the OpenClaw core's
             // postRotationStartupUntilMs mechanism (PR #49001).
-            const provider = typeof contextForLog.Provider === "string" ? contextForLog.Provider : "";
-            const messageThreadId = contextForLog.MessageThreadId;
-            if (provider === "discord" && (messageThreadId == null || messageThreadId === "")) {
+            // Note: Provider lives in sessionEntry.Provider; MessageThreadId lives in
+            // sessionEntry.threadId (populated from ctx.MessageThreadId at session creation).
+            const provider = contextForLog.sessionEntry?.Provider ?? "";
+            const threadId = contextForLog.sessionEntry?.threadId;
+            if (provider === "discord" && (threadId == null || threadId === "")) {
               api.logger.info(
                 `self-improvement: command:${action} skipped on Discord channel (non-thread) reset to avoid startup race; use /new in thread or restart gateway if startup is incomplete`
               );


### PR DESCRIPTION
## Summary
Skip self-improvement note injection on Discord channel (non-thread) resets.
The appendSelfImprovementNote hook was push()ing synchronously into
event.messages before the first agent turn ran, which contributed to
the post-reset startup race described in openclaw/openclaw#46941.

## Root cause
Discord channel resets (non-thread) have no MessageThreadId. The hook
interfered with the reset flow by modifying event.messages before the
first agent turn could complete. This is distinct from thread resets,
which are handled by the OpenClaw core's postRotationStartupUntilMs
mechanism (PR openclaw/openclaw#49001).

## Fix
Guard: when Provider=discord AND (MessageThreadId is absent or empty),
log and return early without modifying event.messages. Thread resets
and non-Discord surfaces are unaffected.

## Related
- openclaw/openclaw#46941 — /new re-fires command:new hooks (root cause)
- openclaw/openclaw#49001 — Thread-only post-rotation window
- openclaw/openclaw#53524 — This PR's companion for the channel session fix