### PR TITLE
feat: add configurable rerank timeout (rerankTimeoutMs)

### DIFF
--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -45,6 +45,8 @@ export interface RetrievalConfig {
   rerankModel?: string;
   /** Reranker API endpoint (default: https://api.jina.ai/v1/rerank). */
   rerankEndpoint?: string;
+  /** Reranker request timeout in milliseconds (default: 10000). */
+  rerankTimeoutMs?: number;
   /** Reranker provider format. Determines request/response shape and auth header.
    *  - "jina" (default): Authorization: Bearer, string[] documents, results[].relevance_score
    *  - "siliconflow": same format as jina (alias, for clarity)
@@ -858,9 +860,10 @@ export class MemoryRetriever {
           results.length,
         );
 
-        // Timeout: 5 seconds to prevent stalling retrieval pipeline
+        // Timeout to prevent stalling retrieval pipeline
+        const RERANK_TIMEOUT_MS = this.config.rerankTimeoutMs ?? 10_000;
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 5000);
+        const timeout = setTimeout(() => controller.abort(), RERANK_TIMEOUT_MS);
 
         const response = await fetch(endpoint, {
           method: "POST",


### PR DESCRIPTION
## Summary

The cross-encoder rerank request timeout was hardcoded at 5 seconds, which is too aggressive for self-hosted rerank services (e.g. HuggingFace TEI via Infinity) that may need 6-7 seconds to respond.

## Changes

- Add `rerankTimeoutMs` optional field to `RetrievalConfig` interface
- Replace hardcoded `5000` with `config.rerankTimeoutMs ?? 10_000`
- Default raised from 5s to 10s for better compatibility with self-hosted endpoints

## Usage

```json
{
  "retrieval": {
    "rerank": "cross-encoder",
    "rerankTimeoutMs": 20000
  }
}
```

## Backwards Compatibility

Fully backwards compatible. Existing configs without `rerankTimeoutMs` will get the new 10s default.