### PR TITLE
[codex] split cli-smoke into grouped CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,76 @@ jobs:
         run: npm ci
 
       - name: Test
-        run: npm test
+        run: npm run test:cli-smoke
+
+  core-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm run test:core-regression
+
+  storage-and-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm run test:storage-and-schema
+
+  llm-clients-and-auth:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm run test:llm-clients-and-auth
+
+  packaging-and-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm run test:packaging-and-workflow

--- a/package.json
+++ b/package.json
@@ -38,7 +38,15 @@
     ]
   },
   "scripts": {
-    "test": "node test/embedder-error-hints.test.mjs && node test/cjk-recursion-regression.test.mjs && node test/migrate-legacy-schema.test.mjs && node --test test/config-session-strategy-migration.test.mjs && node --test test/scope-access-undefined.test.mjs && node --test test/reflection-bypass-hook.test.mjs && node --test test/smart-extractor-scope-filter.test.mjs && node --test test/store-empty-scope-filter.test.mjs && node --test test/recall-text-cleanup.test.mjs && node test/update-consistency-lancedb.test.mjs && node --test test/strip-envelope-metadata.test.mjs && node test/cli-smoke.mjs && node test/functional-e2e.mjs && node test/retriever-rerank-regression.mjs && node test/smart-memory-lifecycle.mjs && node test/smart-extractor-branches.mjs && node test/plugin-manifest-regression.mjs && node --test test/session-summary-before-reset.test.mjs && node --test test/sync-plugin-version.test.mjs && node test/smart-metadata-v2.mjs && node test/vector-search-cosine.test.mjs && node test/context-support-e2e.mjs && node test/temporal-facts.test.mjs && node test/memory-update-supersede.test.mjs && node test/memory-upgrader-diagnostics.test.mjs && node --test test/llm-api-key-client.test.mjs && node --test test/llm-oauth-client.test.mjs && node --test test/cli-oauth-login.test.mjs && node --test test/workflow-fork-guards.test.mjs && node --test test/clawteam-scope.test.mjs && node --test test/cross-process-lock.test.mjs && node --test test/preference-slots.test.mjs && node test/is-latest-auto-supersede.test.mjs && node --test test/temporal-awareness.test.mjs",
+    "test": "node scripts/verify-ci-test-manifest.mjs && npm run test:cli-smoke && npm run test:core-regression && npm run test:storage-and-schema && npm run test:llm-clients-and-auth && npm run test:packaging-and-workflow",
+    "test:cli-smoke": "node scripts/run-ci-tests.mjs --group cli-smoke",
+    "test:core-regression": "node scripts/run-ci-tests.mjs --group core-regression",
+    "test:storage-and-schema": "node scripts/run-ci-tests.mjs --group storage-and-schema",
+    "test:llm-clients-and-auth": "node scripts/run-ci-tests.mjs --group llm-clients-and-auth",
+    "test:packaging-and-workflow": "node scripts/verify-ci-test-manifest.mjs && node scripts/run-ci-tests.mjs --group packaging-and-workflow",
+    "bench": "jiti benchmark/run.ts",
+    "bench:locomo": "jiti benchmark/run.ts --benchmark locomo",
+    "bench:longmemeval": "jiti benchmark/run.ts --benchmark longmemeval",
     "test:openclaw-host": "node test/openclaw-host-functional.mjs",
     "version": "node scripts/sync-plugin-version.mjs openclaw.plugin.json package.json && git add openclaw.plugin.json"
   },

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -1,0 +1,52 @@
+export const CI_TEST_GROUPS = [
+  "cli-smoke",
+  "core-regression",
+  "storage-and-schema",
+  "llm-clients-and-auth",
+  "packaging-and-workflow",
+];
+
+export const CI_TEST_MANIFEST = [
+  { group: "llm-clients-and-auth", runner: "node", file: "test/embedder-error-hints.test.mjs" },
+  { group: "llm-clients-and-auth", runner: "node", file: "test/cjk-recursion-regression.test.mjs" },
+  { group: "storage-and-schema", runner: "node", file: "test/migrate-legacy-schema.test.mjs" },
+  { group: "storage-and-schema", runner: "node", file: "test/config-session-strategy-migration.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/scope-access-undefined.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/reflection-bypass-hook.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/smart-extractor-scope-filter.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/store-empty-scope-filter.test.mjs", args: ["--test"] },
+  { group: "core-regression", runner: "node", file: "test/recall-text-cleanup.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/update-consistency-lancedb.test.mjs" },
+  { group: "core-regression", runner: "node", file: "test/strip-envelope-metadata.test.mjs", args: ["--test"] },
+  { group: "cli-smoke", runner: "node", file: "test/cli-smoke.mjs" },
+  { group: "cli-smoke", runner: "node", file: "test/functional-e2e.mjs" },
+  { group: "core-regression", runner: "node", file: "test/retriever-rerank-regression.mjs" },
+  { group: "core-regression", runner: "node", file: "test/smart-memory-lifecycle.mjs" },
+  { group: "core-regression", runner: "node", file: "test/smart-extractor-branches.mjs" },
+  { group: "packaging-and-workflow", runner: "node", file: "test/plugin-manifest-regression.mjs" },
+  { group: "core-regression", runner: "node", file: "test/session-summary-before-reset.test.mjs", args: ["--test"] },
+  { group: "packaging-and-workflow", runner: "node", file: "test/sync-plugin-version.test.mjs", args: ["--test"] },
+  { group: "core-regression", runner: "node", file: "test/smart-metadata-v2.mjs" },
+  { group: "storage-and-schema", runner: "node", file: "test/vector-search-cosine.test.mjs" },
+  { group: "core-regression", runner: "node", file: "test/context-support-e2e.mjs" },
+  { group: "core-regression", runner: "node", file: "test/temporal-facts.test.mjs" },
+  { group: "core-regression", runner: "node", file: "test/memory-update-supersede.test.mjs" },
+  { group: "llm-clients-and-auth", runner: "node", file: "test/memory-upgrader-diagnostics.test.mjs" },
+  { group: "llm-clients-and-auth", runner: "node", file: "test/llm-api-key-client.test.mjs", args: ["--test"] },
+  { group: "llm-clients-and-auth", runner: "node", file: "test/llm-oauth-client.test.mjs", args: ["--test"] },
+  { group: "llm-clients-and-auth", runner: "node", file: "test/cli-oauth-login.test.mjs", args: ["--test"] },
+  { group: "packaging-and-workflow", runner: "node", file: "test/workflow-fork-guards.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/clawteam-scope.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/cross-process-lock.test.mjs", args: ["--test"] },
+  { group: "core-regression", runner: "node", file: "test/preference-slots.test.mjs", args: ["--test"] },
+  { group: "core-regression", runner: "node", file: "test/is-latest-auto-supersede.test.mjs" },
+  { group: "core-regression", runner: "node", file: "test/temporal-awareness.test.mjs", args: ["--test"] },
+];
+
+export function getEntriesForGroup(group) {
+  if (!CI_TEST_GROUPS.includes(group)) {
+    throw new Error(`Unknown CI test group: ${group}`);
+  }
+
+  return CI_TEST_MANIFEST.filter((entry) => entry.group === group);
+}

--- a/scripts/run-ci-tests.mjs
+++ b/scripts/run-ci-tests.mjs
@@ -1,0 +1,52 @@
+import { spawn } from "node:child_process";
+import { CI_TEST_MANIFEST, getEntriesForGroup } from "./ci-test-manifest.mjs";
+
+function parseArgs(argv) {
+  if (argv.includes("--all")) {
+    return { mode: "all" };
+  }
+
+  const idx = argv.indexOf("--group");
+  if (idx !== -1 && argv[idx + 1]) {
+    return { mode: "group", group: argv[idx + 1] };
+  }
+
+  throw new Error("Usage: node scripts/run-ci-tests.mjs --all | --group <name>");
+}
+
+function buildCommand(entry) {
+  return [entry.runner, ...(entry.args ?? []), entry.file];
+}
+
+async function runEntry(entry) {
+  const [cmd, ...args] = buildCommand(entry);
+  const printable = [cmd, ...args].join(" ");
+  console.log(`==> ${printable}`);
+
+  await new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: "inherit" });
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`${entry.file} exited ${code}`));
+    });
+    child.on("error", reject);
+  });
+}
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  const entries = parsed.mode === "all" ? CI_TEST_MANIFEST : getEntriesForGroup(parsed.group);
+
+  for (const entry of entries) {
+    await runEntry(entry);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/verify-ci-test-manifest.mjs
+++ b/scripts/verify-ci-test-manifest.mjs
@@ -1,0 +1,140 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { CI_TEST_GROUPS, CI_TEST_MANIFEST } from "./ci-test-manifest.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const EXPECTED_BASELINE = [
+  { group: "llm-clients-and-auth", runner: "node", file: "test/embedder-error-hints.test.mjs" },
+  { group: "llm-clients-and-auth", runner: "node", file: "test/cjk-recursion-regression.test.mjs" },
+  { group: "storage-and-schema", runner: "node", file: "test/migrate-legacy-schema.test.mjs" },
+  { group: "storage-and-schema", runner: "node", file: "test/config-session-strategy-migration.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/scope-access-undefined.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/reflection-bypass-hook.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/smart-extractor-scope-filter.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/store-empty-scope-filter.test.mjs", args: ["--test"] },
+  { group: "core-regression", runner: "node", file: "test/recall-text-cleanup.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/update-consistency-lancedb.test.mjs" },
+  { group: "core-regression", runner: "node", file: "test/strip-envelope-metadata.test.mjs", args: ["--test"] },
+  { group: "cli-smoke", runner: "node", file: "test/cli-smoke.mjs" },
+  { group: "cli-smoke", runner: "node", file: "test/functional-e2e.mjs" },
+  { group: "core-regression", runner: "node", file: "test/retriever-rerank-regression.mjs" },
+  { group: "core-regression", runner: "node", file: "test/smart-memory-lifecycle.mjs" },
+  { group: "core-regression", runner: "node", file: "test/smart-extractor-branches.mjs" },
+  { group: "packaging-and-workflow", runner: "node", file: "test/plugin-manifest-regression.mjs" },
+  { group: "core-regression", runner: "node", file: "test/session-summary-before-reset.test.mjs", args: ["--test"] },
+  { group: "packaging-and-workflow", runner: "node", file: "test/sync-plugin-version.test.mjs", args: ["--test"] },
+  { group: "core-regression", runner: "node", file: "test/smart-metadata-v2.mjs" },
+  { group: "storage-and-schema", runner: "node", file: "test/vector-search-cosine.test.mjs" },
+  { group: "core-regression", runner: "node", file: "test/context-support-e2e.mjs" },
+  { group: "core-regression", runner: "node", file: "test/temporal-facts.test.mjs" },
+  { group: "core-regression", runner: "node", file: "test/memory-update-supersede.test.mjs" },
+  { group: "llm-clients-and-auth", runner: "node", file: "test/memory-upgrader-diagnostics.test.mjs" },
+  { group: "llm-clients-and-auth", runner: "node", file: "test/llm-api-key-client.test.mjs", args: ["--test"] },
+  { group: "llm-clients-and-auth", runner: "node", file: "test/llm-oauth-client.test.mjs", args: ["--test"] },
+  { group: "llm-clients-and-auth", runner: "node", file: "test/cli-oauth-login.test.mjs", args: ["--test"] },
+  { group: "packaging-and-workflow", runner: "node", file: "test/workflow-fork-guards.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/clawteam-scope.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/cross-process-lock.test.mjs", args: ["--test"] },
+  { group: "core-regression", runner: "node", file: "test/preference-slots.test.mjs", args: ["--test"] },
+  { group: "core-regression", runner: "node", file: "test/is-latest-auto-supersede.test.mjs" },
+  { group: "core-regression", runner: "node", file: "test/temporal-awareness.test.mjs", args: ["--test"] },
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function normalizeArgs(args = []) {
+  return args;
+}
+
+function formatCommand(entry) {
+  return [entry.runner, ...normalizeArgs(entry.args), entry.file].join(" ");
+}
+
+function verifyGroups() {
+  for (const entry of CI_TEST_MANIFEST) {
+    if (!CI_TEST_GROUPS.includes(entry.group)) {
+      fail(`invalid CI test group: ${entry.group} for ${entry.file}`);
+    }
+  }
+}
+
+function verifyFilesExist() {
+  for (const entry of CI_TEST_MANIFEST) {
+    const absolutePath = path.resolve(repoRoot, entry.file);
+    if (!fs.existsSync(absolutePath)) {
+      fail(`missing test file on disk: ${entry.file}`);
+    }
+  }
+}
+
+function verifyExactOnceCoverage() {
+  const counts = new Map();
+  for (const entry of CI_TEST_MANIFEST) {
+    counts.set(entry.file, (counts.get(entry.file) ?? 0) + 1);
+  }
+
+  for (const expectedEntry of EXPECTED_BASELINE) {
+    const file = expectedEntry.file;
+    const count = counts.get(file) ?? 0;
+    if (count === 0) {
+      fail(`missing baseline test: ${file}`);
+    }
+    if (count > 1) {
+      fail(`duplicate test entry: ${file}`);
+    }
+  }
+
+  for (const [file, count] of counts) {
+    if (!EXPECTED_BASELINE.some((entry) => entry.file === file)) {
+      fail(`unexpected manifest entry: ${file}`);
+    }
+    if (count > 1) {
+      fail(`duplicate test entry: ${file}`);
+    }
+  }
+}
+
+function verifyExactBaseline() {
+  if (CI_TEST_MANIFEST.length !== EXPECTED_BASELINE.length) {
+    fail(`expected ${EXPECTED_BASELINE.length} baseline entries, found ${CI_TEST_MANIFEST.length}`);
+  }
+
+  for (let index = 0; index < EXPECTED_BASELINE.length; index += 1) {
+    const expected = EXPECTED_BASELINE[index];
+    const actual = CI_TEST_MANIFEST[index];
+
+    if (expected.file !== actual.file) {
+      fail(`baseline order mismatch at position ${index + 1}: expected ${expected.file}, found ${actual.file}`);
+    }
+
+    if (expected.group !== actual.group) {
+      fail(`group mismatch for ${actual.file}: expected ${expected.group}, found ${actual.group}`);
+    }
+
+    if (expected.runner !== actual.runner) {
+      fail(`runner mismatch for ${actual.file}: expected ${expected.runner}, found ${actual.runner}`);
+    }
+
+    const expectedArgs = normalizeArgs(expected.args);
+    const actualArgs = normalizeArgs(actual.args);
+    if (expectedArgs.length !== actualArgs.length || expectedArgs.some((arg, argIndex) => arg !== actualArgs[argIndex])) {
+      fail(`command mismatch for ${actual.file}: expected "${formatCommand(expected)}", found "${formatCommand(actual)}"`);
+    }
+  }
+}
+
+function main() {
+  verifyGroups();
+  verifyFilesExist();
+  verifyExactOnceCoverage();
+  verifyExactBaseline();
+  console.log(`CI test manifest covers baseline exactly once (${EXPECTED_BASELINE.length} entries)`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- split the monolithic `CI / cli-smoke` workflow job into explicit grouped jobs while preserving the existing `cli-smoke` check name
- add a shared CI test manifest plus runner/verifier scripts so grouped jobs and local `npm test` stay aligned with the baseline suite
- align the grouped manifest with `master`'s current 34-test baseline, including `test/is-latest-auto-supersede.test.mjs` and `test/temporal-awareness.test.mjs`

## Why
`CI / cli-smoke` currently runs the entire Node test suite, so failures in storage, smart extractor, auth, or packaging regressions all surface as a misleading CLI smoke failure. This change makes the fast smoke path explicit while keeping the rest of the suite required and visible as separate checks.

## Impact
- `CI / cli-smoke` now only runs the fast CLI smoke path
- new required-check candidates become visible separately: `core-regression`, `storage-and-schema`, `llm-clients-and-auth`, and `packaging-and-workflow`
- `npm test` still runs the full suite, now via grouped `test:*` scripts guarded by a manifest verifier

## Validation
- `node scripts/verify-ci-test-manifest.mjs`
- `npm test`

## Rollout
After this lands on `master`, wait for the default branch to emit the new check names before adding them to branch protection as required checks.
