### PR TITLE
fix: resolve env vars in retrieval rerank config

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3808,7 +3808,25 @@ export function parsePluginConfig(value: unknown): PluginConfig {
     autoRecallPerItemMaxChars: parsePositiveInt(cfg.autoRecallPerItemMaxChars) ?? 180,
     maxRecallPerTurn: parsePositiveInt(cfg.maxRecallPerTurn) ?? 10,
     captureAssistant: cfg.captureAssistant === true,
-    retrieval: typeof cfg.retrieval === "object" && cfg.retrieval !== null ? cfg.retrieval as any : undefined,
+    retrieval:
+      typeof cfg.retrieval === "object" && cfg.retrieval !== null
+        ? (() => {
+          const retrieval = { ...(cfg.retrieval as Record<string, unknown>) } as Record<string, unknown>;
+          if (typeof retrieval.rerankApiKey === "string") {
+            retrieval.rerankApiKey = resolveEnvVars(retrieval.rerankApiKey);
+          }
+          if (typeof retrieval.rerankEndpoint === "string") {
+            retrieval.rerankEndpoint = resolveEnvVars(retrieval.rerankEndpoint);
+          }
+          if (typeof retrieval.rerankModel === "string") {
+            retrieval.rerankModel = resolveEnvVars(retrieval.rerankModel);
+          }
+          if (typeof retrieval.rerankProvider === "string") {
+            retrieval.rerankProvider = resolveEnvVars(retrieval.rerankProvider);
+          }
+          return retrieval as any;
+        })()
+        : undefined,
     decay: typeof cfg.decay === "object" && cfg.decay !== null ? cfg.decay as any : undefined,
     tier: typeof cfg.tier === "object" && cfg.tier !== null ? cfg.tier as any : undefined,
     // Smart extraction config (Phase 1)

--- a/test/resolve-env-vars-array.test.mjs
+++ b/test/resolve-env-vars-array.test.mjs
@@ -179,3 +179,34 @@ test("parsePluginConfig rejects empty array apiKey", () => {
     /apiKey/,
   );
 });
+
+test("parsePluginConfig resolves env vars in retrieval rerank config", () => {
+  process.env.__TEST_RERANK_KEY = "rerank-key-from-env";
+  process.env.__TEST_RERANK_ENDPOINT = "https://api.jina.ai/v1/rerank";
+  process.env.__TEST_RERANK_MODEL = "jina-reranker-v2-base-multilingual";
+  process.env.__TEST_RERANK_PROVIDER = "jina";
+  try {
+    const config = parsePluginConfig({
+      embedding: {
+        apiKey: "embed-key",
+        model: "text-embedding-3-small",
+      },
+      retrieval: {
+        rerank: "cross-encoder",
+        rerankApiKey: "${__TEST_RERANK_KEY}",
+        rerankEndpoint: "${__TEST_RERANK_ENDPOINT}",
+        rerankModel: "${__TEST_RERANK_MODEL}",
+        rerankProvider: "${__TEST_RERANK_PROVIDER}",
+      },
+    });
+    assert.equal(config.retrieval.rerankApiKey, "rerank-key-from-env");
+    assert.equal(config.retrieval.rerankEndpoint, "https://api.jina.ai/v1/rerank");
+    assert.equal(config.retrieval.rerankModel, "jina-reranker-v2-base-multilingual");
+    assert.equal(config.retrieval.rerankProvider, "jina");
+  } finally {
+    delete process.env.__TEST_RERANK_KEY;
+    delete process.env.__TEST_RERANK_ENDPOINT;
+    delete process.env.__TEST_RERANK_MODEL;
+    delete process.env.__TEST_RERANK_PROVIDER;
+  }
+});


### PR DESCRIPTION
## Summary
- resolve env placeholders in `retrieval.rerankApiKey` before building rerank requests
- also resolve `retrieval.rerankEndpoint`, `retrieval.rerankModel`, and `retrieval.rerankProvider` for consistency with env-based config
- add a regression test covering env expansion in retrieval rerank config

## Why
`embedding.apiKey` already supports `${ENV_VAR}` expansion, but `retrieval.rerankApiKey` was passed through without explicit resolution in `parsePluginConfig`. In env-based OpenClaw configs this can lead to rerank auth failures or literal `${JINA_API_KEY}` values being propagated.

## Validation
- patched running OpenClaw instance and verified memory pipeline remained healthy
- `node --test test/resolve-env-vars-array.test.mjs`
