### PR TITLE
feat: make rerank timeout configurable via rerankTimeoutMs

### DIFF
--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -58,6 +58,8 @@ export interface RetrievalConfig {
     | "pinecone"
     | "dashscope"
     | "tei";
+  /** Rerank API timeout in milliseconds (default: 5000). Increase for local/CPU-based rerank servers. */
+  rerankTimeoutMs?: number;
   /**
    * Length normalization: penalize long entries that dominate via sheer keyword
    * density. Formula: score *= 1 / (1 + log2(charLen / anchor)).
@@ -127,6 +129,7 @@ export const DEFAULT_RETRIEVAL_CONFIG: RetrievalConfig = {
   filterNoise: true,
   rerankModel: "jina-reranker-v3",
   rerankEndpoint: "https://api.jina.ai/v1/rerank",
+  rerankTimeoutMs: 5000,
   lengthNormAnchor: 500,
   hardMinScore: 0.35,
   timeDecayHalfLifeDays: 60,
@@ -858,9 +861,9 @@ export class MemoryRetriever {
           results.length,
         );
 
-        // Timeout: 5 seconds to prevent stalling retrieval pipeline
+        // Timeout: configurable via rerankTimeoutMs (default: 5000ms)
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 5000);
+        const timeout = setTimeout(() => controller.abort(), this.config.rerankTimeoutMs ?? 5000);
 
         const response = await fetch(endpoint, {
           method: "POST",
@@ -928,7 +931,7 @@ export class MemoryRetriever {
         }
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {
-          console.warn("Rerank API timed out (5s), falling back to cosine");
+          console.warn(`Rerank API timed out (${this.config.rerankTimeoutMs ?? 5000}ms), falling back to cosine`);
         } else {
           console.warn("Rerank API failed, falling back to cosine:", error);
         }


### PR DESCRIPTION
feat: make rerank timeout configurable via rerankTimeoutMs

## Summary

Add a configurable `rerankTimeoutMs` parameter to `RetrievalConfig` so that users running local/CPU-based rerank servers can adjust the timeout without patching source code. Closes #346.

## Changes

### 1. `src/retriever.ts` — `RetrievalConfig` interface

Add `rerankTimeoutMs` field after `rerankProvider`:

```typescript
/** Rerank API timeout in milliseconds (default: 5000). Increase for local/CPU-based rerank servers. */
rerankTimeoutMs?: number;
```

### 2. `src/retriever.ts` — `DEFAULT_RETRIEVAL_CONFIG`

```typescript
rerankEndpoint: "https://api.jina.ai/v1/rerank",
rerankTimeoutMs: 5000,
```

### 3. `src/retriever.ts` — `rerankResults()` method

Line 866 — replace hardcoded `5000`:

```typescript
// Before
const timeout = setTimeout(() => controller.abort(), 5000);

// After
const rerankTimeout = this.config.rerankTimeoutMs ?? 5000;
const timeout = rerankTimeout > 0 ? setTimeout(() => controller.abort(), rerankTimeout) : null;
```

Also updated `clearTimeout` to guard against the null case (timeout is `null` when `rerankTimeout=0`).

### 4. `src/retriever.ts` — Warning message

```typescript
// Before
console.warn("Rerank API timed out (5s), falling back to cosine");

// After
console.warn(`Rerank API timed out (${rerankTimeout}ms), falling back to cosine`);
```

## Usage Example

```json
{
  "plugins": {
    "entries": {
      "memory-lancedb-pro": {
        "config": {
          "retrieval": {
            "rerankTimeoutMs": 120000
          }
        }
      }
    }
  }
}
```

## Local Model Example (James's Setup)

Full config for local `BAAI/bge-reranker-base` via `reranker_server.py` (port 18799, SiliconFlow-compatible):

```json
{
  "plugins": {
    "entries": {
      "memory-lancedb-pro": {
        "config": {
          "retrieval": {
            "rerank": "cross-encoder",
            "rerankProvider": "siliconflow",
            "rerankEndpoint": "http://127.0.0.1:18799/v1/rerank",
            "rerankTimeoutMs": 120000
          }
        }
      }
    }
  }
}
```

## Backward Compatibility

- Default `5000ms` is identical to the current hardcoded behavior
- Users who don't specify `rerankTimeoutMs` see no change
- GPU users can keep short timeouts; CPU users can increase as needed

## Issue

Closes #346
