### PR TITLE
fix: move backup timer setup to register() for late-loading plugins

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3605,6 +3605,7 @@ const memoryLanceDBProPlugin = {
     // Auto-Backup (daily JSONL export)
     // ========================================================================
 
+    let backupInitialTimeout: ReturnType<typeof setTimeout> | null = null;
     let backupTimer: ReturnType<typeof setInterval> | null = null;
     const BACKUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
@@ -3652,6 +3653,32 @@ const memoryLanceDBProPlugin = {
       } catch (err) {
         api.logger.warn(`memory-lancedb-pro: backup failed: ${String(err)}`);
       }
+    }
+
+    function clearBackupTimers() {
+      if (backupInitialTimeout) {
+        clearTimeout(backupInitialTimeout);
+        backupInitialTimeout = null;
+      }
+      if (backupTimer) {
+        clearInterval(backupTimer);
+        backupTimer = null;
+      }
+    }
+
+    function setupBackupTimers() {
+      if (backupInitialTimeout || backupTimer) return;
+
+      api.logger.info("memory-lancedb-pro: setting up auto-backup");
+
+      backupInitialTimeout = setTimeout(() => {
+        backupInitialTimeout = null;
+        void runBackup();
+      }, 60_000);
+      backupInitialTimeout.unref?.();
+
+      backupTimer = setInterval(() => void runBackup(), BACKUP_INTERVAL_MS);
+      backupTimer.unref?.();
     }
 
     // ========================================================================
@@ -3750,23 +3777,13 @@ const memoryLanceDBProPlugin = {
         // even when plugin is registered after gateway startup.
       },
       stop: async () => {
-        if (backupTimer) {
-          clearInterval(backupTimer);
-          backupTimer = null;
-        }
+        clearBackupTimers();
         api.logger.info("memory-lancedb-pro: stopped");
       },
     });
 
-    // CRITICAL FIX: Set backup timer in register() instead of start().
-    // This ensures backups work even when plugin is registered after gateway startup
-    // (e.g., when plugin is loaded on-demand by agent session).
-    if (!backupTimer) {
-      api.logger.info("memory-lancedb-pro: setting up auto-backup");
-      // Run initial backup after a short delay, then schedule daily
-      setTimeout(() => void runBackup(), 60_000); // 1 min after register
-      backupTimer = setInterval(() => void runBackup(), BACKUP_INTERVAL_MS);
-    }
+    // Set backup timers in register() so late-loaded plugins still auto-backup.
+    setupBackupTimers();
   },
 };
 

--- a/index.ts
+++ b/index.ts
@@ -3746,9 +3746,8 @@ const memoryLanceDBProPlugin = {
           }
         }, 5_000);
 
-        // Run initial backup after a short delay, then schedule daily
-        setTimeout(() => void runBackup(), 60_000); // 1 min after start
-        backupTimer = setInterval(() => void runBackup(), BACKUP_INTERVAL_MS);
+        // Note: Backup timer is now set in register() to ensure it works
+        // even when plugin is registered after gateway startup.
       },
       stop: async () => {
         if (backupTimer) {
@@ -3758,6 +3757,16 @@ const memoryLanceDBProPlugin = {
         api.logger.info("memory-lancedb-pro: stopped");
       },
     });
+
+    // CRITICAL FIX: Set backup timer in register() instead of start().
+    // This ensures backups work even when plugin is registered after gateway startup
+    // (e.g., when plugin is loaded on-demand by agent session).
+    if (!backupTimer) {
+      api.logger.info("memory-lancedb-pro: setting up auto-backup");
+      // Run initial backup after a short delay, then schedule daily
+      setTimeout(() => void runBackup(), 60_000); // 1 min after register
+      backupTimer = setInterval(() => void runBackup(), BACKUP_INTERVAL_MS);
+    }
   },
 };
 

--- a/index.ts
+++ b/index.ts
@@ -1615,6 +1615,39 @@ const pluginVersion = getPluginVersion();
 // Plugin Definition
 // ============================================================================
 
+interface PluginLifecycleState {
+  resolvedDbPath: string;
+  token: number;
+  stopped: boolean;
+  backupInitialTimeout: ReturnType<typeof setTimeout> | null;
+  backupTimer: ReturnType<typeof setInterval> | null;
+  startupChecksTimeout: ReturnType<typeof setTimeout> | null;
+  legacyScanTimeout: ReturnType<typeof setTimeout> | null;
+}
+
+let nextLifecycleToken = 1;
+
+const _activeLifecyclesByDbPath = new Map<string, PluginLifecycleState>();
+
+function clearLifecycleTimers(lifecycle: PluginLifecycleState) {
+  if (lifecycle.backupInitialTimeout) {
+    clearTimeout(lifecycle.backupInitialTimeout);
+    lifecycle.backupInitialTimeout = null;
+  }
+  if (lifecycle.backupTimer) {
+    clearInterval(lifecycle.backupTimer);
+    lifecycle.backupTimer = null;
+  }
+  if (lifecycle.startupChecksTimeout) {
+    clearTimeout(lifecycle.startupChecksTimeout);
+    lifecycle.startupChecksTimeout = null;
+  }
+  if (lifecycle.legacyScanTimeout) {
+    clearTimeout(lifecycle.legacyScanTimeout);
+    lifecycle.legacyScanTimeout = null;
+  }
+}
+
 // WeakSet keyed by API instance — each distinct API object tracks its own initialized state.
 // Using WeakSet instead of a module-level boolean avoids the "second register() call skips
 // hook/tool registration for the new API instance" regression that rwmjhb identified.
@@ -1639,6 +1672,15 @@ const memoryLanceDBProPlugin = {
     const config = parsePluginConfig(api.pluginConfig);
 
     const resolvedDbPath = api.resolvePath(config.dbPath || getDefaultDbPath());
+    const lifecycle: PluginLifecycleState = {
+      resolvedDbPath,
+      token: nextLifecycleToken++,
+      stopped: false,
+      backupInitialTimeout: null,
+      backupTimer: null,
+      startupChecksTimeout: null,
+      legacyScanTimeout: null,
+    };
 
     // Pre-flight: validate storage path (symlink resolution, mkdir, write check).
     // Runs synchronously and logs warnings; does NOT block gateway startup.
@@ -3605,11 +3647,34 @@ const memoryLanceDBProPlugin = {
     // Auto-Backup (daily JSONL export)
     // ========================================================================
 
-    let backupInitialTimeout: ReturnType<typeof setTimeout> | null = null;
-    let backupTimer: ReturnType<typeof setInterval> | null = null;
     const BACKUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+    const INITIAL_BACKUP_DELAY_MS = 60_000;
+    const LEGACY_SCAN_DELAY_MS = 5_000;
 
-    async function runBackup() {
+    const isLifecycleActive = (token = lifecycle.token) =>
+      !lifecycle.stopped
+      && _activeLifecyclesByDbPath.get(resolvedDbPath)?.token === token;
+
+    const stopLifecycle = () => {
+      lifecycle.stopped = true;
+      clearLifecycleTimers(lifecycle);
+      if (_activeLifecyclesByDbPath.get(resolvedDbPath)?.token === lifecycle.token) {
+        _activeLifecyclesByDbPath.delete(resolvedDbPath);
+      }
+    };
+
+    const replacedLifecycle = _activeLifecyclesByDbPath.get(resolvedDbPath);
+    if (replacedLifecycle) {
+      replacedLifecycle.stopped = true;
+      clearLifecycleTimers(replacedLifecycle);
+      api.logger.info(
+        "memory-lancedb-pro: replaced existing runtime for the same dbPath during register()",
+      );
+    }
+    _activeLifecyclesByDbPath.set(resolvedDbPath, lifecycle);
+
+    async function runBackup(token = lifecycle.token) {
+      if (!isLifecycleActive(token)) return;
       try {
         const backupDir = api.resolvePath(
           join(resolvedDbPath, "..", "backups"),
@@ -3617,6 +3682,7 @@ const memoryLanceDBProPlugin = {
         await mkdir(backupDir, { recursive: true });
 
         const allMemories = await store.list(undefined, undefined, 10000, 0);
+        if (!isLifecycleActive(token)) return;
         if (allMemories.length === 0) return;
 
         const dateStr = new Date().toISOString().split("T")[0];
@@ -3651,34 +3717,32 @@ const memoryLanceDBProPlugin = {
           `memory-lancedb-pro: backup completed (${allMemories.length} entries → ${backupFile})`,
         );
       } catch (err) {
+        if (!isLifecycleActive(token)) return;
         api.logger.warn(`memory-lancedb-pro: backup failed: ${String(err)}`);
       }
     }
 
     function clearBackupTimers() {
-      if (backupInitialTimeout) {
-        clearTimeout(backupInitialTimeout);
-        backupInitialTimeout = null;
-      }
-      if (backupTimer) {
-        clearInterval(backupTimer);
-        backupTimer = null;
-      }
+      clearLifecycleTimers(lifecycle);
     }
 
     function setupBackupTimers() {
-      if (backupInitialTimeout || backupTimer) return;
+      if (lifecycle.backupInitialTimeout || lifecycle.backupTimer) return;
 
       api.logger.info("memory-lancedb-pro: setting up auto-backup");
 
-      backupInitialTimeout = setTimeout(() => {
-        backupInitialTimeout = null;
+      lifecycle.backupInitialTimeout = setTimeout(() => {
+        lifecycle.backupInitialTimeout = null;
+        if (!isLifecycleActive()) return;
         void runBackup();
-      }, 60_000);
-      backupInitialTimeout.unref?.();
+      }, INITIAL_BACKUP_DELAY_MS);
+      lifecycle.backupInitialTimeout.unref?.();
 
-      backupTimer = setInterval(() => void runBackup(), BACKUP_INTERVAL_MS);
-      backupTimer.unref?.();
+      lifecycle.backupTimer = setInterval(() => {
+        if (!isLifecycleActive()) return;
+        void runBackup();
+      }, BACKUP_INTERVAL_MS);
+      lifecycle.backupTimer.unref?.();
     }
 
     // ========================================================================
@@ -3703,6 +3767,7 @@ const memoryLanceDBProPlugin = {
               () => reject(new Error(`${label} timed out after ${ms}ms`)),
               ms,
             );
+            timeout.unref?.();
           });
           try {
             return await Promise.race([p, timeoutPromise]);
@@ -3711,7 +3776,8 @@ const memoryLanceDBProPlugin = {
           }
         };
 
-        const runStartupChecks = async () => {
+        const runStartupChecks = async (token = lifecycle.token) => {
+          if (!isLifecycleActive(token)) return;
           try {
             // Test components (bounded time)
             const embedTest = await withTimeout(
@@ -3724,6 +3790,7 @@ const memoryLanceDBProPlugin = {
               8_000,
               "retriever.test()",
             );
+            if (!isLifecycleActive(token)) return;
 
             api.logger.info(
               `memory-lancedb-pro: initialized successfully ` +
@@ -3748,6 +3815,7 @@ const memoryLanceDBProPlugin = {
             embedHealth = { ok: !!embedTest.success, error: embedTest.error };
             retrievalHealth = !!retrievalTest.success;
           } catch (error) {
+            if (!isLifecycleActive(token)) return;
             api.logger.warn(
               `memory-lancedb-pro: startup checks failed: ${String(error)}`,
             );
@@ -3755,13 +3823,27 @@ const memoryLanceDBProPlugin = {
         };
 
         // Fire-and-forget: allow gateway to start serving immediately.
-        setTimeout(() => void runStartupChecks(), 0);
+        if (lifecycle.startupChecksTimeout) {
+          clearTimeout(lifecycle.startupChecksTimeout);
+        }
+        lifecycle.startupChecksTimeout = setTimeout(() => {
+          lifecycle.startupChecksTimeout = null;
+          if (!isLifecycleActive()) return;
+          void runStartupChecks();
+        }, 0);
+        lifecycle.startupChecksTimeout.unref?.();
 
         // Check for legacy memories that could be upgraded
-        setTimeout(async () => {
+        if (lifecycle.legacyScanTimeout) {
+          clearTimeout(lifecycle.legacyScanTimeout);
+        }
+        lifecycle.legacyScanTimeout = setTimeout(async () => {
+          lifecycle.legacyScanTimeout = null;
+          if (!isLifecycleActive()) return;
           try {
             const upgrader = createMemoryUpgrader(store, null);
             const counts = await upgrader.countLegacy();
+            if (!isLifecycleActive()) return;
             if (counts.legacy > 0) {
               api.logger.info(
                 `memory-lancedb-pro: found ${counts.legacy} legacy memories (of ${counts.total} total) that can be upgraded to the new smart memory format. ` +
@@ -3771,13 +3853,14 @@ const memoryLanceDBProPlugin = {
           } catch {
             // Non-critical: silently ignore
           }
-        }, 5_000);
+        }, LEGACY_SCAN_DELAY_MS);
+        lifecycle.legacyScanTimeout.unref?.();
 
         // Note: Backup timer is now set in register() to ensure it works
         // even when plugin is registered after gateway startup.
       },
       stop: async () => {
-        clearBackupTimers();
+        stopLifecycle();
         api.logger.info("memory-lancedb-pro: stopped");
       },
     });

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -56,6 +56,77 @@ function createMockApi(pluginConfig, options = {}) {
   };
 }
 
+async function withFakeTimers(run) {
+  const realSetTimeout = globalThis.setTimeout;
+  const realSetInterval = globalThis.setInterval;
+  const realClearTimeout = globalThis.clearTimeout;
+  const realClearInterval = globalThis.clearInterval;
+
+  let nextId = 1;
+  const timeouts = [];
+  const intervals = [];
+  const clearedTimeouts = [];
+  const clearedIntervals = [];
+  const unrefTimeouts = [];
+  const unrefIntervals = [];
+
+  globalThis.setTimeout = ((fn, delay, ...args) => {
+    const handle = {
+      id: nextId++,
+      kind: "timeout",
+      delay,
+      fn,
+      args,
+      unref() {
+        unrefTimeouts.push(this.id);
+        return this;
+      },
+    };
+    timeouts.push(handle);
+    return handle;
+  });
+
+  globalThis.setInterval = ((fn, delay, ...args) => {
+    const handle = {
+      id: nextId++,
+      kind: "interval",
+      delay,
+      fn,
+      args,
+      unref() {
+        unrefIntervals.push(this.id);
+        return this;
+      },
+    };
+    intervals.push(handle);
+    return handle;
+  });
+
+  globalThis.clearTimeout = ((handle) => {
+    clearedTimeouts.push(handle?.id ?? null);
+  });
+
+  globalThis.clearInterval = ((handle) => {
+    clearedIntervals.push(handle?.id ?? null);
+  });
+
+  try {
+    await run({
+      timeouts,
+      intervals,
+      clearedTimeouts,
+      clearedIntervals,
+      unrefTimeouts,
+      unrefIntervals,
+    });
+  } finally {
+    globalThis.setTimeout = realSetTimeout;
+    globalThis.setInterval = realSetInterval;
+    globalThis.clearTimeout = realClearTimeout;
+    globalThis.clearInterval = realClearInterval;
+  }
+}
+
 for (const key of [
   "smartExtraction",
   "extractMinMessages",
@@ -135,6 +206,97 @@ const services = [];
 const embeddingRequests = [];
 
 try {
+  await withFakeTimers(async ({
+    timeouts,
+    intervals,
+    clearedTimeouts,
+    clearedIntervals,
+    unrefTimeouts,
+    unrefIntervals,
+  }) => {
+    const timerServices = [];
+    const firstTimerApi = createMockApi(
+      {
+        dbPath: path.join(workDir, "db-backup-timers-1"),
+        autoCapture: false,
+        autoRecall: false,
+        embedding: {
+          provider: "openai-compatible",
+          apiKey: "dummy",
+          model: "text-embedding-3-small",
+          baseURL: "http://127.0.0.1:9/v1",
+          dimensions: 1536,
+        },
+      },
+      { services: timerServices },
+    );
+
+    plugin.register(firstTimerApi);
+    const firstBackupTimeout = timeouts.find((handle) => handle.delay === 60_000);
+    const firstBackupInterval = intervals.find((handle) => handle.delay === 24 * 60 * 60 * 1000);
+
+    assert.ok(firstBackupTimeout, "register() should arm the initial backup timeout");
+    assert.ok(firstBackupInterval, "register() should arm the recurring backup interval");
+    assert.ok(
+      unrefTimeouts.includes(firstBackupTimeout.id),
+      "initial backup timeout should be unref()'d so register-only tests can exit",
+    );
+    assert.ok(
+      unrefIntervals.includes(firstBackupInterval.id),
+      "backup interval should be unref()'d so register-only tests can exit",
+    );
+
+    await assert.doesNotReject(
+      timerServices[0].stop(),
+      "service stop should clear backup timers without throwing",
+    );
+    assert.ok(
+      clearedTimeouts.includes(firstBackupTimeout.id),
+      "stop() should clear the initial backup timeout",
+    );
+    assert.ok(
+      clearedIntervals.includes(firstBackupInterval.id),
+      "stop() should clear the recurring backup interval",
+    );
+
+    const secondTimerServices = [];
+    const secondTimerApi = createMockApi(
+      {
+        dbPath: path.join(workDir, "db-backup-timers-2"),
+        autoCapture: false,
+        autoRecall: false,
+        embedding: {
+          provider: "openai-compatible",
+          apiKey: "dummy",
+          model: "text-embedding-3-small",
+          baseURL: "http://127.0.0.1:9/v1",
+          dimensions: 1536,
+        },
+      },
+      { services: secondTimerServices },
+    );
+
+    plugin.register(secondTimerApi);
+    const backupTimeouts = timeouts.filter((handle) => handle.delay === 60_000);
+    const backupIntervals = intervals.filter((handle) => handle.delay === 24 * 60 * 60 * 1000);
+
+    assert.equal(backupTimeouts.length, 2, "re-register should create one fresh initial backup timeout");
+    assert.equal(backupIntervals.length, 2, "re-register should create one fresh recurring backup interval");
+
+    await assert.doesNotReject(
+      secondTimerServices[0].stop(),
+      "second service stop should also clear backup timers without throwing",
+    );
+    assert.ok(
+      clearedTimeouts.includes(backupTimeouts[1].id),
+      "second stop() should clear the re-armed initial backup timeout",
+    );
+    assert.ok(
+      clearedIntervals.includes(backupIntervals[1].id),
+      "second stop() should clear the re-armed recurring backup interval",
+    );
+  });
+
   const api = createMockApi(
     {
       dbPath: path.join(workDir, "db"),

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -26,10 +26,12 @@ const pkg = JSON.parse(
 );
 
 function createMockApi(pluginConfig, options = {}) {
+  const services = options.services ?? [];
   return {
     pluginConfig,
     hooks: {},
     toolFactories: {},
+    services,
     logger: {
       info() {},
       warn() {},
@@ -45,7 +47,7 @@ function createMockApi(pluginConfig, options = {}) {
     },
     registerCli() {},
     registerService(service) {
-      options.services?.push(service);
+      services.push(service);
     },
     on(name, handler) {
       this.hooks[name] = handler;
@@ -54,6 +56,12 @@ function createMockApi(pluginConfig, options = {}) {
       this.hooks[name] = handler;
     },
   };
+}
+
+async function stopRegisteredServices(api) {
+  await Promise.allSettled(
+    (api.services ?? []).map((service) => service?.stop?.()),
+  );
 }
 
 async function withFakeTimers(run) {
@@ -247,8 +255,25 @@ try {
     );
 
     await assert.doesNotReject(
+      timerServices[0].start(),
+      "service start should schedule startup lifecycle timers without throwing",
+    );
+    const startupChecksTimeout = timeouts.find((handle) => handle.delay === 0);
+    const legacyScanTimeout = timeouts.find((handle) => handle.delay === 5_000);
+    assert.ok(startupChecksTimeout, "start() should arm the startup checks timeout");
+    assert.ok(legacyScanTimeout, "start() should arm the legacy scan timeout");
+    assert.ok(
+      unrefTimeouts.includes(startupChecksTimeout.id),
+      "startup checks timeout should be unref()'d so tests can exit",
+    );
+    assert.ok(
+      unrefTimeouts.includes(legacyScanTimeout.id),
+      "legacy scan timeout should be unref()'d so tests can exit",
+    );
+
+    await assert.doesNotReject(
       timerServices[0].stop(),
-      "service stop should clear backup timers without throwing",
+      "service stop should clear lifecycle timers without throwing",
     );
     assert.ok(
       clearedTimeouts.includes(firstBackupTimeout.id),
@@ -257,6 +282,14 @@ try {
     assert.ok(
       clearedIntervals.includes(firstBackupInterval.id),
       "stop() should clear the recurring backup interval",
+    );
+    assert.ok(
+      clearedTimeouts.includes(startupChecksTimeout.id),
+      "stop() should clear the startup checks timeout",
+    );
+    assert.ok(
+      clearedTimeouts.includes(legacyScanTimeout.id),
+      "stop() should clear the legacy scan timeout",
     );
 
     const secondTimerServices = [];
@@ -294,6 +327,74 @@ try {
     assert.ok(
       clearedIntervals.includes(backupIntervals[1].id),
       "second stop() should clear the re-armed recurring backup interval",
+    );
+
+    const hotReloadPath = path.join(workDir, "db-backup-hot-reload");
+    const hotReloadFirstApi = createMockApi(
+      {
+        dbPath: hotReloadPath,
+        autoCapture: false,
+        autoRecall: false,
+        embedding: {
+          provider: "openai-compatible",
+          apiKey: "dummy",
+          model: "text-embedding-3-small",
+          baseURL: "http://127.0.0.1:9/v1",
+          dimensions: 1536,
+        },
+      },
+      { services: [] },
+    );
+    plugin.register(hotReloadFirstApi);
+    const hotReloadTimeoutBefore = timeouts.at(-1);
+    const hotReloadIntervalBefore = intervals.at(-1);
+    assert.equal(hotReloadTimeoutBefore?.delay, 60_000);
+    assert.equal(hotReloadIntervalBefore?.delay, 24 * 60 * 60 * 1000);
+
+    const hotReloadSecondApi = createMockApi(
+      {
+        dbPath: hotReloadPath,
+        autoCapture: false,
+        autoRecall: false,
+        embedding: {
+          provider: "openai-compatible",
+          apiKey: "dummy",
+          model: "text-embedding-3-small",
+          baseURL: "http://127.0.0.1:9/v1",
+          dimensions: 1536,
+        },
+      },
+      { services: [] },
+    );
+    plugin.register(hotReloadSecondApi);
+    const hotReloadTimeoutAfter = timeouts.at(-1);
+    const hotReloadIntervalAfter = intervals.at(-1);
+    assert.notEqual(
+      hotReloadTimeoutAfter?.id,
+      hotReloadTimeoutBefore?.id,
+      "same-path re-register should replace the initial backup timeout",
+    );
+    assert.notEqual(
+      hotReloadIntervalAfter?.id,
+      hotReloadIntervalBefore?.id,
+      "same-path re-register should replace the recurring backup interval",
+    );
+    assert.ok(
+      clearedTimeouts.includes(hotReloadTimeoutBefore.id),
+      "same-path re-register should clear the previous initial backup timeout",
+    );
+    assert.ok(
+      clearedIntervals.includes(hotReloadIntervalBefore.id),
+      "same-path re-register should clear the previous recurring backup interval",
+    );
+
+    await assert.doesNotReject(
+      stopRegisteredServices(hotReloadFirstApi),
+      "stale hot-reload service stop should be harmless",
+    );
+    await assert.doesNotReject(
+      stopRegisteredServices(hotReloadSecondApi),
+      "active hot-reload service stop should be harmless",
     );
   });
 
@@ -340,6 +441,7 @@ try {
     "function",
     "command:new hook should be registered (selfImprovement default-on since #391)",
   );
+  await stopRegisteredServices(sessionDefaultApi);
 
   const sessionEnabledApi = createMockApi({
     dbPath: path.join(workDir, "db-session-enabled"),
@@ -366,6 +468,7 @@ try {
     "function",
     "command:new hook should be registered (selfImprovement default-on since #391)",
   );
+  await stopRegisteredServices(sessionEnabledApi);
 
   const longText = `${"Long embedding payload. ".repeat(420)}tail`;
   const threshold = 6000;
@@ -528,6 +631,11 @@ try {
       false,
       "embedding.omitDimensions=true should omit dimensions from embedding requests",
     );
+
+    await stopRegisteredServices(chunkingOffApi);
+    await stopRegisteredServices(chunkingOnApi);
+    await stopRegisteredServices(withDimensionsApi);
+    await stopRegisteredServices(omitDimensionsApi);
   } finally {
     await new Promise((resolve) => embeddingServer.close(resolve));
   }

--- a/test/resolve-env-vars-array.test.mjs
+++ b/test/resolve-env-vars-array.test.mjs
@@ -50,6 +50,7 @@ async function withTestEnv(apiKeyConfig, fn) {
   const dbPath = path.join(workDir, "test.db");
   const embeddingServer = createEmbeddingServer();
   const llmServer = createLlmServer();
+  let api;
   await new Promise((r) => embeddingServer.listen(0, "127.0.0.1", r));
   await new Promise((r) => llmServer.listen(0, "127.0.0.1", r));
   const ePort = embeddingServer.address().port;
@@ -57,7 +58,7 @@ async function withTestEnv(apiKeyConfig, fn) {
 
   try {
     const logs = [];
-    const api = {
+    api = {
       pluginConfig: {
         dbPath,
         autoCapture: false,
@@ -99,6 +100,7 @@ async function withTestEnv(apiKeyConfig, fn) {
     plugin.register(api);
     await fn(logs);
   } finally {
+    await Promise.allSettled((api?.services ?? []).map((service) => service?.stop?.()));
     await new Promise((r) => embeddingServer.close(r));
     await new Promise((r) => llmServer.close(r));
     rmSync(workDir, { recursive: true, force: true });

--- a/test/session-summary-before-reset.test.mjs
+++ b/test/session-summary-before-reset.test.mjs
@@ -83,9 +83,11 @@ describe("systemSessionMemory before_reset", () => {
   let workDir;
   let embeddingServer;
   let embeddingBaseURL;
+  let apis;
 
   beforeEach(async () => {
     workDir = mkdtempSync(path.join(tmpdir(), "memory-session-summary-"));
+    apis = [];
     embeddingServer = createEmbeddingServer();
     await new Promise((resolve) => embeddingServer.listen(0, "127.0.0.1", resolve));
     const port = embeddingServer.address().port;
@@ -93,6 +95,9 @@ describe("systemSessionMemory before_reset", () => {
   });
 
   afterEach(async () => {
+    await Promise.allSettled(
+      apis.flatMap((api) => (api.services ?? []).map((service) => service?.stop?.())),
+    );
     await new Promise((resolve) => embeddingServer.close(resolve));
     rmSync(workDir, { recursive: true, force: true });
   });
@@ -100,6 +105,7 @@ describe("systemSessionMemory before_reset", () => {
   it("stores a session-summary row for /new using before_reset messages", async () => {
     const dbPath = path.join(workDir, "db");
     const api = createApiHarness({ dbPath, embeddingBaseURL });
+    apis.push(api);
 
     memoryLanceDBProPlugin.register(api);
 
@@ -141,6 +147,7 @@ describe("systemSessionMemory before_reset", () => {
   it("skips writes for /reset", async () => {
     const dbPath = path.join(workDir, "db-reset");
     const api = createApiHarness({ dbPath, embeddingBaseURL });
+    apis.push(api);
 
     memoryLanceDBProPlugin.register(api);
 

--- a/test/smart-extractor-branches.mjs
+++ b/test/smart-extractor-branches.mjs
@@ -28,6 +28,8 @@ const EMBEDDING_DIMENSIONS = 2560;
 // mock embeddings do not accidentally classify normal user text as noise.
 NoisePrototypeBank.prototype.isNoise = () => false;
 
+const registeredServices = new Set();
+
 function createDeterministicEmbedding(text, dimensions = EMBEDDING_DIMENSIONS) {
   void text;
   const value = 1 / Math.sqrt(dimensions);
@@ -133,6 +135,7 @@ function createMockApi(dbPath, embeddingBaseURL, llmBaseURL, logs) {
     registerCli() {},
     registerService(service) {
       this.services.push(service);
+      registeredServices.add(service);
     },
     on(name, handler) {
       this.hooks[name] = handler;
@@ -141,6 +144,12 @@ function createMockApi(dbPath, embeddingBaseURL, llmBaseURL, logs) {
       this.hooks[name] = handler;
     },
   };
+}
+
+async function stopRegisteredServices() {
+  const services = Array.from(registeredServices);
+  registeredServices.clear();
+  await Promise.allSettled(services.map((service) => service?.stop?.()));
 }
 
 async function runAgentEndHook(api, event, ctx) {
@@ -296,6 +305,7 @@ async function runScenario(mode) {
 
     return { entries, llmCalls, logs };
   } finally {
+    await stopRegisteredServices();
     delete process.env.TEST_EMBEDDING_BASE_URL;
     await new Promise((resolve) => embeddingServer.close(resolve));
     await new Promise((resolve) => server.close(resolve));
@@ -475,6 +485,7 @@ async function runMultiRoundScenario() {
     const entries = await freshStore.list(["agent:life"], undefined, 10, 0);
     return { entries, extractionCall, dedupCall, mergeCall, logs };
   } finally {
+    await stopRegisteredServices();
     delete process.env.TEST_EMBEDDING_BASE_URL;
     await new Promise((resolve) => embeddingServer.close(resolve));
     await new Promise((resolve) => server.close(resolve));
@@ -570,6 +581,7 @@ async function runInjectedRecallScenario() {
 
     return { llmCalls, logs };
   } finally {
+    await stopRegisteredServices();
     delete process.env.TEST_EMBEDDING_BASE_URL;
     await new Promise((resolve) => embeddingServer.close(resolve));
     await new Promise((resolve) => server.close(resolve));
@@ -664,6 +676,7 @@ async function runPrependedRecallWithUserTextScenario() {
 
     return { llmCalls, logs };
   } finally {
+    await stopRegisteredServices();
     delete process.env.TEST_EMBEDDING_BASE_URL;
     await new Promise((resolve) => embeddingServer.close(resolve));
     await new Promise((resolve) => server.close(resolve));
@@ -754,6 +767,7 @@ async function runInboundMetadataWrappedScenario() {
 
     return { llmCalls, logs };
   } finally {
+    await stopRegisteredServices();
     delete process.env.TEST_EMBEDDING_BASE_URL;
     await new Promise((resolve) => embeddingServer.close(resolve));
     await new Promise((resolve) => server.close(resolve));
@@ -827,6 +841,7 @@ async function runSessionDeltaScenario() {
 
     return logs;
   } finally {
+    await stopRegisteredServices();
     delete process.env.TEST_EMBEDDING_BASE_URL;
     await new Promise((resolve) => embeddingServer.close(resolve));
     rmSync(workDir, { recursive: true, force: true });
@@ -876,6 +891,7 @@ async function runPendingIngressScenario() {
 
     return logs;
   } finally {
+    await stopRegisteredServices();
     delete process.env.TEST_EMBEDDING_BASE_URL;
     await new Promise((resolve) => embeddingServer.close(resolve));
     rmSync(workDir, { recursive: true, force: true });
@@ -944,6 +960,7 @@ async function runRememberCommandContextScenario() {
 
     return logs;
   } finally {
+    await stopRegisteredServices();
     delete process.env.TEST_EMBEDDING_BASE_URL;
     await new Promise((resolve) => embeddingServer.close(resolve));
     rmSync(workDir, { recursive: true, force: true });
@@ -1055,6 +1072,7 @@ async function runUserMdExclusiveProfileScenario() {
     const entries = await store.list(["agent:life"], undefined, 10, 0);
     return { entries, logs };
   } finally {
+    await stopRegisteredServices();
     await new Promise((resolve) => embeddingServer.close(resolve));
     await new Promise((resolve) => llmServer.close(resolve));
     rmSync(workDir, { recursive: true, force: true });
@@ -1153,6 +1171,7 @@ async function runBoundarySkipKeepsRegexFallbackScenario() {
     const entries = await store.list(["agent:life"], undefined, 10, 0);
     return { entries, logs };
   } finally {
+    await stopRegisteredServices();
     await new Promise((resolve) => embeddingServer.close(resolve));
     await new Promise((resolve) => llmServer.close(resolve));
     rmSync(workDir, { recursive: true, force: true });
@@ -1287,6 +1306,7 @@ async function runInboundMetadataCleanupScenario() {
     const entries = await freshStore.list(["global", "agent:main"], undefined, 10, 0);
     return { entries, llmCalls, logs, extractionPrompt };
   } finally {
+    await stopRegisteredServices();
     delete process.env.TEST_EMBEDDING_BASE_URL;
     await new Promise((resolve) => embeddingServer.close(resolve));
     await new Promise((resolve) => server.close(resolve));


### PR DESCRIPTION
## 🐛 Problem

The auto-backup feature stops working when the plugin registers **after** the gateway has completed startup. This happens because the backup timer is only set up in `service.start()`, which is never called for late-loading plugins.

**Impact**: No daily backups are created, risking memory data loss.

---

## 🔍 Root Cause

- Gateway calls `service.start()` only on plugins registered **during** gateway startup
- If plugin registers **after** gateway is ready (e.g., on-demand loading), `start()` is never called
- No backup timer is created → no backups

---

## ✅ Solution

Move backup timer setup from `service.start()` to `register()`:

```typescript
// CRITICAL FIX: Set backup timer in register() instead of start()
if (!backupTimer) {
  api.logger.info('memory-lancedb-pro: setting up auto-backup');
  setTimeout(() => void runBackup(), 60_000);
  backupTimer = setInterval(() => void runBackup(), BACKUP_INTERVAL_MS);
}
```

**Benefits**:
- Ensures backups work regardless of plugin registration timing
- Simple, minimal change with no breaking changes
- Idempotent guard prevents duplicate timers

---

## 📝 Testing

Verified on local environment:
- ✅ Backup timer created immediately on plugin registration
- ✅ Initial backup completed ~65 seconds after registration
- ✅ Daily backup schedule established
- ✅ No duplicate timers on multiple registrations

---

## 📊 Evidence

See issue for full timeline comparison and logs.

Fixes #551