### PR TITLE
fix: remove invalid WeakSet.clear() call from resetRegistration()

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4139,7 +4139,7 @@ export function resetRegistration() {
   // Note: WeakSets cannot be cleared by design. In test scenarios where the
   // same process reloads the module, a fresh module state means a new WeakSet.
   // For hot-reload scenarios, the module is re-imported fresh.
-  _registeredApis.clear();
+  // (WeakSet.clear() does not exist, so we do nothing here.)
 }
 
 export default memoryLanceDBProPlugin;


### PR DESCRIPTION
## Summary

Remove the invalid \_registeredApis.clear()\ call in \esetRegistration()\ and replace it with a comment explaining why no-op is correct.

## What was fixed

**Problem**: \WeakSet\ in JavaScript does not have a \.clear()\ method. The old code called \_registeredApis.clear();\ which would throw a \TypeError\ at runtime.

**Fix**: Replaced \_registeredApis.clear();\ with a comment. This is intentional because:

1. WeakSet entries are garbage-collected automatically when the referenced object is no longer reachable
2. Module hot-reload triggers a fresh module state, creating a new \_registeredApis\ WeakSet automatically
3. The existing comment already documented: \WeakSets cannot be cleared by design\

## Files changed

- \index.ts\: +1/-1 line in \esetRegistration()\

## Testing

- No behavior change (was already effectively a no-op, just crashing instead of doing nothing)
- After this fix: \esetRegistration()\ silently does nothing as intended

## Related

- Replaces PR #498 (scope drift cleaned up)
- WeakSet.clear() issue found during code review