### PR TITLE
fix test: update hardcoded seed date to stay within 14-day age limit

### DIFF
--- a/test/reflection-bypass-hook.test.mjs
+++ b/test/reflection-bypass-hook.test.mjs
@@ -96,7 +96,7 @@ async function seedReflection(dbPath, agentId) {
     command: "command:new",
     scope: "global",
     toolErrorSignals: [],
-    runAt: Date.UTC(2026, 2, 12, 15, 0, 0),
+    runAt: Date.UTC(2026, 2, 26, 15, 0, 0),  // 2026-03-26 — within 14-day derive age limit
     usedFallback: false,
     embedPassage: async () => FIXED_VECTOR,
     vectorSearch: async () => [],


### PR DESCRIPTION
## Summary

Fixes CI failure in \	est/reflection-bypass-hook.test.mjs\.

## Root Cause Analysis

The test seeds a derived reflection entry with a **hardcoded date**:

\\\js
runAt: Date.UTC(2026, 2, 12, 15, 0, 0)  // March 12, 2026
\\\

The production age filter in \src/reflection-store.ts\ has a **14-day hard limit** on derived entries:

\\\js
export const DEFAULT_REFLECTION_DERIVED_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;  // 14 days

// rankReflectionLines():
if (now - timestamp > options.maxAgeMs!) {
  continue;  // filtered out
}
\\\

Current date is **2026-03-27** — the seeded entry is **15 days old**, exceeding the 14-day threshold. The derived entry is silently filtered out, causing all assertions against \<derived-focus>\ to fail.

**Note**: The production code logic is **correct**. This is a test maintenance issue — the hardcoded date has simply expired past the age threshold.

## Why Invariants Pass But Derived Fails

- \invariantMaxAgeMs\ → \undefined\ → age check skipped (no filtering)
- \deriveMaxAgeMs\ → \14 days\ → age check applies (filters out 15-day-old entry)

## Fix

Updated seed date from \2026-03-12\ to \2026-03-26\ (2 days ago), keeping the entry well within the 14-day window.

## Impact

- **Severity**: CI regression (pre-existing, unrelated to any active PR)
- **Production impact**: None
- **Test impact**: Fixes 4 failing subtests in \eflection-bypass-hook.test.mjs\

Fixes #384.