### PR TITLE
fix: suppress plugin registration logs in CLI mode (#380)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2999,7 +2999,9 @@ const memoryLanceDBProPlugin = {
         });
       }
 
-      api.logger.info("self-improvement: integrated hooks registered (agent:bootstrap, command:new, command:reset)");
+      (isCliMode() ? api.logger.debug : api.logger.info)(
+        "self-improvement: integrated hooks registered (agent:bootstrap, command:new, command:reset)"
+      );
     }
 
     // ========================================================================
@@ -3430,7 +3432,9 @@ const memoryLanceDBProPlugin = {
         name: "memory-lancedb-pro.memory-reflection.command-reset",
         description: "Generate reflection log before /reset",
       });
-      api.logger.info("memory-reflection: integrated hooks registered (command:new, command:reset, after_tool_call, before_prompt_build, session_end)");
+      (isCliMode() ? api.logger.debug : api.logger.info)(
+        "memory-reflection: integrated hooks registered (command:new, command:reset, after_tool_call, before_prompt_build, session_end)"
+      );
     }
 
     if (config.sessionStrategy === "systemSessionMemory") {


### PR DESCRIPTION
## Summary

Fixes #380

## Problem
Every `openclaw memory-pro` CLI command (stats, list, search, etc.) outputs ~11 lines of plugin registration logs to stderr before the actual command output, making CLI output very hard to read.

## Solution
Detect CLI mode via `OPENCLAW_CLI` environment variable (set by OpenClaw when running CLI subcommands). In CLI mode, downgrade registration and lifecycle logs from `info` to `debug` level.

## Changes
- Added `isCliMode()` helper that checks `process.env.OPENCLAW_CLI === "1"`
- Downgraded 5 registration/lifecycle log lines to debug in CLI mode:
  - smart extraction enabled
  - plugin registered (db, model, smartExtraction)
  - diagnostic build tag loaded
  - session-strategy: using none
  - session-memory: typed before_reset hook registered

## Behavior
| Context | Before | After |
|---------|--------|-------|
| Gateway runtime | info (visible) | info (unchanged) |
| CLI commands | info (noisy ~11 lines) | debug (suppressed) |

## Testing
Tested with `openclaw memory-pro stats` — registration logs no longer appear in stderr. Gateway startup logs remain unchanged.