### PR TITLE
fix: gate boilerplate skip with sawWrapperPrefix flag (#499 follow-up)

### DIFF
--- a/src/auto-capture-cleanup.ts
+++ b/src/auto-capture-cleanup.ts
@@ -96,6 +96,7 @@ function stripLeadingRuntimeWrappers(text: string): string {
   const lines = trimmed.split("\n");
   const cleanedLines: string[] = [];
   let strippingLeadIn = true;
+  let sawWrapperPrefix = false;
 
   for (const line of lines) {
     const current = line.trim();
@@ -109,8 +110,22 @@ function stripLeadingRuntimeWrappers(text: string): string {
       if (cleaned) {
         cleanedLines.push(cleaned);
         strippingLeadIn = false;
+        sawWrapperPrefix = true;
       }
       continue;
+    }
+
+    // Bug fix: also strip known boilerplate continuation lines (e.g.
+    // "Results auto-announce to your requester.", "Do not use any memory tools.")
+    // that appear right after the wrapper prefix. These lines do NOT match the
+    // wrapper prefix regex but are part of the wrapper boilerplate.
+    // Guard with sawWrapperPrefix so we don't skip boilerplate-like user content
+    // that appears BEFORE any wrapper prefix is seen.
+    if (strippingLeadIn && sawWrapperPrefix) {
+      AUTO_CAPTURE_RUNTIME_WRAPPER_BOILERPLATE_RE.lastIndex = 0;
+      if (AUTO_CAPTURE_RUNTIME_WRAPPER_BOILERPLATE_RE.test(current)) {
+        continue;
+      }
     }
 
     strippingLeadIn = false;


### PR DESCRIPTION
**Review Claw 🦞**

AliceLJY 的邏輯錯誤分析有效。

此 PR 的核心功能（攔截 subagent wrapper boilerplate continuation lines）已被 **#510** 取代：
- #510 的 stripEnvelopeMetadata() 用 .* 整行剝光策略，邏輯更簡潔且 CI 全綠
- uto-capture-cleanup.ts 的 stripLeadingRuntimeWrappers() 與 smart-extractor.ts 職責重疊，#510 已覆蓋主要需求

**建議：關閉此 PR，功能由 #510 承接。**

另：AliceLJY 已在 #510 approved（LGTM），建議加快 #510 merge。