### PR TITLE
fix(retrieval): ensure store initialization before hybrid routing

### DIFF
--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -561,6 +561,9 @@ export class MemoryRetriever {
   async retrieve(context: RetrievalContext): Promise<RetrievalResult[]> {
     const { query, limit, scopeFilter, category, source } = context;
     const safeLimit = clampInt(limit, 1, 20);
+    // Ensure store is fully initialized before routing decision (hybrid vs vector-only).
+    // Without this, hasFtsSupport may be false on first call if FTS index creation is still in flight.
+    await this.store.ensureInitialized();
     this.lastDiagnostics = null;
     const diagnostics: RetrievalDiagnostics = {
       source,

--- a/src/store.ts
+++ b/src/store.ts
@@ -220,7 +220,8 @@ export class MemoryStore {
     return this.config.dbPath;
   }
 
-  private async ensureInitialized(): Promise<void> {
+  /** Ensure the store is fully initialized (FTS index created, table opened, etc.). Safe to call multiple times. */
+  public async ensureInitialized(): Promise<void> {
     if (this.table) {
       return;
     }


### PR DESCRIPTION
## Summary

This fixes a cold-start race in hybrid retrieval.

On the first retrieval after startup, the store may still be finishing initialization
(particularly FTS setup). In that window, `hasFtsSupport` can still read as `false`,
so `retrieve()` incorrectly routes to vector-only retrieval instead of hybrid retrieval.

This patch makes `retrieve()` await store initialization before making the routing decision.

## Changes

- expose `ensureInitialized()` on `MemoryStore`
- call `await this.store.ensureInitialized()` at the start of `retrieve()`
before hybrid vs vector-only routing is decided

## Root cause

The issue was not caused by BM25 itself, CLI formatting, or retrieval filtering.

The actual problem was timing:

- retrieval mode was already `hybrid`
- but `store.hasFtsSupport` could still be `false` on the first call
- so the first call incorrectly took the vector-only path
- later calls worked because initialization had finished by then

## Validation

Validated locally with a minimal reproduction:

- before this patch:
 - first call: vector only
 - second call: vector + bm25 + fused + reranked
- after this patch:
 - first call already enters the correct hybrid path

## Scope

This PR only contains the minimal fix for the hybrid cold-start routing race.

It does not include unrelated local changes such as autoCapture, smart-extractor,
or other workspace-only modifications.