### PR TITLE
feat: make rerank timeout configurable via rerankTimeoutMs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -120,6 +120,8 @@ interface PluginConfig {
     rerankApiKey?: string;
     rerankModel?: string;
     rerankEndpoint?: string;
+    /** Rerank API timeout in milliseconds (default: 5000). Increase for local/CPU-based rerank servers. */
+    rerankTimeoutMs?: number;
     rerankProvider?:
       | "jina"
       | "siliconflow"

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -319,6 +319,12 @@
             "default": "https://api.jina.ai/v1/rerank",
             "description": "Reranker API endpoint URL. Compatible with Jina-compatible endpoints and dedicated adapters such as TEI, SiliconFlow, Voyage, Pinecone, and DashScope."
           },
+          "rerankTimeoutMs": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 5000,
+            "description": "Rerank API timeout in milliseconds (default: 5000). Increase for local/CPU-based rerank servers."
+          },
           "rerankProvider": {
             "type": "string",
             "enum": [
@@ -1076,6 +1082,12 @@
       "label": "Reranker Endpoint",
       "placeholder": "https://api.jina.ai/v1/rerank",
       "help": "Custom reranker API endpoint URL",
+      "advanced": true
+    },
+    "retrieval.rerankTimeoutMs": {
+      "label": "Rerank Timeout (ms)",
+      "placeholder": "5000",
+      "help": "Rerank API timeout in milliseconds. Increase for local/CPU-based rerank servers.",
       "advanced": true
     },
     "retrieval.rerankProvider": {

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -865,14 +865,17 @@ export class MemoryRetriever {
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), this.config.rerankTimeoutMs ?? 5000);
 
-        const response = await fetch(endpoint, {
-          method: "POST",
-          headers,
-          body: JSON.stringify(body),
-          signal: controller.signal,
-        });
-
-        clearTimeout(timeout);
+        let response: Response;
+        try {
+          response = await fetch(endpoint, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(body),
+            signal: controller.signal,
+          });
+        } finally {
+          clearTimeout(timeout);
+        }
 
         if (response.ok) {
           const data: unknown = await response.json();


### PR DESCRIPTION
feat: make rerank timeout configurable via rerankTimeoutMs

## Summary

Add a configurable `rerankTimeoutMs` parameter to `RetrievalConfig` so that users running local/CPU-based rerank servers can adjust the timeout without patching source code. Closes #346.

## Changes (4 lines across 1 file)

### 1. `src/retriever.ts` — `RetrievalConfig` interface

```typescript
/** Rerank API timeout in milliseconds (default: 5000). Increase for local/CPU-based rerank servers. */
rerankTimeoutMs?: number;
```

### 2. `src/retriever.ts` — `DEFAULT_RETRIEVAL_CONFIG`

```typescript
rerankEndpoint: "https://api.jina.ai/v1/rerank",
rerankTimeoutMs: 5000,
```

### 3. `src/retriever.ts` — `rerankResults()` method

```typescript
// Before
const timeout = setTimeout(() => controller.abort(), 5000);

// After
const timeout = setTimeout(() => controller.abort(), this.config.rerankTimeoutMs ?? 5000);
```

### 4. `src/retriever.ts` — Warning message

```typescript
// Before
console.warn("Rerank API timed out (5s), falling back to cosine");

// After
console.warn(`Rerank API timed out (${this.config.rerankTimeoutMs ?? 5000}ms), falling back to cosine`);
```

## Usage Example

```json
{
  "plugins": {
    "entries": {
      "memory-lancedb-pro": {
        "config": {
          "retrieval": {
            "rerankTimeoutMs": 120000
          }
        }
      }
    }
  }
}
```

## Local Model Example (BAAI/bge-reranker-base via reranker_server.py)

```json
{
  "plugins": {
    "entries": {
      "memory-lancedb-pro": {
        "config": {
          "retrieval": {
            "rerank": "cross-encoder",
            "rerankProvider": "siliconflow",
            "rerankEndpoint": "http://127.0.0.1:18799/v1/rerank",
            "rerankTimeoutMs": 120000
          }
        }
      }
    }
  }
}
```

## Backward Compatibility

- Default `5000ms` is identical to the current hardcoded behavior
- Users who don't specify `rerankTimeoutMs` see no change
- GPU users can keep short timeouts; CPU users can increase as needed

## Issue

Closes #346
