### PR TITLE
fix: prevent reflection loop with global cross-instance re-entrant guard

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3137,6 +3137,7 @@ const memoryLanceDBProPlugin = {
           }
         }
         if (sessionKey) globalLock.set(sessionKey, true);
+        let reflectionRan = false;
         try {
           pruneReflectionSessionState();
           const action = String(event?.action || "unknown");
@@ -3201,6 +3202,11 @@ const memoryLanceDBProPlugin = {
             );
             return;
           }
+
+          // Mark that reflection will actually run — cooldown is only recorded
+          // for runs that pass all pre-condition checks, not for early exits
+          // (missing cfg, session file, or conversation).
+          reflectionRan = true;
 
           const now = new Date(typeof event.timestamp === "number" ? event.timestamp : Date.now());
           const nowTs = now.getTime();
@@ -3397,7 +3403,9 @@ const memoryLanceDBProPlugin = {
           if (sessionKey) {
             reflectionErrorStateBySession.delete(sessionKey);
             getGlobalReflectionLock().delete(sessionKey);
-            getSerialGuardMap().set(sessionKey, Date.now());
+            if (reflectionRan) {
+              getSerialGuardMap().set(sessionKey, Date.now());
+            }
           }
           pruneReflectionSessionState();
         }


### PR DESCRIPTION
## Problem

Each plugin instance maintained its own re-entrant guard `Map`. When the runtime re-loaded the plugin during embedded agent turns (e.g. `command:new` inside a reflection), a new instance would bypass the guard, causing infinite reflection loops.

## Solution

Introduce two global guards using `Symbol.for` + `globalThis` so **all** plugin instances share the same state:

1. **Global re-entrant lock** — prevents concurrent reflection calls for the same `sessionKey` across all plugin instances.
2. **Serial loop guard** — imposes a 2-minute cooldown per `sessionKey` between consecutive reflection runs, preventing gateway-level re-triggering chains (`session_end` → new session → `command:new`).

## Changes

- Only `index.ts` modified — no dependency changes.
- Guards are initialized lazily via `Symbol.for` keys, safe for multiple loads.
- Cooldown is configurable via `SERIAL_GUARD_COOLDOWN_MS` constant (currently 120s).