### PR TITLE
fix: memory_recall includeFullText now returns L2 content instead of L0

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -102,20 +102,16 @@ function deriveManualMemoryLayer(category: string): "durable" | "working" {
 }
 
 function sanitizeMemoryForSerialization(results: RetrievalResult[]) {
-  return results.map((r) => {
-    const metadata = parseSmartMetadata(r.entry.metadata, r.entry);
-    return {
-      id: r.entry.id,
-      text: r.entry.text,
-      fullText: metadata.l2_content || metadata.l1_overview || r.entry.text,
-      category: getDisplayCategoryTag(r.entry),
-      rawCategory: r.entry.category,
-      scope: r.entry.scope,
-      importance: r.entry.importance,
-      score: r.score,
-      sources: r.sources,
-    };
-  });
+  return results.map((r) => ({
+    id: r.entry.id,
+    text: r.entry.text,
+    category: getDisplayCategoryTag(r.entry),
+    rawCategory: r.entry.category,
+    scope: r.entry.scope,
+    importance: r.entry.importance,
+    score: r.score,
+    sources: r.sources,
+  }));
 }
 
 const _warnedMissingAgentId = new Set<string>();
@@ -618,6 +614,15 @@ export function registerMemoryRecallTool(
             })
             .join("\n");
 
+          const serializedMemories = sanitizeMemoryForSerialization(results);
+          if (includeFullText) {
+            for (let i = 0; i < results.length; i++) {
+              const metadata = parseSmartMetadata(results[i].entry.metadata, results[i].entry);
+              (serializedMemories[i] as Record<string, unknown>).fullText =
+                metadata.l2_content || metadata.l1_overview || results[i].entry.text;
+            }
+          }
+
           return {
             content: [
               {
@@ -627,7 +632,7 @@ export function registerMemoryRecallTool(
             ],
             details: {
               count: results.length,
-              memories: sanitizeMemoryForSerialization(results),
+              memories: serializedMemories,
               query,
               scopes: scopeFilter,
               retrievalMode: runtimeContext.retriever.getConfig().mode,

--- a/test/recall-text-cleanup.test.mjs
+++ b/test/recall-text-cleanup.test.mjs
@@ -479,6 +479,72 @@ describe("recall text cleanup", () => {
     assert.equal(resFull.details.memories[0].text, l0, "details.memories[0].text should still be L0 for compatibility");
   });
 
+  it("includeFullText=false does not expose fullText in details.memories", async () => {
+    const l0 = "short L0 abstract";
+    const l2 = "Full L2 narrative that should not appear when includeFullText is false.";
+
+    const results = [
+      {
+        entry: {
+          id: "case-2",
+          text: l0,
+          category: "fact",
+          scope: "global",
+          importance: 0.85,
+          timestamp: Date.now(),
+          metadata: stringifySmartMetadata(
+            buildSmartMetadata(
+              { text: l0, category: "fact", importance: 0.85 },
+              {
+                l0_abstract: l0,
+                l1_overview: "## Overview\n- some overview",
+                l2_content: l2,
+                memory_category: "cases",
+                fact_key: "cases:opt-in-check",
+              },
+            ),
+          ),
+        },
+        score: 0.9,
+        sources: { vector: { score: 0.9, rank: 1 } },
+      },
+    ];
+
+    const tool = createTool(registerMemoryRecallTool, makeRecallContext(results));
+    const res = await tool.execute(null, { query: "opt-in check" });
+
+    assert.equal(res.details.memories[0].fullText, undefined, "fullText should be absent when includeFullText=false");
+    assert.equal(res.details.memories[0].text, l0, "text should still carry L0");
+  });
+
+  it("includeFullText=true falls back to entry.text for legacy memories without smart metadata", async () => {
+    const legacyText = "legacy memory with no smart metadata at all";
+
+    const results = [
+      {
+        entry: {
+          id: "legacy-1",
+          text: legacyText,
+          category: "fact",
+          scope: "global",
+          importance: 0.6,
+          timestamp: Date.now(),
+          // no metadata field — simulates pre-smart-extraction records
+        },
+        score: 0.75,
+        sources: { vector: { score: 0.75, rank: 1 } },
+      },
+    ];
+
+    const tool = createTool(registerMemoryRecallTool, makeRecallContext(results));
+    const res = await tool.execute(null, { query: "legacy fallback", includeFullText: true });
+    const lines = extractRenderedMemoryRecallLines(res.content[0].text);
+
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /legacy memory with no smart metadata/, "should render entry.text as fallback for legacy memories");
+    assert.equal(res.details.memories[0].fullText, legacyText, "details.memories[0].fullText should fall back to entry.text");
+  });
+
 
   it("applies auto-recall item/char budgets before injecting context", async () => {
     MemoryRetriever.prototype.retrieve = async () => makeManyResults(5);


### PR DESCRIPTION
Closes #333

## Problem

`memory_recall` with `includeFullText: true` was returning L0 (one-line abstract) instead of the full L2 content. This happened because the `text` column in LanceDB stores the L0 abstract, and the tool read directly from that column for both `includeFullText: true` and `false` — making the parameter a no-op.

```ts
// Before (broken)
const base = includeFullText
  ? r.entry.text            // ← r.entry.text is L0
  : metadata.l0_abstract || r.entry.text;
```

## Fix

Resolve full content through the L2 → L1 → L0 fallback chain when `includeFullText: true`:

```ts
// After
const base = includeFullText
  ? (metadata.l2_content || metadata.l1_overview || r.entry.text)
  : (metadata.l0_abstract || r.entry.text);
```

Also add `fullText` to `sanitizeMemoryForSerialization` so the `details.memories` structured payload exposes L2 content for callers that inspect the tool response directly.

## Why this matters

When an agent explicitly calls `memory_recall`, it signals active intent to retrieve memory detail. Auto-recall (passive injection) returning L0 hints is fine — it keeps context concise. But an explicit tool call should return the full narrative, especially for `cases` and `patterns` categories where L2 contains actionable step-by-step content that L0 cannot capture in one line.

## Changes

- `src/tools.ts` — 2 hunks, no new dependencies