### PR TITLE
fix: stop session summaries polluting LanceDB tools

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -308,13 +308,6 @@ function resolveHookAgentId(
     : parseAgentIdFromSessionKey(sessionKey)) || "main";
 }
 
-function resolveSourceFromSessionKey(sessionKey: string | undefined): string {
-  const trimmed = sessionKey?.trim() ?? "";
-  const match = /^agent:[^:]+:([^:]+)/.exec(trimmed);
-  const source = match?.[1]?.trim();
-  return source || "unknown";
-}
-
 function summarizeAgentEndMessages(messages: unknown[]): string {
   const roleCounts = new Map<string, number>();
   let textBlocks = 0;
@@ -3578,110 +3571,16 @@ const memoryLanceDBProPlugin = {
     }
 
     if (config.sessionStrategy === "systemSessionMemory") {
-      const sessionMessageCount = config.sessionMemory?.messageCount ?? 15;
-
-      const storeSystemSessionSummary = async (params: {
-        agentId: string;
-        defaultScope: string;
-        sessionKey: string;
-        sessionId: string;
-        source: string;
-        sessionContent: string;
-        timestampMs?: number;
-      }) => {
-        const now = new Date(params.timestampMs ?? Date.now());
-        const dateStr = now.toISOString().split("T")[0];
-        const timeStr = now.toISOString().split("T")[1].split(".")[0];
-        const memoryText = [
-          `Session: ${dateStr} ${timeStr} UTC`,
-          `Session Key: ${params.sessionKey}`,
-          `Session ID: ${params.sessionId}`,
-          `Source: ${params.source}`,
-          "",
-          "Conversation Summary:",
-          params.sessionContent,
-        ].join("\n");
-
-        const vector = await embedder.embedPassage(memoryText);
-        await store.store({
-          text: memoryText,
-          vector,
-          category: "fact",
-          scope: params.defaultScope,
-          importance: 0.5,
-          metadata: stringifySmartMetadata(
-            buildSmartMetadata(
-              {
-                text: `Session summary for ${dateStr}`,
-                category: "fact",
-                importance: 0.5,
-                timestamp: Date.now(),
-              },
-              {
-                l0_abstract: `Session summary for ${dateStr}`,
-                l1_overview: `- Session summary saved for ${params.sessionId}`,
-                l2_content: memoryText,
-                memory_category: "patterns",
-                tier: "peripheral",
-                confidence: 0.5,
-                type: "session-summary",
-                sessionKey: params.sessionKey,
-                sessionId: params.sessionId,
-                date: dateStr,
-                agentId: params.agentId,
-                scope: params.defaultScope,
-              },
-            ),
-          ),
-        });
-
-        api.logger.info(
-          `session-memory: stored session summary for ${params.sessionId} (agent: ${params.agentId}, scope: ${params.defaultScope})`
-        );
-      };
-
-      api.on("before_reset", async (event, ctx) => {
+      api.on("before_reset", async (event) => {
         if (event.reason !== "new") return;
-
-        try {
-          const sessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : "";
-          const agentId = resolveHookAgentId(
-            typeof ctx.agentId === "string" ? ctx.agentId : undefined,
-            sessionKey,
-          );
-          const defaultScope = isSystemBypassId(agentId)
-            ? config.scopes?.default ?? "global"
-            : scopeManager.getDefaultScope(agentId);
-          const currentSessionId =
-            typeof ctx.sessionId === "string" && ctx.sessionId.trim().length > 0
-              ? ctx.sessionId
-              : "unknown";
-          const source = resolveSourceFromSessionKey(sessionKey);
-          const sessionContent =
-            summarizeRecentConversationMessages(event.messages ?? [], sessionMessageCount) ??
-            (typeof event.sessionFile === "string"
-              ? await readSessionConversationWithResetFallback(event.sessionFile, sessionMessageCount)
-              : null);
-
-          if (!sessionContent) {
-            api.logger.debug("session-memory: no session content found, skipping");
-            return;
-          }
-
-          await storeSystemSessionSummary({
-            agentId,
-            defaultScope,
-            sessionKey,
-            sessionId: currentSessionId,
-            source,
-            sessionContent,
-          });
-        } catch (err) {
-          api.logger.warn(`session-memory: failed to save: ${String(err)}`);
-        }
+        api.logger.debug(
+          "session-memory: skipped LanceDB session-summary write; relying on host session memory instead",
+        );
       });
 
-      (isCliMode() ? api.logger.debug : api.logger.info)("session-memory: typed before_reset hook registered for /new session summaries");
+      (isCliMode() ? api.logger.debug : api.logger.info)(
+        "session-memory: compatibility before_reset hook registered; LanceDB session-summary writes disabled",
+      );
     }
     if (config.sessionStrategy === "none") {
       (isCliMode() ? api.logger.debug : api.logger.info)("session-strategy: using none (plugin memory-reflection hooks disabled)");

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -9,7 +9,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { MemoryRetriever, RetrievalResult } from "./retriever.js";
-import type { MemoryStore } from "./store.js";
+import type { MemoryEntry, MemoryStore } from "./store.js";
 import { isNoise } from "./noise-filter.js";
 import { isSystemBypassId, resolveScopeFilter, parseAgentIdFromSessionKey, type MemoryScopeManager } from "./scopes.js";
 import type { Embedder } from "./embedder.js";
@@ -100,6 +100,38 @@ function deriveManualMemoryLayer(category: string): "durable" | "working" {
     return "durable";
   }
   return "working";
+}
+
+function isSessionSummaryEntry(entry: MemoryEntry): boolean {
+  return parseSmartMetadata(entry.metadata, entry).type === "session-summary";
+}
+
+function filterSessionSummaryResults(results: RetrievalResult[]): RetrievalResult[] {
+  return results.filter((result) => !isSessionSummaryEntry(result.entry));
+}
+
+async function listVisibleEntries(
+  store: MemoryStore,
+  scopeFilter: string[] | undefined,
+  category: string | undefined,
+  limit: number,
+  offset: number,
+): Promise<MemoryEntry[]> {
+  const targetCount = offset + limit;
+  const visibleEntries: MemoryEntry[] = [];
+  let rawOffset = 0;
+  const batchSize = Math.max(50, Math.min(200, targetCount || 50));
+
+  // Hidden session-summary rows should not consume user-facing pagination.
+  while (visibleEntries.length < targetCount) {
+    const batch = await store.list(scopeFilter, category, batchSize, rawOffset);
+    if (batch.length === 0) break;
+    visibleEntries.push(...batch.filter((entry) => !isSessionSummaryEntry(entry)));
+    rawOffset += batch.length;
+    if (batch.length < batchSize) break;
+  }
+
+  return visibleEntries.slice(offset, targetCount);
 }
 
 function sanitizeMemoryForSerialization(results: RetrievalResult[]) {
@@ -567,13 +599,19 @@ export function registerMemoryRecallTool(
             }
           }
 
-          const results = filterUserMdExclusiveRecallResults(await retrieveWithRetry(runtimeContext.retriever, {
-            query,
-            limit: safeLimit,
-            scopeFilter,
-            category,
-            source: "manual",
-          }), runtimeContext.workspaceBoundary);
+          const requestedLimit = Math.min(
+            includeFullText ? 40 : 24,
+            Math.max(safeLimit * 4, safeLimit + 8),
+          );
+          const results = filterSessionSummaryResults(
+            filterUserMdExclusiveRecallResults(await retrieveWithRetry(runtimeContext.retriever, {
+              query,
+              limit: requestedLimit,
+              scopeFilter,
+              category,
+              source: "manual",
+            }), runtimeContext.workspaceBoundary),
+          ).slice(0, safeLimit);
 
           if (results.length === 0) {
             return {
@@ -1699,7 +1737,8 @@ export function registerMemoryListTool(
             }
           }
 
-          const entries = await context.store.list(
+          const entries = await listVisibleEntries(
+            context.store,
             scopeFilter,
             category,
             safeLimit,

--- a/test/recall-text-cleanup.test.mjs
+++ b/test/recall-text-cleanup.test.mjs
@@ -25,7 +25,11 @@ const origCreateEmbedder = embedderModuleForMock.createEmbedder;
 
 const pluginModule = jiti("../index.ts");
 const memoryLanceDBProPlugin = pluginModule.default || pluginModule;
-const { registerMemoryRecallTool, registerMemoryStoreTool } = jiti("../src/tools.ts");
+const {
+  registerMemoryListTool,
+  registerMemoryRecallTool,
+  registerMemoryStoreTool,
+} = jiti("../src/tools.ts");
 const { MemoryRetriever } = jiti("../src/retriever.js");
 const { buildSmartMetadata, stringifySmartMetadata } = jiti("../src/smart-metadata.ts");
 
@@ -107,6 +111,50 @@ function makeResults() {
       },
     },
   ];
+}
+
+function makeSessionSummaryEntry({
+  id = "ss1",
+  text = "Session: 2026-04-03 12:00:00 UTC\nConversation Summary:\nuser: discussed OAuth endpoint",
+  scope = "global",
+  timestamp = Date.now(),
+} = {}) {
+  return {
+    id,
+    text,
+    category: "fact",
+    scope,
+    importance: 0.5,
+    timestamp,
+    metadata: stringifySmartMetadata(
+      buildSmartMetadata(
+        { text: "Session summary for 2026-04-03", category: "fact", importance: 0.5, timestamp },
+        {
+          l0_abstract: "Session summary for 2026-04-03",
+          l1_overview: "- Session summary saved for session-42",
+          l2_content: text,
+          memory_category: "patterns",
+          tier: "peripheral",
+          confidence: 0.5,
+          type: "session-summary",
+          sessionKey: "agent:main:telegram:group:-100123:topic:42",
+          sessionId: "session-42",
+          scope,
+        },
+      ),
+    ),
+  };
+}
+
+function makeSessionSummaryResult(overrides = {}) {
+  return {
+    entry: makeSessionSummaryEntry(overrides.entry),
+    score: 0.99,
+    sources: {
+      vector: { score: 0.99, rank: 1 },
+    },
+    ...overrides,
+  };
 }
 
 function makeExpandedResults() {
@@ -436,6 +484,28 @@ describe("recall text cleanup", () => {
     assert.doesNotMatch(output.prependContext, /\d+%/);
   });
 
+  it("filters session-summary rows from memory_recall output and patch updates", async () => {
+    const patchedIds = [];
+    const tool = createTool(registerMemoryRecallTool, {
+      ...makeRecallContext([makeSessionSummaryResult(), ...makeResults()]),
+      store: {
+        patchMetadata: async (id) => {
+          patchedIds.push(id);
+          return null;
+        },
+      },
+    });
+    const res = await tool.execute(null, { query: "recent session summary leak", limit: 3 });
+
+    assert.deepEqual(extractRenderedMemoryRecallLines(res.content[0].text), [
+      "1. [m1] [fact:global] remember this",
+      "2. [m2] [preference:global] prefer concise diffs",
+    ]);
+    assert.equal(res.details.memories.length, 2);
+    assert.deepEqual(patchedIds, ["m1", "m2"]);
+    assert.doesNotMatch(res.content[0].text, /Session summary for 2026-04-03/);
+  });
+
   it("defaults memory_recall to concise output (limit=3, preview text)", async () => {
     const tool = createTool(registerMemoryRecallTool, makeRecallContext(makeManyResults(7)));
     const res = await tool.execute(null, { query: "many memories" });
@@ -724,6 +794,55 @@ describe("recall text cleanup", () => {
     assert.doesNotMatch(res.content[0].text, /称呼偏好：宙斯/);
   });
 
+  it("filters session-summary rows from memory_list without consuming visible offsets", async () => {
+    const listedEntries = [
+      makeSessionSummaryEntry({ id: "ss-top", timestamp: 5_000 }),
+      {
+        id: "n1",
+        text: "visible memory 1",
+        category: "fact",
+        scope: "global",
+        importance: 0.7,
+        timestamp: 4_000,
+        metadata: "{}",
+      },
+      makeSessionSummaryEntry({ id: "ss-middle", timestamp: 3_000 }),
+      {
+        id: "n2",
+        text: "visible memory 2",
+        category: "fact",
+        scope: "global",
+        importance: 0.7,
+        timestamp: 2_000,
+        metadata: "{}",
+      },
+      {
+        id: "n3",
+        text: "visible memory 3",
+        category: "fact",
+        scope: "global",
+        importance: 0.7,
+        timestamp: 1_000,
+        metadata: "{}",
+      },
+    ];
+    const tool = createTool(registerMemoryListTool, {
+      ...makeRecallContext(),
+      store: {
+        async list(_scopeFilter, _category, limit = 20, offset = 0) {
+          return listedEntries.slice(offset, offset + limit);
+        },
+      },
+    });
+    const res = await tool.execute(null, { limit: 2, offset: 1 });
+    const lines = extractRenderedMemoryRecallLines(res.content[0].text);
+
+    assert.equal(lines.length, 2);
+    assert.match(lines[0], /\[n2\].*visible memory 2/);
+    assert.match(lines[1], /\[n3\].*visible memory 3/);
+    assert.doesNotMatch(res.content[0].text, /Session: 2026-04-03 12:00:00 UTC/);
+  });
+
   it("skips USER.md-exclusive facts in memory_store", async () => {
     const tool = createTool(registerMemoryStoreTool, {
       ...makeRecallContext(),
@@ -925,4 +1044,3 @@ describe("recall text cleanup", () => {
     assert.match(res.content[0].text, /称呼偏好：宙斯/);
   });
 });
-

--- a/test/session-summary-before-reset.test.mjs
+++ b/test/session-summary-before-reset.test.mjs
@@ -97,7 +97,7 @@ describe("systemSessionMemory before_reset", () => {
     rmSync(workDir, { recursive: true, force: true });
   });
 
-  it("stores a session-summary row for /new using before_reset messages", async () => {
+  it("does not store a session-summary row for /new using before_reset messages", async () => {
     const dbPath = path.join(workDir, "db");
     const api = createApiHarness({ dbPath, embeddingBaseURL });
 
@@ -125,17 +125,7 @@ describe("systemSessionMemory before_reset", () => {
 
     const store = new MemoryStore({ dbPath, vectorDim: EMBEDDING_DIMENSIONS });
     const entries = await store.list(undefined, undefined, 10, 0);
-    assert.equal(entries.length, 1);
-
-    const [entry] = entries;
-    const metadata = JSON.parse(entry.metadata || "{}");
-    assert.equal(metadata.type, "session-summary");
-    assert.equal(metadata.sessionId, "session-42");
-    assert.equal(metadata.sessionKey, "agent:main:telegram:group:-100123:topic:42");
-    assert.match(entry.text, /Source: telegram/);
-    assert.match(entry.text, /Conversation Summary:/);
-    assert.match(entry.text, /user: Need to fix the OAuth endpoint\./);
-    assert.match(entry.text, /assistant: Patched the endpoint and verified the login flow\./);
+    assert.equal(entries.length, 0);
   });
 
   it("skips writes for /reset", async () => {


### PR DESCRIPTION
## Summary
- stop `systemSessionMemory` from writing `session-summary` rows into the main LanceDB store
- filter legacy `session-summary` rows from `memory_recall` and `memory_list`
- add regression coverage for `/new` handling and user-facing tool filtering

## Testing
- `node --test test/session-summary-before-reset.test.mjs`
- `node --test test/recall-text-cleanup.test.mjs`
- `node test/plugin-manifest-regression.mjs`

Fixes #485.
