### PR TITLE
fix: prevent autoRecall context inflation (#345)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -100,6 +100,8 @@ interface PluginConfig {
   autoRecallMaxItems?: number;
   autoRecallMaxChars?: number;
   autoRecallPerItemMaxChars?: number;
+  /** Hard per-turn injection cap (safety valve). Overrides autoRecallMaxItems if lower. Default: 10. */
+  maxRecallPerTurn?: number;
   recallMode?: "full" | "summary" | "adaptive" | "off";
   captureAssistant?: boolean;
   retrieval?: {
@@ -2255,7 +2257,10 @@ const memoryLanceDBProPlugin = {
             );
           }
 
-          const autoRecallMaxItems = clampInt(config.autoRecallMaxItems ?? 3, 1, 20);
+          const configMaxItems = clampInt(config.autoRecallMaxItems ?? 3, 1, 20);
+          const maxPerTurn = clampInt(config.maxRecallPerTurn ?? 10, 1, 50);
+          // maxRecallPerTurn acts as a hard ceiling on top of autoRecallMaxItems (#345)
+          const autoRecallMaxItems = Math.min(configMaxItems, maxPerTurn);
           const autoRecallMaxChars = clampInt(config.autoRecallMaxChars ?? 600, 64, 8000);
           const autoRecallPerItemMaxChars = clampInt(config.autoRecallPerItemMaxChars ?? 180, 32, 1000);
           const retrieveLimit = clampInt(Math.max(autoRecallMaxItems * 2, autoRecallMaxItems), 1, 20);
@@ -2473,6 +2478,10 @@ const memoryLanceDBProPlugin = {
               `${memoryContext}\n` +
               `[END UNTRUSTED DATA]\n` +
               `</relevant-memories>`,
+            // Mark as ephemeral so the host framework's compaction logic can
+            // safely discard injected memory blocks instead of persisting them
+            // into the session transcript (#345).
+            ephemeral: true,
           };
         };
 
@@ -2493,6 +2502,22 @@ const memoryLanceDBProPlugin = {
         } catch (err) {
           clearTimeout(timeoutId);
           api.logger.warn(`memory-lancedb-pro: recall failed: ${String(err)}`);
+        }
+      }, { priority: 10 });
+
+      // Clean up auto-recall session state on session end to prevent unbounded
+      // growth of recallHistory and turnCounter Maps (#345).
+      api.on("session_end", (_event: any, ctx: any) => {
+        const sessionId = ctx?.sessionId || "";
+        if (sessionId) {
+          recallHistory.delete(sessionId);
+          turnCounter.delete(sessionId);
+          lastRawUserMessage.delete(sessionId);
+        }
+        // Also clean by channelId/conversationId if present (shared cache key)
+        const cacheKey = ctx?.channelId || ctx?.conversationId || "";
+        if (cacheKey && cacheKey !== sessionId) {
+          lastRawUserMessage.delete(cacheKey);
         }
       }, { priority: 10 });
     }
@@ -3766,6 +3791,7 @@ export function parsePluginConfig(value: unknown): PluginConfig {
     autoRecallMaxItems: parsePositiveInt(cfg.autoRecallMaxItems) ?? 3,
     autoRecallMaxChars: parsePositiveInt(cfg.autoRecallMaxChars) ?? 600,
     autoRecallPerItemMaxChars: parsePositiveInt(cfg.autoRecallPerItemMaxChars) ?? 180,
+    maxRecallPerTurn: parsePositiveInt(cfg.maxRecallPerTurn) ?? 10,
     captureAssistant: cfg.captureAssistant === true,
     retrieval: typeof cfg.retrieval === "object" && cfg.retrieval !== null ? cfg.retrieval as any : undefined,
     decay: typeof cfg.decay === "object" && cfg.decay !== null ? cfg.decay as any : undefined,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -137,6 +137,13 @@
         "default": 180,
         "description": "Maximum character budget per auto-injected memory summary."
       },
+      "maxRecallPerTurn": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 50,
+        "default": 10,
+        "description": "Hard per-turn injection cap applied after dedup. Acts as a safety ceiling on top of autoRecallMaxItems to prevent context inflation. Default: 10."
+      },
       "recallMode": {
         "type": "string",
         "enum": ["full", "summary", "adaptive", "off"],
@@ -1016,6 +1023,11 @@
       "label": "Recall Mode",
       "help": "Auto-recall depth: full (default), summary (L0 only), adaptive (intent-based category routing), off.",
       "advanced": false
+    },
+    "maxRecallPerTurn": {
+      "label": "Max Recall Per Turn",
+      "help": "Hard per-turn injection cap. Acts as a safety ceiling on top of Auto-Recall Max Items. Default: 10.",
+      "advanced": true
     },
     "captureAssistant": {
       "label": "Capture Assistant Messages",


### PR DESCRIPTION
## Summary
- Fixes #345 — autoRecall injected memory blocks caused context to balloon and trigger compaction loops
- Three compounding root causes addressed:
  1. **Session state leak**: `recallHistory` and `turnCounter` Maps never cleaned on `session_end`, causing unbounded growth
  2. **No hard per-turn safety cap**: Added `maxRecallPerTurn` config (default 10) as a ceiling on `autoRecallMaxItems`
  3. **Injection blocks not ephemeral**: Added `ephemeral: true` flag so compaction can safely discard `<relevant-memories>` blocks

## Changes
- `index.ts`: Add `maxRecallPerTurn` config + parsing, apply `Math.min(configMaxItems, maxPerTurn)` cap, add `ephemeral: true` to hook return, add `session_end` handler to clean recallHistory/turnCounter/lastRawUserMessage
- `openclaw.plugin.json`: Add `maxRecallPerTurn` schema definition + settings hint

## Test plan
- [x] All 17 existing test suites pass (0 failures)
- [x] Plugin manifest regression test passes
- [ ] Manual test: 10+ turn conversation with `autoRecall=true` confirms no duplicate injection
- [ ] Confirm `maxRecallPerTurn` config is respected when set lower than `autoRecallMaxItems`
- [ ] Confirm session state Maps are cleaned after session_end

🤖 Generated with [Claude Code](https://claude.com/claude-code)