### PR TITLE
docs: fix sessionMemory.enabled vs sessionStrategy config guidance (#540)

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ Query → BM25 FTS ─────┘
       "discord-bot": ["global", "agent:discord-bot"]
     }
   },
+  "sessionStrategy": "none",
   "sessionMemory": {
     "enabled": false,
     "messageCount": 15

--- a/README_CN.md
+++ b/README_CN.md
@@ -447,6 +447,7 @@ git clone https://github.com/CortexReach/memory-lancedb-pro-skill.git ~/.opencla
       "discord-bot": ["global", "agent:discord-bot"]
     }
   },
+  "sessionStrategy": "none",
   "sessionMemory": {
     "enabled": false,
     "messageCount": 15

--- a/docs/openclaw-integration-playbook.md
+++ b/docs/openclaw-integration-playbook.md
@@ -44,8 +44,10 @@ Use this when you also want `/new` to write a searchable session summary into La
 
 In this mode:
 
-- enable plugin `sessionMemory.enabled`
+- set plugin `sessionStrategy: "memoryReflection"` for LLM-powered reflection (structured extraction, dedup, lifecycle scoring)
 - decide whether OpenClaw built-in `session-memory` should also remain enabled
+
+> **Note:** The legacy `sessionMemory.enabled = true` maps to `systemSessionMemory` (simple session summary stored directly in LanceDB), not `memoryReflection`. If you need the full reflection pipeline, use `sessionStrategy` explicitly.
 
 If both are enabled, `/new` can produce two outputs:
 
@@ -58,28 +60,46 @@ That is valid, but it is a double-write design. If you do not want duplicated se
 
 For most users, use one of these patterns.
 
-### Option 1: Built-in only
+### Option 1: Disabled (no plugin session hooks)
 
-Choose this when you mainly want transcript persistence and workspace summaries.
+Choose this when you mainly want transcript persistence and workspace summaries without plugin involvement.
 
-- plugin `sessionMemory.enabled = false`
+- plugin `sessionStrategy: "none"` (or omit `sessionStrategy` entirely)
 - OpenClaw built-in `hooks.internal.entries.session-memory.enabled = true`
 
-### Option 2: Plugin only
+### Option 2: Plugin only (LLM reflection)
 
-Choose this when you want session summaries to participate in LanceDB retrieval, dedupe, and lifecycle scoring.
+Choose this when you want session summaries to participate in LanceDB retrieval with LLM-powered structured extraction, dedup, and lifecycle scoring.
 
-- plugin `sessionMemory.enabled = true`
+- plugin `sessionStrategy: "memoryReflection"`
 - OpenClaw built-in `hooks.internal.entries.session-memory.enabled = false`
 
-### Option 3: Dual write
+### Option 3: Plugin only (simple summary)
+
+Choose this when you want session summaries stored in LanceDB but do not need the full LLM reflection pipeline.
+
+- plugin `sessionStrategy: "systemSessionMemory"`
+- OpenClaw built-in `hooks.internal.entries.session-memory.enabled = false`
+
+This writes a plain session summary directly into LanceDB as `fact` / `peripheral` tier entries, without LLM-driven dedup or lifecycle scoring.
+
+### Option 4: Dual write
 
 Choose this only if you explicitly want both:
 
-- workspace markdown/session artifacts
-- LanceDB-searchable session memories
+- workspace markdown/session artifacts (via built-in session-memory)
+- LanceDB-searchable session memories (via plugin `sessionStrategy`)
 
 If you use dual write, document it for your team. Otherwise it will look like duplicate behavior during debugging.
+
+### Strategy comparison
+
+| Configuration | Strategy | Behavior |
+|---|---|---|
+| `sessionStrategy: "memoryReflection"` | memoryReflection | LLM-powered reflection: structured extraction, dedup, lifecycle scoring |
+| `sessionStrategy: "systemSessionMemory"` | systemSessionMemory | Simple session summary stored directly in LanceDB as fact/peripheral |
+| `sessionMemory: { enabled: true }` | systemSessionMemory | Legacy shorthand, same as `systemSessionMemory` above |
+| `sessionStrategy: "none"` or omitted | none | Plugin session hooks disabled |
 
 ## 3. Baseline Verification Checklist
 
@@ -292,7 +312,7 @@ Check in this order:
 
 Check:
 
-- plugin session memory is enabled
+- plugin `sessionStrategy` is set to `"memoryReflection"` or `"systemSessionMemory"` (not `"none"`)
 - plugin hook is actually registered and named
 - gateway has been restarted after the hook/config change
 - built-in hook state matches your intended design

--- a/docs/openclaw-integration-playbook.zh-CN.md
+++ b/docs/openclaw-integration-playbook.zh-CN.md
@@ -46,8 +46,10 @@
 
 这时需要：
 
-- 开启插件 `sessionMemory.enabled`
+- 设置插件 `sessionStrategy: "memoryReflection"`（LLM 结构化反思：去重、错误追踪、lifecycle 评分）
 - 明确决定是否保留 OpenClaw 内置 `session-memory`
+
+> **注意：** 旧版 `sessionMemory.enabled = true` 实际映射为 `systemSessionMemory`（简单摘要直存 LanceDB），而非 `memoryReflection`。如需完整反思管线，请显式使用 `sessionStrategy`。
 
 如果两者同时开启，`/new` 可能产生两类结果：
 
@@ -60,7 +62,7 @@
 
 大部分场景推荐三选一，而不是默认双开。
 
-### 方案 1：只用内置 session-memory
+### 方案 1：禁用（不启用插件 session hook）
 
 适合：
 
@@ -69,29 +71,52 @@
 
 建议配置：
 
-- 插件 `sessionMemory.enabled = false`
+- 插件 `sessionStrategy: "none"`（或不设置 `sessionStrategy`）
 - OpenClaw `hooks.internal.entries.session-memory.enabled = true`
 
-### 方案 2：只用插件 session memory
+### 方案 2：只用插件（LLM 反思模式）
 
 适合：
 
 - 希望 session summary 进入 LanceDB
-- 需要后续参与去重、生命周期排序、统一检索
+- 需要 LLM 结构化提取、去重、lifecycle 评分
 
 建议配置：
 
-- 插件 `sessionMemory.enabled = true`
+- 插件 `sessionStrategy: "memoryReflection"`
 - OpenClaw `hooks.internal.entries.session-memory.enabled = false`
 
-### 方案 3：双写
+### 方案 3：只用插件（简单摘要模式）
+
+适合：
+
+- 希望 session summary 存入 LanceDB
+- 不需要 LLM 反思管线
+
+建议配置：
+
+- 插件 `sessionStrategy: "systemSessionMemory"`
+- OpenClaw `hooks.internal.entries.session-memory.enabled = false`
+
+此模式将会话摘要直接写入 LanceDB，存为 `fact` / `peripheral` 层级条目，不经过 LLM 去重或 lifecycle 评分。
+
+### 方案 4：双写
 
 只在你明确需要以下两类产物时使用：
 
-- workspace 中的摘要文件
-- LanceDB 中可检索的 session 记忆
+- workspace 中的摘要文件（通过内置 session-memory）
+- LanceDB 中可检索的 session 记忆（通过插件 `sessionStrategy`）
 
 若采用双写，建议在团队文档中写清楚，否则后续维护者容易把它误判成重复存储问题。
+
+### 策略对照表
+
+| 配置方式 | 策略 | 行为 |
+|---|---|---|
+| `sessionStrategy: "memoryReflection"` | memoryReflection | LLM 结构化反思：提取、去重、lifecycle 评分 |
+| `sessionStrategy: "systemSessionMemory"` | systemSessionMemory | 简单会话摘要直存 LanceDB（fact/peripheral 层级） |
+| `sessionMemory: { enabled: true }` | systemSessionMemory | 旧版简写，等同于上面的 `systemSessionMemory` |
+| `sessionStrategy: "none"` 或不设置 | none | 插件 session hook 不启用 |
 
 ## 3. 基线检查清单
 
@@ -304,7 +329,7 @@ openclaw memory-pro search "your test keyword" --scope global --limit 5
 
 优先检查：
 
-- 插件 `sessionMemory` 是否开启
+- 插件 `sessionStrategy` 是否设为 `"memoryReflection"` 或 `"systemSessionMemory"`（而非 `"none"`）
 - 插件 Hook 是否真的注册成功且有名字
 - 改完配置后 Gateway 是否已重启
 - 内置 Hook 状态是否符合当前设计


### PR DESCRIPTION
## Summary

Fixes #540. The Integration Playbook incorrectly documented `sessionMemory.enabled = true` as enabling plugin-only session memory with LLM reflection features. In reality, this legacy flag maps to `systemSessionMemory` (simple summary storage), not `memoryReflection`.

### Changes
- Updated playbook Mode B description to reference `sessionStrategy: "memoryReflection"` with legacy mapping note
- Replaced Options 1/2/3 with four explicit options using `sessionStrategy` field: `none`, `memoryReflection`, `systemSessionMemory`, dual write
- Added strategy comparison table clarifying all three strategies and the legacy shorthand
- Updated troubleshooting section to reference `sessionStrategy` instead of `sessionMemory`
- Added `sessionStrategy` field to full config reference in README.md and README_CN.md
- Synced all changes between English and Chinese playbook versions

### Verification
- [x] Confirmed config mapping against source code (`index.ts` lines 3901-3910): `sessionMemory.enabled = true` resolves to `"systemSessionMemory"`, not `"memoryReflection"`
- [x] Cross-checked with `SessionStrategy` type definition: `"memoryReflection" | "systemSessionMemory" | "none"`
- [x] EN and CN playbooks consistent
- [x] README changes limited to adding `sessionStrategy` in full config reference (no changes to quick-start examples which correctly use `sessionMemory.enabled: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)