### PR TITLE
fix: complete Issue #492 protection -- per-agent exclusion + configurable serial cooldown

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -203,6 +203,10 @@ interface PluginConfig {
     thinkLevel?: ReflectionThinkLevel;
     errorReminderMaxEntries?: number;
     dedupeErrorSignals?: boolean;
+    /** Cooldown in milliseconds between reflection triggers for the same session.
+     *  Default: 120000 (2 minutes). Set to 0 to disable the serial guard.
+     *  @example 60000 (1 min), 180000 (3 min) */
+    serialCooldownMs?: number;
   };
   mdMirror?: { enabled?: boolean; dir?: string };
   workspaceBoundary?: WorkspaceBoundaryConfig;
@@ -3360,13 +3364,22 @@ const memoryLanceDBProPlugin = {
           api.logger.info(`memory-reflection: command hook skipped (re-entrant, sessionKey=${sessionKey})`);
           return;
         }
+        // Parse context before guards so cfg is available
+        const context = (event.context || {}) as Record<string, unknown>;
+        const cfg = context.cfg as Record<string, unknown> | undefined;
+
         // Serial loop guard: prevent rapid re-trigger within cooldown window
         if (sessionKey) {
           const serialGuard = getSerialGuardMap();
           const lastRun = serialGuard.get(sessionKey);
-          if (lastRun && (Date.now() - lastRun) < SERIAL_GUARD_COOLDOWN_MS) {
-            api.logger.info(`memory-reflection: command hook skipped (cooldown ${((Date.now() - lastRun) / 1000).toFixed(0)}s, sessionKey=${sessionKey})`);
-            return;
+          if (lastRun) {
+            const cooldownMs = typeof (cfg?.memoryReflection as Record<string, unknown> | undefined)?.serialCooldownMs === "number"
+              ? (cfg!.memoryReflection as Record<string, unknown>).serialCooldownMs as number
+              : 120_000;
+            if ((Date.now() - lastRun) < cooldownMs) {
+              api.logger.info(`memory-reflection: command hook skipped (cooldown ${((Date.now() - lastRun) / 1000).toFixed(0)}s/${(cooldownMs / 1000).toFixed(0)}s, sessionKey=${sessionKey})`);
+              return;
+            }
           }
         }
         if (sessionKey) globalLock.set(sessionKey, true);
@@ -3374,8 +3387,6 @@ const memoryLanceDBProPlugin = {
         try {
           pruneReflectionSessionState();
           const action = String(event?.action || "unknown");
-          const context = (event.context || {}) as Record<string, unknown>;
-          const cfg = context.cfg;
           const workspaceDir = resolveWorkspaceDirFromContext(context);
           if (!cfg) {
             api.logger.warn(`memory-reflection: command:${action} sessionKey=${sessionKey} missing cfg; skip reflection`);

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -146,7 +146,12 @@
       },
       "recallMode": {
         "type": "string",
-        "enum": ["full", "summary", "adaptive", "off"],
+        "enum": [
+          "full",
+          "summary",
+          "adaptive",
+          "off"
+        ],
         "default": "full",
         "description": "Auto-recall depth mode. 'full': inject with configured per-item budget. 'summary': L0 abstracts only (compact). 'adaptive': analyze query intent to auto-select category and depth. 'off': disable auto-recall injection."
       },
@@ -245,23 +250,78 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "utility": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.1 },
-              "confidence": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.1 },
-              "novelty": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.1 },
-              "recency": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.1 },
-              "typePrior": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.6 }
+              "utility": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.1
+              },
+              "confidence": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.1
+              },
+              "novelty": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.1
+              },
+              "recency": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.1
+              },
+              "typePrior": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.6
+              }
             }
           },
           "typePriors": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "profile": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.95 },
-              "preferences": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.9 },
-              "entities": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.75 },
-              "events": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.45 },
-              "cases": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.8 },
-              "patterns": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.85 }
+              "profile": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.95
+              },
+              "preferences": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.9
+              },
+              "entities": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.75
+              },
+              "events": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.45
+              },
+              "cases": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.8
+              },
+              "patterns": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.85
+              }
             }
           }
         }
@@ -635,6 +695,18 @@
           "dedupeErrorSignals": {
             "type": "boolean",
             "default": true
+          },
+          "serialCooldownMs": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Cooldown in ms between reflection triggers for the same session. Default: 120000 (2 min). Set to 0 to disable."
+          },
+          "excludeAgents": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Agent/session patterns excluded from reflection injection. Supports exact match, wildcard prefix (e.g. pi-), and temp:*."
           }
         }
       },
@@ -838,6 +910,13 @@
             "description": "Maximum number of auto-capture extractions allowed per hour"
           }
         }
+      },
+      "autoRecallExcludeAgents": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Agent/session patterns excluded from auto-recall and reflection injection. Supports exact match, wildcard prefix (e.g. pi-), and temp:*."
       }
     },
     "required": [


### PR DESCRIPTION
## Problem

Issue #492: memoryReflection hooks in before_prompt_build synchronously execute
LanceDB queries on every user session, causing 30-50% of sessions to fail.

## Solution

Per-agent exclusion mechanism via autoRecallExcludeAgents + configurable serial cooldown.

## Changes

### 1. isAgentOrSessionExcluded helper
Supports exact/wildcard-prefix/temp:* patterns.

### 2. Fixed auto-recall before_prompt_build exclusion check
Removed ineffective agentId !== undefined check.

### 3. Added exclusion checks to both reflection before_prompt_build hooks
Priority 12 and 15 now have isInternal guard + exclusion check.

### 4. Three-layer guard on runMemoryReflection command hook
- Internal session guard
- Re-entrant guard (Symbol.for + globalThis)
- Serial cooldown guard (now configurable)

### 5. serialCooldownMs now configurable (THIS COMMIT)
Added to PluginConfig interface and openclaw.plugin.json schema.
Users can now adjust via openclaw.json without code changes.

### 6. Added internal session guard to appendSelfImprovementNote
Consistent with agent:bootstrap hook.

### 7. Enhanced early-return logging with sessionKey/sessionId

## openclaw.json Usage

```json
{
  "memory-lancedb-pro": {
    "memoryReflection": {
      "serialCooldownMs": 60000
    },
    "autoRecallExcludeAgents": ["memory-distiller", "pi-", "temp:*"]
  }
}
```

## Questions for Maintainers

1. Is dual-purpose autoRecallExcludeAgents acceptable, or split into reflectionExcludeAgents?
2. Is 120s default cooldown reasonable?
3. Any concerns about globalThis + Symbol.for for lock maps?

---
Related to: #492
See also: Issue #514