### PR TITLE
fix: exclude vector arrays from CLI --json output

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -406,7 +406,11 @@ function formatMemory(memory: any, index?: number): string {
 }
 
 function formatJson(obj: any): string {
-  return JSON.stringify(obj, null, 2);
+  return JSON.stringify(obj, (key, value) => {
+    // Exclude verbose vector arrays from CLI output
+    if (key === "vector") return undefined;
+    return value;
+  }, 2);
 }
 
 async function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary

The `--json` output for `list`, `search`, and `stats` CLI commands included full vector arrays (768-1024 dimensional floats per entry), making output extremely verbose and unreadable.

## Changes

Use a JSON replacer function in `formatJson()` to automatically filter out `vector` fields from all CLI JSON output. This is consistent with the `export` command which already strips vectors (line 888: `vector: undefined`).

## Before
```json
{
  "id": "abc123",
  "text": "Some memory",
  "vector": [0.023, -0.045, 0.012, ...],  // 768+ numbers!
  ...
}
```

## After
```json
{
  "id": "abc123",
  "text": "Some memory",
  ...
}
```

## Files Changed
| File | Change |
|------|--------|
| `cli.ts` | `formatJson()` now uses JSON replacer to exclude `vector` key |

Fixes #302