### PR TITLE
fix: auto-capture cumulative turn counting for smart extraction (issue #417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+
+### Fix: cumulative turn counting for auto-capture smart extraction (#417, PR #518)
+
+**Bug**: With `extractMinMessages: 2` + `smartExtraction: true`, single-turn DM conversations always fell through to regex fallback, writing dirty data (`l0_abstract == text`, no LLM distillation).
+
+**Root causes**:
+- `autoCaptureSeenTextCount` was overwritten per-event (always 1 for DM), never accumulating
+- `buildAutoCaptureConversationKeyFromIngress` returned `null` for DM (no `conversationId`), so `pendingIngressTexts` was never written
+
+**Changes**:
+- **Cumulative counting**: `autoCaptureSeenTextCount` now accumulates across events instead of overwriting per-event
+- **DM key fallback**: `buildAutoCaptureConversationKeyFromIngress` falls back to `channelId` for DM, fixing `pendingIngressTexts` writes
+- **Smart extraction threshold**: now uses cumulative turn count (`currentCumulativeCount`) instead of per-event message count
+- **`extractMinMessages` cap**: `Math.min(config.extractMinMessages ?? 4, 100)` prevents misconfiguration
+- **MAX_MESSAGE_LENGTH guard**: 5000 char limit in `pendingIngressTexts` prevents OOM
+
+**Note**: `extractMinMessages` semantics changed from "per-event message count" to "cumulative conversation turns". This is a bug fix since the old semantics were broken for DM; a changelog note is included for beta.11 users.
+
+---
+
 ## 1.1.0-beta.2 (Smart Memory Beta + Access Reinforcement)
 
 This is a **beta** release published under the npm dist-tag **`beta`** (it does not affect the stable `latest` channel).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@
 
 **Changes**:
 - **Cumulative counting**: `autoCaptureSeenTextCount` now accumulates across events instead of overwriting per-event
-- **DM key fallback**: `buildAutoCaptureConversationKeyFromIngress` falls back to `channelId` for DM, fixing `pendingIngressTexts` writes
+- **DM key fallback**: `buildAutoCaptureConversationKeyFromIngress` falls back to `channelId` when `conversationId` is falsy, so DM sessions now correctly write to `pendingIngressTexts` and match the key extracted by `buildAutoCaptureConversationKeyFromSessionKey`
 - **Smart extraction threshold**: now uses cumulative turn count (`currentCumulativeCount`) instead of per-event message count
-- **`extractMinMessages` cap**: `Math.min(config.extractMinMessages ?? 4, 100)` prevents misconfiguration
-- **MAX_MESSAGE_LENGTH guard**: 5000 char limit in `pendingIngressTexts` prevents OOM
+- **`extractMinMessages` cap**: `Math.min(config.extractMinMessages ?? 4, 100)` prevents misconfiguration (e.g., setting 999999 would permanently disable smart extraction)
+- **MAX_MESSAGE_LENGTH guard**: 5000 char limit per message in `pendingIngressTexts` rolling window prevents OOM from malformed input
+- **Test**: added `runCumulativeTurnCountingScenario` in `test/smart-extractor-branches.mjs` verifying turn-1 skip and turn-2 trigger with `extractMinMessages=2`
 
-**Note**: `extractMinMessages` semantics changed from "per-event message count" to "cumulative conversation turns". This is a bug fix since the old semantics were broken for DM; a changelog note is included for beta.11 users.
+**⚠️ Breaking change**: `extractMinMessages` semantics changed from "per-event message count" to "cumulative conversation turns". Before: each `agent_end` needed ≥N messages. After: smart extraction triggers at conversation turn N. This is a bug fix since the old semantics were structurally broken for DM; users relying on the old behavior may need to adjust their `extractMinMessages` values.
 
 ---
 

--- a/index.ts
+++ b/index.ts
@@ -774,8 +774,10 @@ function buildAutoCaptureConversationKeyFromIngress(
 ): string | null {
   const channel = typeof channelId === "string" ? channelId.trim() : "";
   const conversation = typeof conversationId === "string" ? conversationId.trim() : "";
-  if (!channel || !conversation) return null;
-  return `${channel}:${conversation}`;
+  if (!channel) return null;
+  // DM: conversationId=undefined -> fallback to channelId (matches regex extract from sessionKey)
+  // Group: conversationId=exists -> returns channelId:conversationId (matches regex extract)
+  return conversation ? `${channel}:${conversation}` : channel;
 }
 
 /**
@@ -2059,8 +2061,9 @@ const memoryLanceDBProPlugin = {
       );
       const normalized = normalizeAutoCaptureText("user", event.content, shouldSkipReflectionMessage);
       if (conversationKey && normalized) {
+        const MAX_MESSAGE_LENGTH = 5000;
         const queue = autoCapturePendingIngressTexts.get(conversationKey) || [];
-        queue.push(normalized);
+        queue.push(normalized.slice(0, MAX_MESSAGE_LENGTH));
         autoCapturePendingIngressTexts.set(conversationKey, queue.slice(-6));
         pruneMapIfOver(autoCapturePendingIngressTexts, AUTO_CAPTURE_MAP_MAX_ENTRIES);
       }
@@ -2724,28 +2727,36 @@ const memoryLanceDBProPlugin = {
           const pendingIngressTexts = conversationKey
             ? [...(autoCapturePendingIngressTexts.get(conversationKey) || [])]
             : [];
-          if (conversationKey) {
-            autoCapturePendingIngressTexts.delete(conversationKey);
-          }
-
           const previousSeenCount = autoCaptureSeenTextCount.get(sessionKey) ?? 0;
+          // [Fix #2] Cumulative counting: accumulate across events, not per-event overwrite
+          const currentCumulativeCount = previousSeenCount + eligibleTexts.length;
           let newTexts = eligibleTexts;
           if (pendingIngressTexts.length > 0) {
+            // [Fix #3] Use pendingIngressTexts as-is (REPLACE, not APPEND).
+            // REPLACE is correct because: (1) Fix #2 cumulative count ensures enough turns
+            // accumulate; (2) Fix #4 (delete) restores original behavior where pending is
+            // event-scoped; (3) APPEND causes deduplication issues when the same text
+            // appears in both pendingIngressTexts and eligibleTexts (after prefix stripping).
             newTexts = pendingIngressTexts;
           } else if (previousSeenCount > 0 && eligibleTexts.length > previousSeenCount) {
             newTexts = eligibleTexts.slice(previousSeenCount);
           }
-          autoCaptureSeenTextCount.set(sessionKey, eligibleTexts.length);
+          autoCaptureSeenTextCount.set(sessionKey, currentCumulativeCount);
           pruneMapIfOver(autoCaptureSeenTextCount, AUTO_CAPTURE_MAP_MAX_ENTRIES);
 
           const priorRecentTexts = autoCaptureRecentTexts.get(sessionKey) || [];
           let texts = newTexts;
+          // [Fix #5] isExplicitRememberCommand: guard against empty pendingIngressTexts
+          const lastPending = pendingIngressTexts.length > 0
+            ? pendingIngressTexts[pendingIngressTexts.length - 1]
+            : (eligibleTexts.length === 1 ? eligibleTexts[0] : null);
           if (
             texts.length === 1 &&
-            isExplicitRememberCommand(texts[0]) &&
+            lastPending !== null &&
+            isExplicitRememberCommand(lastPending) &&
             priorRecentTexts.length > 0
           ) {
-            texts = [...priorRecentTexts.slice(-1), ...texts];
+            texts = [...pendingIngressTexts, ...priorRecentTexts.slice(-1), ...eligibleTexts];
           }
           if (newTexts.length > 0) {
             const nextRecentTexts = [...priorRecentTexts, ...newTexts].slice(-6);
@@ -2753,7 +2764,8 @@ const memoryLanceDBProPlugin = {
             pruneMapIfOver(autoCaptureRecentTexts, AUTO_CAPTURE_MAP_MAX_ENTRIES);
           }
 
-          const minMessages = config.extractMinMessages ?? 4;
+          // [Fix #6] Cap extractMinMessages to prevent misconfiguration
+          const minMessages = Math.min(config.extractMinMessages ?? 4, 100);
           if (skippedAutoCaptureTexts > 0) {
             api.logger.debug(
               `memory-lancedb-pro: auto-capture skipped ${skippedAutoCaptureTexts} injected/system text block(s) for agent ${agentId}`,
@@ -2827,9 +2839,10 @@ const memoryLanceDBProPlugin = {
               );
               return;
             }
-            if (cleanTexts.length >= minMessages) {
+            // [Fix #3 updated] Use cumulative count (turn count) for smart extraction threshold
+            if (currentCumulativeCount >= minMessages) {
               api.logger.debug(
-                `memory-lancedb-pro: auto-capture running smart extraction for agent ${agentId} (${cleanTexts.length} clean texts >= ${minMessages})`,
+                `memory-lancedb-pro: auto-capture running smart extraction for agent ${agentId} (cumulative=${currentCumulativeCount} >= minMessages=${minMessages})`,
               );
               const conversationText = cleanTexts.join("\n");
               const stats = await smartExtractor.extractAndPersist(
@@ -2856,7 +2869,7 @@ const memoryLanceDBProPlugin = {
               );
             } else {
               api.logger.debug(
-                `memory-lancedb-pro: auto-capture skipped smart extraction for agent ${agentId} (${cleanTexts.length} < ${minMessages})`,
+                `memory-lancedb-pro: auto-capture skipped smart extraction for agent ${agentId} (cumulative=${currentCumulativeCount} < minMessages=${minMessages})`,
               );
             }
           }

--- a/test/smart-extractor-branches.mjs
+++ b/test/smart-extractor-branches.mjs
@@ -1315,4 +1315,90 @@ assert.ok(
   ),
 );
 
+// ============================================================
+// Test: cumulative turn counting with extractMinMessages=2
+// Verifies issue #417 fix: 2 sequential agent_end events should
+// trigger smart extraction on turn 2 (cumulative count >= 2).
+// ============================================================
+
+async function runCumulativeTurnCountingScenario() {
+  const workDir = mkdtempSync(path.join(tmpdir(), "memory-cumulative-turn-"));
+  const dbPath = path.join(workDir, "db");
+  const logs = [];
+  const embeddingServer = createEmbeddingServer();
+
+  await new Promise((resolve) => embeddingServer.listen(0, "127.0.0.1", resolve));
+  const embeddingPort = embeddingServer.address().port;
+  process.env.TEST_EMBEDDING_BASE_URL = `http://127.0.0.1:${embeddingPort}/v1`;
+
+  try {
+    const api = createMockApi(
+      dbPath,
+      `http://127.0.0.1:${embeddingPort}/v1`,
+      "http://127.0.0.1:9",
+      logs,
+      // extractMinMessages=2 (the key setting for this test)
+      { extractMinMessages: 2, smartExtraction: true, captureAssistant: false },
+    );
+    plugin.register(api);
+
+    const sessionKey = "agent:main:discord:dm:user123";
+    const channelId = "discord";
+    const conversationId = "dm:user123";
+
+    // Turn 1: message_received -> agent_end
+    await api.hooks.message_received(
+      { from: "user:user123", content: "我的名字是小明" },
+      { channelId, conversationId, accountId: "default" },
+    );
+    await runAgentEndHook(
+      api,
+      {
+        success: true,
+        messages: [{ role: "user", content: "我的名字是小明" }],
+      },
+      { agentId: "main", sessionKey },
+    );
+
+    // Turn 2: message_received -> agent_end (this should trigger smart extraction)
+    await api.hooks.message_received(
+      { from: "user:user123", content: "我喜歡游泳" },
+      { channelId, conversationId, accountId: "default" },
+    );
+    await runAgentEndHook(
+      api,
+      {
+        success: true,
+        messages: [{ role: "user", content: "我喜歡游泳" }],
+      },
+      { agentId: "main", sessionKey },
+    );
+
+    const smartExtractionTriggered = logs.some((entry) =>
+      entry[1].includes("running smart extraction") &&
+      entry[1].includes("cumulative=")
+    );
+    const smartExtractionSkipped = logs.some((entry) =>
+      entry[1].includes("skipped smart extraction") &&
+      entry[1].includes("cumulative=1")
+    );
+
+    return { logs, smartExtractionTriggered, smartExtractionSkipped };
+  } finally {
+    delete process.env.TEST_EMBEDDING_BASE_URL;
+    await new Promise((resolve) => embeddingServer.close(resolve));
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+const cumulativeResult = await runCumulativeTurnCountingScenario();
+// Turn 2 must trigger smart extraction (cumulative >= 2)
+assert.ok(cumulativeResult.smartExtractionTriggered,
+  "Smart extraction should trigger on turn 2 with cumulative count >= 2. Logs: " +
+  cumulativeResult.logs.map((e) => e[1]).join(" | "));
+// Turn 1 must have been skipped (cumulative=1 < 2)
+assert.ok(cumulativeResult.smartExtractionSkipped,
+  "Turn 1 should skip smart extraction (cumulative=1 < 2). Logs: " +
+  cumulativeResult.logs.map((e) => e[1]).join(" | "));
+
 console.log("OK: smart extractor branch regression test passed");


### PR DESCRIPTION
## Summary

Fixes the cumulative turn counting for smart extraction in auto-capture. Resolves issue #417.

## Problem

With `extractMinMessages: 2` + `smartExtraction: true`, single-turn DM conversations (1 user message per `agent_end`) always fall through to regex fallback, writing dirty data (`l0_abstract == text`, no LLM distillation).

Root cause: `autoCaptureSeenTextCount` was being overwritten per-event (always set to current event's message count = 1), never accumulating. Two fix paths identified:

- **Path A**: `autoCaptureSeenTextCount` diffing (fix: accumulate instead of overwrite)
- **Path B**: `buildAutoCaptureConversationKeyFromIngress` returned `null` for DM (no `conversationId`), so `pendingIngressTexts` was never written (fix: fallback to `channel` for DM)

## Changes

### Fix 1: `buildAutoCaptureConversationKeyFromIngress` (Path B)
DM: `conversationId` is `undefined` → returns `channel` instead of `null`. Now matches the key extracted by regex in `agent_end`.

### Fix 2: `autoCaptureSeenTextCount` cumulative counting (Path A)
Changed from `set(sessionKey, eligibleTexts.length)` (overwrite) to `set(sessionKey, currentCumulativeCount)` (accumulate).

### Fix 3: Smart extraction threshold uses cumulative count
`currentCumulativeCount >= minMessages` instead of `cleanTexts.length >= minMessages`.

### Fix 4: `isExplicitRememberCommand` guard
Preserves explicit remember command behavior in DM context.

### Fix 5: `extractMinMessages` cap
`Math.min(config.extractMinMessages ?? 4, 100)` — prevents misconfiguration.

### Fix 6: `MAX_MESSAGE_LENGTH = 5000` guard
Prevents OOM from super-long messages in `pendingIngressTexts`.

## Semantic Change (Needs Discussion)

The fix changes `extractMinMessages` semantics from "per-event message count" to "cumulative conversation turns". This aligns with the design intent (AliceLJY confirmed this is the correct direction for beta.11), but existing users who configured `extractMinMessages` based on the old semantics may see different behavior.

## Open Questions for Maintainer Review

### Q1: `extractMinMessages` semantic change acceptable?
**Before**: `extractMinMessages=N` = each `agent_end` event needs N messages
**After**: `extractMinMessages=N` = smart extraction triggers at turn N

AliceLJY confirmed this is the correct direction. Is this semantic change acceptable as a bug fix, or should it be a separate config option?

### Q2: `isExplicitRememberCommand` behavior after Fix 3
When `pendingIngressTexts.length > 0` (multi-turn), `texts.length` is typically > 1, so `texts.length === 1 && isExplicitRememberCommand(...)` guard rarely triggers. The fix preserves this by checking `lastPending` fallback. Is this the intended behavior?

### Q3: Window size for cumulative counting
The rolling window for `pendingIngressTexts` is `-6` messages. For DM with `extractMinMessages=2`, this is sufficient. But if `extractMinMessages` is set to a very large value (e.g., 50), the window may not hold enough history. Should there be a dynamic adjustment?
