### PR TITLE
fix: auto-captured memories write confirmed state to unblock autoRecall

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2802,7 +2802,11 @@ const memoryLanceDBProPlugin = {
                     l2_content: text,
                     source_session: (event as any).sessionKey || "unknown",
                     source: "auto-capture",
-                    state: "pending",
+                    // Write "confirmed" so auto-recall governance filter accepts
+                    // these memories immediately. Previously "pending" caused a
+                    // deadlock where auto-captured memories could never be
+                    // auto-recalled (see #350).
+                    state: "confirmed",
                     memory_layer: "working",
                     injected_count: 0,
                     bad_recall_count: 0,

--- a/src/smart-extractor.ts
+++ b/src/smart-extractor.ts
@@ -978,7 +978,7 @@ export class SmartExtractor {
             confidence: 0.7,
             source_session: sessionKey,
             source: "auto-capture",
-            state: "pending",
+            state: "confirmed", // #350: write confirmed to unblock auto-recall
             memory_layer: "working",
             injected_count: 0,
             bad_recall_count: 0,
@@ -1076,7 +1076,7 @@ export class SmartExtractor {
       last_accessed_at: Date.now(),
       source_session: sessionKey,
       source: "auto-capture" as const,
-      state: "pending" as const,
+      state: "confirmed" as const, // #350: write confirmed to unblock auto-recall
       memory_layer: "working" as const,
       injected_count: 0,
       bad_recall_count: 0,
@@ -1140,7 +1140,7 @@ export class SmartExtractor {
       last_accessed_at: Date.now(),
       source_session: sessionKey,
       source: "auto-capture" as const,
-      state: "pending" as const,
+      state: "confirmed" as const, // #350: write confirmed to unblock auto-recall
       memory_layer: "working" as const,
       injected_count: 0,
       bad_recall_count: 0,
@@ -1196,7 +1196,7 @@ export class SmartExtractor {
           confidence: 0.7,
           source_session: sessionKey,
           source: "auto-capture",
-          state: "pending",
+          state: "confirmed", // #350: write confirmed to unblock auto-recall
           memory_layer: "working",
           injected_count: 0,
           bad_recall_count: 0,


### PR DESCRIPTION
## Summary
- Fixes #350
- autoCapture wrote `state: "pending"` in metadata but autoRecall governance filter requires `state === "confirmed"`, creating a deadlock where auto-captured memories could never be auto-recalled
- Changed all 5 auto-capture write paths to write `state: "confirmed"` directly:
  - `index.ts` regex fallback capture (1 location)
  - `src/smart-extractor.ts` Smart Extraction paths: supersede, contextualize, contradict, and new-entry (4 locations)

## Rationale
The `pending → confirmed` lifecycle was introduced in v1.1.0-beta but no automatic promotion mechanism exists. The `memory_promote` tool requires `enableManagementTools: true` (disabled by default), so out-of-the-box autoCapture + autoRecall is broken. Writing `confirmed` at capture time matches the behavior of `memory_store` (manual store) and unblocks the core workflow.

## Test plan
- [x] `npm test` passes (all existing tests)
- [ ] Manual test: enable `autoCapture: true` + `autoRecall: true`, verify new memories appear in `<relevant-memories>` tag
- [ ] Verify `memory_promote` still works for legacy pending memories

🤖 Generated with [Claude Code](https://claude.com/claude-code)