### PR TITLE
fix: Index.fts({ withPosition: true }) to enable phrase queries

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -362,7 +362,7 @@ export class MemoryStore {
         // LanceDB @lancedb/lancedb >=0.26: use Index.fts() config
         const lancedb = await loadLanceDB();
         await table.createIndex("text", {
-          config: (lancedb as any).Index.fts(),
+          config: (lancedb as any).Index.fts({ withPosition: true }),
         });
       }
     } catch (err) {


### PR DESCRIPTION
## Problem

BM25 phrase queries (e.g. `"exact phrase"`) were silently broken because FTS indexes were created without position data (`withPosition: false` is the default).

## Fix

Change `Index.fts()` to `Index.fts({ withPosition: true })` in `src/store.ts`.

This adds position data to the FTS index, enabling phrase queries to work correctly.

## Changelog

- Fix: `Index.fts({ withPosition: true })` enables phrase queries
- Fix: Rebased onto latest upstream/master (3dc0956)
- Note: **Existing users must rebuild their FTS indexes** after upgrading — see Upgrade Note below

## Upgrade Note

Existing users with old FTS indexes will still get broken phrase queries after upgrade. To fix, run:

```bash
openclaw memory-pro reindex-fts
```

Or call `rebuildFtsIndex()` programmatically. This rebuilds the index with position data so phrase queries work correctly.

## Verification

- Before: `Index.fts()` creates index without position data → phrase queries silently fail
- After: `Index.fts({ withPosition: true })` creates index with position data → phrase queries work

Closes #402
