### PR TITLE
fix: add platform-specific native bindings for lancedb

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,6 @@
   "license": "MIT",
   "dependencies": {
     "@lancedb/lancedb": "^0.26.2",
-    "@lancedb/lancedb-darwin-x64": "^0.26.2",
-    "@lancedb/lancedb-darwin-arm64": "^0.26.2",
-    "@lancedb/lancedb-linux-x64-gnu": "^0.26.2",
-    "@lancedb/lancedb-linux-arm64-gnu": "^0.26.2",
-    "@lancedb/lancedb-win32-x64-msvc": "^0.26.2",
     "@sinclair/typebox": "0.34.48",
     "apache-arrow": "18.1.0",
     "json5": "^2.2.3",
@@ -46,6 +41,13 @@
     "test": "node test/embedder-error-hints.test.mjs && node test/cjk-recursion-regression.test.mjs && node test/migrate-legacy-schema.test.mjs && node --test test/config-session-strategy-migration.test.mjs && node --test test/scope-access-undefined.test.mjs && node --test test/reflection-bypass-hook.test.mjs && node --test test/smart-extractor-scope-filter.test.mjs && node --test test/store-empty-scope-filter.test.mjs && node --test test/recall-text-cleanup.test.mjs && node test/update-consistency-lancedb.test.mjs && node --test test/strip-envelope-metadata.test.mjs && node test/cli-smoke.mjs && node test/functional-e2e.mjs && node test/retriever-rerank-regression.mjs && node test/smart-memory-lifecycle.mjs && node test/smart-extractor-branches.mjs && node test/plugin-manifest-regression.mjs && node --test test/sync-plugin-version.test.mjs && node test/smart-metadata-v2.mjs && node test/vector-search-cosine.test.mjs && node test/context-support-e2e.mjs && node test/temporal-facts.test.mjs && node test/memory-update-supersede.test.mjs && node test/memory-upgrader-diagnostics.test.mjs && node --test test/llm-api-key-client.test.mjs && node --test test/llm-oauth-client.test.mjs && node --test test/cli-oauth-login.test.mjs && node --test test/workflow-fork-guards.test.mjs && node --test test/clawteam-scope.test.mjs && node --test test/cross-process-lock.test.mjs && node --test test/preference-slots.test.mjs",
     "test:openclaw-host": "node test/openclaw-host-functional.mjs",
     "version": "node scripts/sync-plugin-version.mjs openclaw.plugin.json package.json && git add openclaw.plugin.json"
+  },
+  "optionalDependencies": {
+    "@lancedb/lancedb-darwin-x64": "^0.26.2",
+    "@lancedb/lancedb-darwin-arm64": "^0.26.2",
+    "@lancedb/lancedb-linux-x64-gnu": "^0.26.2",
+    "@lancedb/lancedb-linux-arm64-gnu": "^0.26.2",
+    "@lancedb/lancedb-win32-x64-msvc": "^0.26.2"
   },
   "devDependencies": {
     "commander": "^14.0.0",


### PR DESCRIPTION
## Problem

On Intel Mac (darwin-x64), the plugin fails to load native lancedb bindings because `package.json` does not declare any platform-specific binding packages. This causes `openclaw memory-pro stats` and related CLI commands to fail.

Fixes #469

## Changes

Added all major platform-specific native binding packages to `dependencies`:

- `@lancedb/lancedb-darwin-x64` (Intel Mac)
- `@lancedb/lancedb-darwin-arm64` (Apple Silicon Mac)
- `@lancedb/lancedb-linux-x64-gnu` (Linux x64)
- `@lancedb/lancedb-linux-arm64-gnu` (Linux ARM64)
- `@lancedb/lancedb-win32-x64-msvc` (Windows x64)

All versions aligned with `@lancedb/lancedb` at `^0.26.2`.

## Testing

Verified on Intel Mac (macOS Tahoe, x86_64) — `openclaw memory-pro stats` works correctly after installing `@lancedb/lancedb-darwin-x64@^0.27.2` locally.