### PR TITLE
fix: strip entire wrapper line in stripEnvelopeMetadata

### DIFF
--- a/src/smart-extractor.ts
+++ b/src/smart-extractor.ts
@@ -72,10 +72,14 @@ import { batchDedup } from "./batch-dedup.js";
 export function stripEnvelopeMetadata(text: string): string {
   // 0. Strip runtime orchestration wrappers that should never become memories
   //    (sub-agent task scaffolding is execution metadata, not conversation content).
+  //    Strip the entire wrapper line (prefix + all inline content) so that subagent
+  //    instruction fragments like 'You are running as a subagent (depth 1/1).' are not
+  //    left behind when inline content does not match the old optional-group patterns.
   let cleaned = text.replace(
-    /^\[(?:Subagent Context|Subagent Task)\]\s*(?:You are running as a subagent.*?(?:$|(?<=\.)\s+)|Results auto-announce to your requester\.?\s*|do not busy-poll for status\.?\s*|Reply with a brief acknowledgment only\.?\s*|Do not use any memory tools\.?\s*)?/gim,
+    /^\[(?:Subagent Context|Subagent Task)\].*/gim,
     "",
   );
+  // Strip standalone boilerplate continuation lines that appear on their own.
   cleaned = cleaned.replace(
     /^(?:Results auto-announce to your requester\.?|do not busy-poll for status\.?|Do not use any memory tools\.?)\s*$/gim,
     "",


### PR DESCRIPTION
## Summary

Fix pre-existing bug in \stripEnvelopeMetadata\ where subagent wrapper lines with inline content were only partially stripped, leaving instruction fragments like \You are running as a subagent (depth 1/1).\ in the output.

## Root Cause

The original regex used an optional group \(?:...)?\ to match boilerplate patterns within wrapper lines. When the inline content did not match any of the specific patterns (e.g. \(depth 1/1)\), the optional group was skipped, leaving the wrapper prefix stripped but the content fragment behind.

\\\	ypescript
// OLD (buggy): optional group means content fragments survive when no pattern matches
/^\\[(?:Subagent Context|Subagent Task)\\]\\s*(?:You are running as a subagent.*?(?:$|(?<=\\.)\\s+)|...)?/gim
//                                                     ↑ optional, skipped when content is different
\\\

## Fix

Strip the **entire** wrapper line using \.*\:

\\\	ypescript
/^\\[(?:Subagent Context|Subagent Task)\\].*/gim
\\\

Standalone boilerplate lines (e.g. \Results auto-announce to your requester.\ on its own line) are still removed by the second replace.

## Test Results

Before: 12 pass / **2 fail** (pre-existing)
After: **14 pass / 0 fail**

## Files Changed

- \src/smart-extractor.ts\: 1 regex changed, 3 comment lines added