### PR TITLE
feat: add skills auto-discovery configuration

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4,6 +4,7 @@
   "description": "Enhanced LanceDB-backed long-term memory with hybrid retrieval, multi-scope isolation, long-context chunking, and management CLI",
   "version": "1.1.0-beta.10",
   "kind": "memory",
+  "skills": ["./skills"],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/skills/lesson/SKILL.md
+++ b/skills/lesson/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: lesson
 description: Store a lesson learned from the current conversation. Triggered by /lesson command. Use when Master signals that the recent conversation contains a pitfall, fix, or key insight that should be persisted to long-term memory.
+metadata: { "openclaw": { "requires": { "config": ["plugins.entries.memory-lancedb-pro.enabled"] } } }
 ---
 
 # Lesson Extraction & Storage


### PR DESCRIPTION
## Summary

This PR adds support for OpenClaw to automatically discover skills in the plugin directory.

## Changes

1. **openclaw.plugin.json**: Added `"skills": ["./skills"]` configuration field
   - Enables OpenClaw to automatically discover and load skills from the plugin's skills directory
   - Follows the OpenClaw plugin specification for skill discovery

2. **skills/lesson/SKILL.md**: Added metadata configuration dependency declaration
   - Declares dependency on `plugins.entries.memory-lancedb-pro.enabled` config
   - Ensures the skill only runs when the plugin is enabled

## Motivation

Currently, OpenClaw requires manual skill registration. This change enables automatic skill discovery from the plugin directory, simplifying plugin development and maintenance.

## Testing

- Tested with OpenClaw workspace plugin loading
- Verified skills are automatically discovered and loaded
- Confirmed lesson skill works correctly with config dependency

## Related

- Plugin type: memory
- Version: 1.1.0-beta.10