### PR TITLE
fix: register memory runtime for OpenClaw 2026.4.1

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2093,6 +2093,109 @@ const memoryLanceDBProPlugin = {
     );
 
     // ========================================================================
+    // Register Memory Runtime (required by OpenClaw 2026.4.1+)
+    // ========================================================================
+
+    api.registerMemoryRuntime({
+      async getMemorySearchManager(params: { cfg: unknown; agentId: string; purpose?: "default" | "status" }) {
+        const accessibleScopes = resolveScopeFilter(scopeManager, params.agentId);
+        const scopeFilter = accessibleScopes;
+        const syntheticPathForId = (id: string, scope: string) => `memory-lancedb-pro/${scope || "global"}/${id}.md`;
+
+        return {
+          manager: {
+            async search(query: string, opts?: { maxResults?: number; minScore?: number; sessionKey?: string }) {
+              const limit = clampInt(opts?.maxResults ?? 5, 1, 20);
+              const minScore = typeof opts?.minScore === "number" ? opts.minScore : 0;
+              const results = await retriever.retrieve({
+                query,
+                limit,
+                scopeFilter,
+                source: "manual",
+              });
+              return results
+                .filter((result) => result.score >= minScore)
+                .map((result) => {
+                  const text = result.entry.text || "";
+                  const lines = text.split(/\r?\n/);
+                  return {
+                    path: syntheticPathForId(result.entry.id, result.entry.scope),
+                    startLine: 1,
+                    endLine: Math.max(1, lines.length),
+                    score: result.score,
+                    snippet: text,
+                    source: "memory" as const,
+                  };
+                });
+            },
+            async readFile(params: { relPath: string; from?: number; lines?: number }) {
+              const relPath = typeof params.relPath === "string" ? params.relPath : "";
+              const base = basename(relPath).replace(/\.md$/i, "");
+              const entry = base ? await store.getById(base, scopeFilter) : null;
+              if (!entry) {
+                throw new Error(`memory entry not found: ${relPath}`);
+              }
+              const allLines = (entry.text || "").split(/\r?\n/);
+              const from = Math.max(1, Math.floor(params.from ?? 1));
+              const lineCount = Math.max(1, Math.floor(params.lines ?? allLines.length));
+              const text = allLines.slice(from - 1, from - 1 + lineCount).join("\n");
+              return {
+                text,
+                path: relPath || syntheticPathForId(entry.id, entry.scope),
+              };
+            },
+            status() {
+              return {
+                backend: "builtin" as const,
+                provider: "memory-lancedb-pro",
+                model: config.embedding.model || "text-embedding-3-small",
+                dbPath: resolvedDbPath,
+                sources: ["memory" as const],
+                workspaceDir: getDefaultWorkspaceDir(),
+                vector: {
+                  enabled: true,
+                  dims: vectorDim,
+                },
+                custom: {
+                  scopeFilter,
+                  purpose: params.purpose || "default",
+                },
+              };
+            },
+            async probeEmbeddingAvailability() {
+              try {
+                await embedder.embedQuery("memory runtime health check");
+                return { ok: true };
+              } catch (err) {
+                return {
+                  ok: false,
+                  error: err instanceof Error ? err.message : String(err),
+                };
+              }
+            },
+            async probeVectorAvailability() {
+              try {
+                await store.stats(scopeFilter);
+                return true;
+              } catch {
+                return false;
+              }
+            },
+            async close() {
+              // no-op: plugin-level store lifecycle is owned by the plugin runtime
+            },
+          },
+        };
+      },
+      resolveMemoryBackendConfig() {
+        return { backend: "builtin" as const };
+      },
+      async closeAllMemorySearchManagers() {
+        // no-op: plugin-level store lifecycle is owned by the plugin runtime
+      },
+    });
+
+    // ========================================================================
     // Register CLI Commands
     // ========================================================================
 


### PR DESCRIPTION
## Summary

Register a memory runtime adapter so `memory-lancedb-pro` is recognized as the active memory backend by OpenClaw 2026.4.1+.

## Problem

After upgrading OpenClaw to `2026.4.1`, the plugin still appeared to load successfully:

- `memory-lancedb-pro@1.1.0-beta.10: plugin registered`
- memory tools remained available

But OpenClaw system-level diagnostics still reported that no active memory plugin/runtime was available, for example:

- `No active memory plugin is registered for the current config.`
- memory status showed as unavailable even though the slot pointed to `memory-lancedb-pro`

This created a half-working state where the plugin looked loaded, but OpenClaw's runtime-facing memory integration could not treat it as an active backend.

## Root cause

OpenClaw `2026.4.1` expects memory plugins to explicitly register a memory runtime via:

- `api.registerMemoryRuntime(...)`

`memory-lancedb-pro` was not doing that yet.

## What this PR changes

This PR adds a minimal runtime adapter that wires the existing plugin internals into OpenClaw's memory runtime contract:

- `getMemorySearchManager(...)`
- `search(...)`
- `readFile(...)`
- `status()`
- `probeEmbeddingAvailability()`
- `probeVectorAvailability()`
- `resolveMemoryBackendConfig()`

The implementation intentionally reuses the plugin's existing store / retriever / embedder / scope resolution logic rather than introducing a second backend path.

## Validation

Validated locally against OpenClaw `2026.4.1` by:

1. loading the patched plugin
2. restarting/reloading the gateway
3. confirming the previous active-memory diagnostic disappeared
4. verifying recall worked again through the memory toolchain
5. verifying write -> recall -> delete roundtrip succeeded
6. running `openclaw doctor --non-interactive` successfully with plugin errors = 0

## Notes

This PR only includes the runtime-registration fix needed for OpenClaw 2026.4.1 compatibility. It intentionally excludes unrelated working-tree changes.
