### PR TITLE
fix: guard rerank env var resolution with rerankEnabled check

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3971,16 +3971,21 @@ export function parsePluginConfig(value: unknown): PluginConfig {
       typeof cfg.retrieval === "object" && cfg.retrieval !== null
         ? (() => {
           const retrieval = { ...(cfg.retrieval as Record<string, unknown>) } as Record<string, unknown>;
-          if (typeof retrieval.rerankApiKey === "string") {
+          // Bug 6 fix: only resolve env vars for rerank fields when reranking is
+          // actually enabled AND the field contains a ${...} placeholder.
+          // This prevents startup failures when reranking is disabled and rerankApiKey
+          // is left as an unresolved placeholder.
+          const rerankEnabled = retrieval.rerank !== "none";
+          if (rerankEnabled && typeof retrieval.rerankApiKey === "string" && retrieval.rerankApiKey.includes("${")) {
             retrieval.rerankApiKey = resolveEnvVars(retrieval.rerankApiKey);
           }
-          if (typeof retrieval.rerankEndpoint === "string") {
+          if (rerankEnabled && typeof retrieval.rerankEndpoint === "string" && retrieval.rerankEndpoint.includes("${")) {
             retrieval.rerankEndpoint = resolveEnvVars(retrieval.rerankEndpoint);
           }
-          if (typeof retrieval.rerankModel === "string") {
+          if (rerankEnabled && typeof retrieval.rerankModel === "string" && retrieval.rerankModel.includes("${")) {
             retrieval.rerankModel = resolveEnvVars(retrieval.rerankModel);
           }
-          if (typeof retrieval.rerankProvider === "string") {
+          if (rerankEnabled && typeof retrieval.rerankProvider === "string" && retrieval.rerankProvider.includes("${")) {
             retrieval.rerankProvider = resolveEnvVars(retrieval.rerankProvider);
           }
           return retrieval as any;


### PR DESCRIPTION
## Summary

Guard rerank config env var resolution with a `rerankEnabled` check, preventing startup failures when reranking is disabled and `rerankApiKey` is left as an unresolved `${...}` placeholder string.

## What was fixed

**Problem**: In `parsePluginConfig()`, the env var resolution for rerank fields (`rerankApiKey`, `rerankEndpoint`, `rerankModel`, `rerankProvider`) ran unconditionally whenever the field was a string. If reranking was disabled (`rerank: none`) and the key was set to a placeholder like `${RERANK_API_KEY}`, `resolveEnvVars()` would fail at startup because there was no env var to resolve.

**Fix**: Added `const rerankEnabled = retrieval.rerank !== 'none'` and gate each env resolution with `rerankEnabled &&`. Also added `includes('${')` guard so only fields that actually contain a placeholder are processed.

## Files changed
- `index.ts`: +9/-4 lines in `parsePluginConfig()`

## Testing
- No behavior change when reranking is enabled and keys are valid
- No startup failure when reranking is disabled with unresolved placeholders

## Related
- Split out from PR #493 (Proposal A v3) per AliceLJY review feedback
- Addresses the scope-drift issue: this fix was bundled with 4 other unrelated changes
