### PR TITLE
fix: guard against null entries in LLM extraction response

### DIFF
--- a/src/smart-extractor.ts
+++ b/src/smart-extractor.ts
@@ -377,6 +377,13 @@ export class SmartExtractor {
     let shortAbstractCount = 0;
     let noiseAbstractCount = 0;
     for (const raw of result.memories) {
+      if (!raw || typeof raw !== "object") {
+        invalidCategoryCount++;
+        this.debugLog(
+          `memory-lancedb-pro: smart-extractor: dropping null/invalid candidate entry`,
+        );
+        continue;
+      }
       const category = normalizeCategory(raw.category ?? "");
       if (!category) {
         invalidCategoryCount++;


### PR DESCRIPTION
## Summary

When the smartExtraction LLM returns malformed JSON with null entries in the `memories` array (e.g. `{memories: [null, {...}]}`), accessing `raw.category` throws:

```
TypeError: Cannot read properties of null (reading 'category')
```

This crash kills the entire auto-capture pipeline, producing the log:
```
memory-lancedb-pro: capture failed: TypeError: Cannot read properties of null (reading 'category')
```

## Root Cause

In `src/smart-extractor.ts`, the candidate processing loop iterates over `result.memories` without checking if individual entries are valid objects:

```typescript
for (const raw of result.memories) {
  const category = normalizeCategory(raw.category ?? ""); // 💥 raw is null!
}
```

Some LLM models (especially under load or rate limiting) occasionally return arrays with null entries mixed in with valid objects.

## Fix

Add a null/type guard at the top of the loop to skip invalid entries gracefully:

```typescript
if (!raw || typeof raw !== 'object') {
  invalidCategoryCount++;
  continue;
}
```

## Evidence

Observed 7 occurrences across multiple days in production:
```
2026-03-21T16:14:36 capture failed: TypeError: Cannot read properties of null (reading 'category')
2026-03-21T20:26:05 capture failed: TypeError: Cannot read properties of null (reading 'category')
2026-03-22T20:06:13 capture failed: TypeError: Cannot read properties of null (reading 'category')
2026-03-24T02:46:33 capture failed: TypeError: Cannot read properties of null (reading 'category')
```

## Files Changed
| File | Change |
|------|--------|
| `src/smart-extractor.ts` | Add null/type guard for candidate entries in extraction loop |