### PR TITLE
feat: add resolvedAt + filterByResolved for reflection items (#447)

### DIFF
--- a/src/reflection-item-store.ts
+++ b/src/reflection-item-store.ts
@@ -23,6 +23,12 @@ export interface ReflectionItemMetadata {
   baseWeight: number;
   quality: number;
   sourceReflectionPath?: string;
+  /** Unix timestamp when the item was marked resolved. Undefined = unresolved. */
+  resolvedAt?: number;
+  /** Agent ID that marked this item resolved. */
+  resolvedBy?: string;
+  /** Optional note explaining why the item was resolved. */
+  resolutionNote?: string;
 }
 
 export interface ReflectionItemPayload {

--- a/src/reflection-store.ts
+++ b/src/reflection-store.ts
@@ -255,13 +255,50 @@ export function loadAgentReflectionSlicesFromEntries(params: LoadReflectionSlice
   // Filter out resolved items — passive suppression for #447
   // resolvedAt === undefined means unresolved (default)
   const unresolvedItemRows = itemRows.filter(({ metadata }) => metadata.resolvedAt === undefined);
+  const resolvedItemRows = itemRows.filter(({ metadata }) => metadata.resolvedAt !== undefined);
 
-  // If there were item rows but all are resolved, suppress to prevent legacy
-  // fallback from reviving them.  If there were NO item rows at all, allow
-  // legacy fallback to run (backward compatibility for stores that predate
-  // itemized reflection rows).
   const hasItemRows = itemRows.length > 0;
-  if (hasItemRows && unresolvedItemRows.length === 0) {
+  const hasLegacyRows = legacyRows.length > 0;
+
+  // Collect normalized text of resolved items so we can detect whether legacy
+  // rows are pure duplicates of already-resolved content.
+  const resolvedInvariantTexts = new Set(
+    resolvedItemRows
+      .filter(({ metadata }) => metadata.itemKind === "invariant")
+      .flatMap(({ entry }) => sanitizeInjectableReflectionLines([entry.text]))
+      .map((line) => normalizeReflectionLineForAggregation(line))
+  );
+  const resolvedDerivedTexts = new Set(
+    resolvedItemRows
+      .filter(({ metadata }) => metadata.itemKind === "derived")
+      .flatMap(({ entry }) => sanitizeInjectableReflectionLines([entry.text]))
+      .map((line) => normalizeReflectionLineForAggregation(line))
+  );
+
+  // Check whether legacy rows add any content not already covered by resolved
+  // items.  If every line in every legacy row is a duplicate of a resolved
+  // item, the legacy fallback would revive just-resolved advice — suppress.
+  const legacyHasUniqueInvariant = legacyRows.some(({ metadata }) =>
+    toStringArray(metadata.invariants).some(
+      (line) => !resolvedInvariantTexts.has(normalizeReflectionLineForAggregation(line))
+    )
+  );
+  const legacyHasUniqueDerived = legacyRows.some(({ metadata }) =>
+    toStringArray(metadata.derived).some(
+      (line) => !resolvedDerivedTexts.has(normalizeReflectionLineForAggregation(line))
+    )
+  );
+
+  // Suppress when:
+  // 1) there were item rows, all are resolved, and there are no legacy rows, OR
+  // 2) there were item rows, all are resolved, legacy rows exist BUT all of their
+  //    content duplicates already-resolved items (prevents legacy fallback from
+  //    reviving just-resolved advice — the P1 bug fixed here).
+  const shouldSuppress =
+    hasItemRows &&
+    unresolvedItemRows.length === 0 &&
+    (!hasLegacyRows || (!legacyHasUniqueInvariant && !legacyHasUniqueDerived));
+  if (shouldSuppress) {
     return { invariants: [], derived: [] };
   }
 

--- a/src/reflection-store.ts
+++ b/src/reflection-store.ts
@@ -252,8 +252,12 @@ export function loadAgentReflectionSlicesFromEntries(params: LoadReflectionSlice
   const itemRows = reflectionRows.filter(({ metadata }) => metadata.type === "memory-reflection-item");
   const legacyRows = reflectionRows.filter(({ metadata }) => metadata.type === "memory-reflection");
 
-  const invariantCandidates = buildInvariantCandidates(itemRows, legacyRows);
-  const derivedCandidates = buildDerivedCandidates(itemRows, legacyRows);
+  // Filter out resolved items — passive suppression for #447
+  // resolvedAt === undefined means unresolved (default)
+  const unresolvedItemRows = itemRows.filter(({ metadata }) => metadata.resolvedAt === undefined);
+
+  const invariantCandidates = buildInvariantCandidates(unresolvedItemRows, legacyRows);
+  const derivedCandidates = buildDerivedCandidates(unresolvedItemRows, legacyRows);
 
   const invariants = rankReflectionLines(invariantCandidates, {
     now,

--- a/src/reflection-store.ts
+++ b/src/reflection-store.ts
@@ -256,6 +256,15 @@ export function loadAgentReflectionSlicesFromEntries(params: LoadReflectionSlice
   // resolvedAt === undefined means unresolved (default)
   const unresolvedItemRows = itemRows.filter(({ metadata }) => metadata.resolvedAt === undefined);
 
+  // If there were item rows but all are resolved, suppress to prevent legacy
+  // fallback from reviving them.  If there were NO item rows at all, allow
+  // legacy fallback to run (backward compatibility for stores that predate
+  // itemized reflection rows).
+  const hasItemRows = itemRows.length > 0;
+  if (hasItemRows && unresolvedItemRows.length === 0) {
+    return { invariants: [], derived: [] };
+  }
+
   const invariantCandidates = buildInvariantCandidates(unresolvedItemRows, legacyRows);
   const derivedCandidates = buildDerivedCandidates(unresolvedItemRows, legacyRows);
 

--- a/src/reflection-store.ts
+++ b/src/reflection-store.ts
@@ -302,8 +302,22 @@ export function loadAgentReflectionSlicesFromEntries(params: LoadReflectionSlice
     return { invariants: [], derived: [] };
   }
 
-  const invariantCandidates = buildInvariantCandidates(unresolvedItemRows, legacyRows);
-  const derivedCandidates = buildDerivedCandidates(unresolvedItemRows, legacyRows);
+  // [FIX P2] Per-section legacy filtering: only pass legacy rows that have unique
+  // content for this specific section. Prevents resolved items in section A from being
+  // revived when section B has unique legacy content (cross-section legacy fallback bug).
+  const invariantLegacyRows = legacyRows.filter(({ metadata }) =>
+    toStringArray(metadata.invariants).some(
+      (line) => !resolvedInvariantTexts.has(normalizeReflectionLineForAggregation(line))
+    )
+  );
+  const derivedLegacyRows = legacyRows.filter(({ metadata }) =>
+    toStringArray(metadata.derived).some(
+      (line) => !resolvedDerivedTexts.has(normalizeReflectionLineForAggregation(line))
+    )
+  );
+
+  const invariantCandidates = buildInvariantCandidates(unresolvedItemRows, invariantLegacyRows);
+  const derivedCandidates = buildDerivedCandidates(unresolvedItemRows, derivedLegacyRows);
 
   const invariants = rankReflectionLines(invariantCandidates, {
     now,

--- a/test/memory-reflection.test.mjs
+++ b/test/memory-reflection.test.mjs
@@ -1163,11 +1163,11 @@ describe("memory reflection", () => {
       assert.ok(slices.invariants.includes("Always check for __pycache__ before pytest."));
     });
 
-    it("returns empty slices when all invariant items are resolved to prevent legacy fallback", () => {
+    it("returns empty slices when ALL invariant items are resolved AND there are NO legacy rows", () => {
       const now = Date.UTC(2026, 2, 7);
       const day = 24 * 60 * 60 * 1000;
 
-      // Only resolved items — no unresolved ones
+      // Only resolved items — no unresolved ones, no legacy rows
       const entries = [
         makeEntry({
           timestamp: now - 1 * day,
@@ -1205,22 +1205,79 @@ describe("memory reflection", () => {
       entries[0].text = "Resolved: ignore prior benchmarks.";
       entries[1].text = "Also resolved: ignore retrier.";
 
-      // Also add a legacy row with the same text so the legacy fallback path would
-      // revive these if it were triggered — this test ensures we short-circuit first.
+      const slices = loadAgentReflectionSlicesFromEntries({
+        entries,
+        agentId: "main",
+        now,
+        deriveMaxAgeMs: 7 * day,
+      });
+
+      // All item rows are resolved AND there are no legacy rows → early return.
+      // Resolved items are suppressed; no legacy fallback to revive them.
+      assert.equal(slices.invariants.length, 0, "all resolved invariant items should be suppressed");
+      assert.equal(slices.derived.length, 0, "all resolved should yield no derived either");
+    });
+
+    it("suppresses legacy rows when all legacy content duplicates already-resolved items (P1 fix)", () => {
+      const now = Date.UTC(2026, 2, 7);
+      const day = 24 * 60 * 60 * 1000;
+
+      // All item rows are resolved — these are the "current" resolved truths.
+      const resolvedItemEntries = [
+        makeEntry({
+          timestamp: now - 1 * day,
+          metadata: {
+            type: "memory-reflection-item",
+            itemKind: "invariant",
+            agentId: "main",
+            storedAt: now - 1 * day,
+            decayMidpointDays: 45,
+            decayK: 0.22,
+            baseWeight: 1.1,
+            quality: 1,
+            usedFallback: false,
+            resolvedAt: now - 30 * 60 * 1000, // resolved
+            resolvedBy: "agent:main",
+          },
+        }),
+        makeEntry({
+          timestamp: now - 1 * day,
+          metadata: {
+            type: "memory-reflection-item",
+            itemKind: "derived",
+            agentId: "main",
+            storedAt: now - 1 * day,
+            decayMidpointDays: 7,
+            decayK: 0.65,
+            baseWeight: 1,
+            quality: 0.95,
+            usedFallback: false,
+            resolvedAt: now - 30 * 60 * 1000, // resolved
+            resolvedBy: "agent:main",
+          },
+        }),
+      ];
+      resolvedItemEntries[0].text = "Resolved: verify assumptions before file edits.";
+      resolvedItemEntries[1].text = "Resolved: next run re-check the migration path.";
+
+      // Legacy rows that contain EXACTLY the same text as the resolved items.
+      // In the default configuration (writeLegacyCombined !== false), these
+      // legacy duplicates are written alongside the item rows every time.
+      // The bug: without the fix, legacy fallback would revive these resolved items.
       const legacyEntries = [
         makeEntry({
           timestamp: now - 1 * day,
           metadata: {
-            type: "memory-reflection",  // legacy type — no resolvedAt
+            type: "memory-reflection",
             agentId: "main",
             storedAt: now - 1 * day,
-            invariants: ["Resolved: ignore prior benchmarks.", "Also resolved: ignore retrier."],
-            derived: [],
+            invariants: ["Resolved: verify assumptions before file edits."],
+            derived: ["Resolved: next run re-check the migration path."],
           },
         }),
       ];
 
-      const allEntries = [...entries, ...legacyEntries];
+      const allEntries = [...resolvedItemEntries, ...legacyEntries];
       const slices = loadAgentReflectionSlicesFromEntries({
         entries: allEntries,
         agentId: "main",
@@ -1228,10 +1285,65 @@ describe("memory reflection", () => {
         deriveMaxAgeMs: 7 * day,
       });
 
-      // All item rows are resolved → should return empty slices.
-      // Must NOT fall back to legacy rows (which would revive the resolved items).
-      assert.equal(slices.invariants.length, 0, "all resolved invariant items should be suppressed");
-      assert.equal(slices.derived.length, 0, "all resolved should yield no derived either");
+      // Both invariants and derived must be empty: legacy rows contain only
+      // duplicates of already-resolved items and must not revive them.
+      assert.equal(slices.invariants.length, 0,
+        "legacy invariant duplicate of resolved item must be suppressed");
+      assert.equal(slices.derived.length, 0,
+        "legacy derived duplicate of resolved item must be suppressed");
+    });
+
+    it("does NOT suppress legacy rows when resolved items exist alongside unrelated legacy rows", () => {
+      const now = Date.UTC(2026, 2, 7);
+      const day = 24 * 60 * 60 * 1000;
+
+      // All item rows are resolved (no unresolved ones)
+      const resolvedItemEntries = [
+        makeEntry({
+          timestamp: now - 1 * day,
+          metadata: {
+            type: "memory-reflection-item",
+            itemKind: "invariant",
+            agentId: "main",
+            storedAt: now - 1 * day,
+            decayMidpointDays: 45,
+            decayK: 0.22,
+            baseWeight: 1.1,
+            quality: 1,
+            usedFallback: false,
+            resolvedAt: now - 10 * 60 * 1000, // resolved — would trigger early return
+            resolvedBy: "agent:main",
+          },
+        }),
+      ];
+      resolvedItemEntries[0].text = "Resolved: this invariant should not appear.";
+
+      // Unrelated legacy row — should NOT be suppressed by the early return
+      const legacyEntries = [
+        makeEntry({
+          timestamp: now - 1 * day,
+          metadata: {
+            type: "memory-reflection",  // legacy type
+            agentId: "main",
+            storedAt: now - 1 * day,
+            invariants: ["Legacy: always run linter before commit."],
+            derived: [],
+          },
+        }),
+      ];
+
+      const allEntries = [...resolvedItemEntries, ...legacyEntries];
+      const slices = loadAgentReflectionSlicesFromEntries({
+        entries: allEntries,
+        agentId: "main",
+        now,
+        deriveMaxAgeMs: 7 * day,
+      });
+
+      // Legacy row should be returned even though item rows are all resolved.
+      // The resolved item is suppressed; the unrelated legacy advice falls through.
+      assert.ok(slices.invariants.includes("Legacy: always run linter before commit."),
+        "legacy invariant should be returned when legacy rows are present alongside resolved items");
     });
   });
 

--- a/test/memory-reflection.test.mjs
+++ b/test/memory-reflection.test.mjs
@@ -1293,6 +1293,130 @@ describe("memory reflection", () => {
         "legacy derived duplicate of resolved item must be suppressed");
     });
 
+    // ---- P2 cross-section suppression fix tests ----
+
+    it("invariants resolved + derived has unique legacy: only derived passes", () => {
+      // Bug scenario: Invariants all resolved, but derived has unique legacy content.
+      // shouldSuppress=false (because derived has unique content).
+      // buildInvariantCandidates must NOT revive resolved invariants via legacy fallback.
+      const now = Date.UTC(2026, 3, 15);
+      const day = 24 * 60 * 60 * 1000;
+
+      // All invariant items are resolved
+      const resolvedInvariantEntry = makeEntry({
+        timestamp: now - 1 * day,
+        metadata: {
+          type: "memory-reflection-item",
+          itemKind: "invariant",
+          agentId: "main",
+          storedAt: now - 1 * day,
+          decayMidpointDays: 45,
+          decayK: 0.22,
+          baseWeight: 1.1,
+          quality: 1,
+          usedFallback: false,
+          resolvedAt: now - 10 * 60 * 1000,
+          resolvedBy: "agent:main",
+        },
+      });
+      resolvedInvariantEntry.text = "Resolved invariant that must stay suppressed.";
+
+      // No unresolved derived items at all
+      const itemRows = [resolvedInvariantEntry];
+
+      // Legacy row: invariant duplicate of resolved + unique derived content
+      const legacyEntries = [
+        makeEntry({
+          timestamp: now - 1 * day,
+          metadata: {
+            type: "memory-reflection",
+            agentId: "main",
+            storedAt: now - 1 * day,
+            invariants: ["Resolved invariant that must stay suppressed."],
+            derived: ["Unique derived that should survive legacy fallback."],
+          },
+        }),
+      ];
+
+      const allEntries = [...itemRows, ...legacyEntries];
+      const slices = loadAgentReflectionSlicesFromEntries({
+        entries: allEntries,
+        agentId: "main",
+        now,
+        deriveMaxAgeMs: 7 * day,
+      });
+
+      // Invariants must be empty: the only invariant is a resolved duplicate
+      assert.equal(slices.invariants.length, 0,
+        "resolved invariant must not be revived via legacy fallback");
+      // Derived must contain the unique legacy derived content
+      assert(slices.derived.length > 0,
+        "unique legacy derived should survive");
+      assert(slices.derived.some((l) => l.includes("Unique derived")),
+        "unique legacy derived text must appear in derived slice");
+    });
+
+    it("derived resolved + invariants has unique legacy: only invariants passes", () => {
+      // Symmetric case: Derived all resolved, but invariants have unique legacy content.
+      // shouldSuppress=false (because invariants has unique content).
+      // buildDerivedCandidates must NOT revive resolved derived via legacy fallback.
+      const now = Date.UTC(2026, 3, 15);
+      const day = 24 * 60 * 60 * 1000;
+
+      // All derived items are resolved
+      const resolvedDerivedEntry = makeEntry({
+        timestamp: now - 1 * day,
+        metadata: {
+          type: "memory-reflection-item",
+          itemKind: "derived",
+          agentId: "main",
+          storedAt: now - 1 * day,
+          decayMidpointDays: 7,
+          decayK: 0.65,
+          baseWeight: 1,
+          quality: 0.95,
+          usedFallback: false,
+          resolvedAt: now - 10 * 60 * 1000,
+          resolvedBy: "agent:main",
+        },
+      });
+      resolvedDerivedEntry.text = "Resolved derived that must stay suppressed.";
+
+      // No unresolved invariant items at all
+      const itemRows = [resolvedDerivedEntry];
+
+      // Legacy row: derived duplicate of resolved + unique invariant content
+      const legacyEntries = [
+        makeEntry({
+          timestamp: now - 1 * day,
+          metadata: {
+            type: "memory-reflection",
+            agentId: "main",
+            storedAt: now - 1 * day,
+            invariants: ["Unique invariant that should survive legacy fallback."],
+            derived: ["Resolved derived that must stay suppressed."],
+          },
+        }),
+      ];
+
+      const allEntries = [...itemRows, ...legacyEntries];
+      const slices = loadAgentReflectionSlicesFromEntries({
+        entries: allEntries,
+        agentId: "main",
+        now,
+        deriveMaxAgeMs: 7 * day,
+      });
+
+      // Invariants must contain the unique legacy invariant content
+      assert(slices.invariants.length > 0,
+        "unique legacy invariant should survive");
+      assert(slices.invariants.some((l) => l.includes("Unique invariant")),
+        "unique legacy invariant text must appear in invariants slice");
+      // Derived must be empty: the only derived is a resolved duplicate
+      assert.equal(slices.derived.length, 0,
+        "resolved derived must not be revived via legacy fallback");
+    });
+
     it("does NOT suppress legacy rows when resolved items exist alongside unrelated legacy rows", () => {
       const now = Date.UTC(2026, 2, 7);
       const day = 24 * 60 * 60 * 1000;

--- a/test/memory-reflection.test.mjs
+++ b/test/memory-reflection.test.mjs
@@ -1023,6 +1023,145 @@ describe("memory reflection", () => {
       assert.ok(slices.derived.includes("Ignore prior flaky results before comparing the new retriever output."));
       assert.ok(slices.derived.includes("This run override previous cached screenshots with fresh captures."));
     });
+
+    it("suppresses resolved invariant items from recall output", () => {
+      const now = Date.UTC(2026, 2, 7);
+      const day = 24 * 60 * 60 * 1000;
+
+      const entries = [
+        makeEntry({
+          timestamp: now - 1 * day,
+          metadata: {
+            type: "memory-reflection-item",
+            itemKind: "invariant",
+            agentId: "main",
+            storedAt: now - 1 * day,
+            decayMidpointDays: 45,
+            decayK: 0.22,
+            baseWeight: 1.1,
+            quality: 1,
+            usedFallback: false,
+            resolvedAt: now - 1 * 60 * 60 * 1000, // resolved 1h ago
+            resolvedBy: "agent:main",
+            resolutionNote: "Issue resolved, no longer needed",
+          },
+        }),
+        makeEntry({
+          timestamp: now - 2 * day,
+          metadata: {
+            type: "memory-reflection-item",
+            itemKind: "invariant",
+            agentId: "main",
+            storedAt: now - 2 * day,
+            decayMidpointDays: 45,
+            decayK: 0.22,
+            baseWeight: 1.1,
+            quality: 1,
+            usedFallback: false,
+            // NOT resolved — should appear
+          },
+        }),
+      ];
+      entries[0].text = "Resolved: ignore prior flaky benchmarks.";
+      entries[1].text = "Unresolved: always validate against fixtures.";
+
+      const slices = loadAgentReflectionSlicesFromEntries({
+        entries,
+        agentId: "main",
+        now,
+        deriveMaxAgeMs: 7 * day,
+      });
+
+      assert.equal(slices.invariants.length, 1);
+      assert.ok(slices.invariants.includes("Unresolved: always validate against fixtures."));
+      assert.ok(!slices.invariants.some((i) => i.includes("Resolved: ignore prior flaky benchmarks.")));
+    });
+
+    it("suppresses resolved derived items from recall output", () => {
+      const now = Date.UTC(2026, 2, 7);
+      const day = 24 * 60 * 60 * 1000;
+
+      const entries = [
+        makeEntry({
+          timestamp: now - 1 * day,
+          metadata: {
+            type: "memory-reflection-item",
+            itemKind: "derived",
+            agentId: "main",
+            storedAt: now - 1 * day,
+            decayMidpointDays: 7,
+            decayK: 0.65,
+            baseWeight: 1,
+            quality: 0.95,
+            usedFallback: false,
+            resolvedAt: now - 30 * 60 * 1000, // resolved 30m ago
+            resolvedBy: "agent:main",
+          },
+        }),
+        makeEntry({
+          timestamp: now - 2 * day,
+          metadata: {
+            type: "memory-reflection-item",
+            itemKind: "derived",
+            agentId: "main",
+            storedAt: now - 2 * day,
+            decayMidpointDays: 7,
+            decayK: 0.65,
+            baseWeight: 1,
+            quality: 0.95,
+            usedFallback: false,
+            // NOT resolved — should appear
+          },
+        }),
+      ];
+      entries[0].text = "Resolved derived: next run re-check retrier.";
+      entries[1].text = "Unresolved derived: next run clear cache.";
+
+      const slices = loadAgentReflectionSlicesFromEntries({
+        entries,
+        agentId: "main",
+        now,
+        deriveMaxAgeMs: 7 * day,
+      });
+
+      assert.equal(slices.derived.length, 1);
+      assert.ok(slices.derived.includes("Unresolved derived: next run clear cache."));
+      assert.ok(!slices.derived.some((d) => d.includes("Resolved derived: next run re-check retrier.")));
+    });
+
+    it("passes unresolved items through unchanged when no resolvedAt is set", () => {
+      const now = Date.UTC(2026, 2, 7);
+      const day = 24 * 60 * 60 * 1000;
+
+      const entries = [
+        makeEntry({
+          timestamp: now - 1 * day,
+          metadata: {
+            type: "memory-reflection-item",
+            itemKind: "invariant",
+            agentId: "main",
+            storedAt: now - 1 * day,
+            decayMidpointDays: 45,
+            decayK: 0.22,
+            baseWeight: 1.1,
+            quality: 1,
+            usedFallback: false,
+            // resolvedAt absent — unresolved by default
+          },
+        }),
+      ];
+      entries[0].text = "Always check for __pycache__ before pytest.";
+
+      const slices = loadAgentReflectionSlicesFromEntries({
+        entries,
+        agentId: "main",
+        now,
+        deriveMaxAgeMs: 7 * day,
+      });
+
+      assert.equal(slices.invariants.length, 1);
+      assert.ok(slices.invariants.includes("Always check for __pycache__ before pytest."));
+    });
   });
 
   describe("mapped reflection metadata and ranking", () => {

--- a/test/memory-reflection.test.mjs
+++ b/test/memory-reflection.test.mjs
@@ -1162,6 +1162,77 @@ describe("memory reflection", () => {
       assert.equal(slices.invariants.length, 1);
       assert.ok(slices.invariants.includes("Always check for __pycache__ before pytest."));
     });
+
+    it("returns empty slices when all invariant items are resolved to prevent legacy fallback", () => {
+      const now = Date.UTC(2026, 2, 7);
+      const day = 24 * 60 * 60 * 1000;
+
+      // Only resolved items — no unresolved ones
+      const entries = [
+        makeEntry({
+          timestamp: now - 1 * day,
+          metadata: {
+            type: "memory-reflection-item",
+            itemKind: "invariant",
+            agentId: "main",
+            storedAt: now - 1 * day,
+            decayMidpointDays: 45,
+            decayK: 0.22,
+            baseWeight: 1.1,
+            quality: 1,
+            usedFallback: false,
+            resolvedAt: now - 10 * 60 * 1000, // resolved
+            resolvedBy: "agent:main",
+            resolutionNote: "Problem solved",
+          },
+        }),
+        makeEntry({
+          timestamp: now - 2 * day,
+          metadata: {
+            type: "memory-reflection-item",
+            itemKind: "invariant",
+            agentId: "main",
+            storedAt: now - 2 * day,
+            decayMidpointDays: 45,
+            decayK: 0.22,
+            baseWeight: 1.1,
+            quality: 1,
+            usedFallback: false,
+            resolvedAt: now - 5 * 60 * 1000, // resolved
+          },
+        }),
+      ];
+      entries[0].text = "Resolved: ignore prior benchmarks.";
+      entries[1].text = "Also resolved: ignore retrier.";
+
+      // Also add a legacy row with the same text so the legacy fallback path would
+      // revive these if it were triggered — this test ensures we short-circuit first.
+      const legacyEntries = [
+        makeEntry({
+          timestamp: now - 1 * day,
+          metadata: {
+            type: "memory-reflection",  // legacy type — no resolvedAt
+            agentId: "main",
+            storedAt: now - 1 * day,
+            invariants: ["Resolved: ignore prior benchmarks.", "Also resolved: ignore retrier."],
+            derived: [],
+          },
+        }),
+      ];
+
+      const allEntries = [...entries, ...legacyEntries];
+      const slices = loadAgentReflectionSlicesFromEntries({
+        entries: allEntries,
+        agentId: "main",
+        now,
+        deriveMaxAgeMs: 7 * day,
+      });
+
+      // All item rows are resolved → should return empty slices.
+      // Must NOT fall back to legacy rows (which would revive the resolved items).
+      assert.equal(slices.invariants.length, 0, "all resolved invariant items should be suppressed");
+      assert.equal(slices.derived.length, 0, "all resolved should yield no derived either");
+    });
   });
 
   describe("mapped reflection metadata and ranking", () => {


### PR DESCRIPTION
## 狀態更新 (2026-04-13)

修復已搬到新 PR：**https://github.com/CortexReach/memory-lancedb-pro/pull/595**

這個 PR 現在關閉，由 PR #595 繼續。