### PR TITLE
fix: add Windows APPDATA path fallback for extensionAPI.js

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -431,6 +431,11 @@ function getExtensionApiImportSpecifiers(): string[] {
   specifiers.push(toImportSpecifier("/usr/local/lib/node_modules/openclaw/dist/extensionAPI.js"));
   specifiers.push(toImportSpecifier("/opt/homebrew/lib/node_modules/openclaw/dist/extensionAPI.js"));
 
+  if (process.platform === "win32" && process.env.APPDATA) {
+    const windowsNpmPath = join(process.env.APPDATA, "npm", "node_modules", "openclaw", "dist", "extensionAPI.js");
+    specifiers.push(toImportSpecifier(windowsNpmPath));
+  }
+
   return [...new Set(specifiers.filter(Boolean))];
 }
 


### PR DESCRIPTION
## Summary

Add Windows APPDATA path fallback for `extensionAPI.js` in `getExtensionApiImportSpecifiers()`.

## Problem

On Windows, npm global packages are installed to `%APPDATA%\npm\node_modules\`. The `getExtensionApiImportSpecifiers()` function only checks Unix/macOS paths, causing `memory-reflection` and other features to fail on Windows without manual environment variable configuration.

## Solution

Add automatic Windows path detection using `process.env.APPDATA`:

```typescript
if (process.platform === "win32" && process.env.APPDATA) {
  const windowsNpmPath = join(process.env.APPDATA, "npm", "node_modules", "openclaw", "dist", "extensionAPI.js");
  specifiers.push(toImportSpecifier(windowsNpmPath));
}
```

## Testing

- [x] Verified the code change compiles correctly
- [x] No breaking changes to existing Unix/macOS behavior

## Fixes

Fixes #575