### PR TITLE
fix: register memory runtime stub to satisfy openclaw doctor check

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2005,6 +2005,11 @@ const memoryLanceDBProPlugin = {
       `  - Use memory_store or auto-capture for recallable memories.\n`
     );
 
+    // Health status for memory runtime stub (reflects actual plugin health)
+    // Updated by runStartupChecks after testing embedder and retriever
+    let embedHealth: { ok: boolean; error?: string } = { ok: false, error: "startup not complete" };
+    let retrievalHealth: boolean = false;
+
     // ========================================================================
     // Stub Memory Runtime (satisfies openclaw doctor memory plugin check)
     // memory-lancedb-pro uses a tool-based architecture, not the built-in memory-core
@@ -2016,9 +2021,14 @@ const memoryLanceDBProPlugin = {
         async getMemorySearchManager(_params: any) {
           return {
             manager: {
-              status: () => ({ backend: "builtin" as const, provider: "memory-lancedb-pro" }),
-              probeEmbeddingAvailability: async () => ({ ok: true }),
-              probeVectorAvailability: async () => true,
+              status: () => ({
+                backend: "builtin" as const,
+                provider: "memory-lancedb-pro",
+                embeddingAvailable: embedHealth.ok,
+                retrievalAvailable: retrievalHealth,
+              }),
+              probeEmbeddingAvailability: async () => ({ ...embedHealth }),
+              probeVectorAvailability: async () => retrievalHealth,
             },
           };
         },
@@ -3712,6 +3722,10 @@ const memoryLanceDBProPlugin = {
                 `memory-lancedb-pro: retrieval test failed: ${retrievalTest.error}`,
               );
             }
+
+            // Update stub health status so openclaw doctor reflects real state
+            embedHealth = { ok: !!embedTest.success, error: embedTest.error };
+            retrievalHealth = !!retrievalTest.success;
           } catch (error) {
             api.logger.warn(
               `memory-lancedb-pro: startup checks failed: ${String(error)}`,


### PR DESCRIPTION
## Summary

Registers a minimal `MemoryPluginRuntime` stub so `openclaw doctor` no longer shows the 'No active memory plugin is registered' warning.

Note: memory-lancedb-pro still uses its tool-based architecture for actual memory operations; this stub only satisfies the registration check.

## Changes

- Added `registerMemoryRuntime()` call with minimal stub implementation in `index.ts`
- Stub implements `getMemorySearchManager()` and `resolveMemoryBackendConfig()` with no-op responses
- Includes guard check `if (typeof api.registerMemoryRuntime === 'function')` for forward compatibility

## Fixes

Fixes #434