### PR TITLE
fix: use cached raw user message as auto-recall query

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2263,10 +2263,15 @@ const memoryLanceDBProPlugin = {
           const agentId = resolveHookAgentId(ctx?.agentId, (event as any).sessionKey);
           const accessibleScopes = resolveScopeFilter(scopeManager, agentId);
 
+          // Use cached raw user message for the recall query to avoid channel
+          // metadata noise (e.g. Slack's Conversation info JSON with message_id,
+          // sender_id, conversation_label) that pollutes the embedding vector and
+          // causes irrelevant memories to rank higher.  Fall back to event.prompt
+          // for non-channel triggers or when no cached message is available.
           // FR-04: Truncate long prompts (e.g. file attachments) before embedding.
           // Auto-recall only needs the user's intent, not full attachment text.
           const MAX_RECALL_QUERY_LENGTH = config.autoRecallMaxQueryLength ?? 2_000;
-          let recallQuery = event.prompt;
+          let recallQuery = lastRawUserMessage.get(cacheKey) || event.prompt;
           if (recallQuery.length > MAX_RECALL_QUERY_LENGTH) {
             const originalLength = recallQuery.length;
             recallQuery = recallQuery.slice(0, MAX_RECALL_QUERY_LENGTH);


### PR DESCRIPTION
## Summary

- Auto-recall's `recallQuery` uses `event.prompt` directly, which on Slack includes Conversation info JSON metadata (message_id, sender_id, conversation_label, etc.) prepended by the platform adapter
- This metadata pollutes the embedding vector, causing irrelevant memories to score higher than actually relevant ones
- The fix uses `lastRawUserMessage.get(cacheKey) || event.prompt` — the same pattern already applied to `gatingText` (line 2245) — so the retrieval query uses clean user text instead of the noisy assembled prompt

## Context

The `gatingText` variable (used for short-message skip and greeting detection) was already correctly patched to prefer `lastRawUserMessage`. However, the actual `recallQuery` passed to `retrieveWithRetry()` was missed, so retrieval itself was still affected.

The `lastRawUserMessage` Map is populated in the `message_received` hook (line 2211–2219), which strips bot mentions and caches clean user text keyed by `channelId`. The `before_prompt_build` hook shares the same `cacheKey` derivation, so the cached value is always available when needed.

## Reproduction

1. Deploy with Slack channel adapter
2. Send a short CJK message (e.g. "我们团队谁负责项目管理")
3. Observe that `event.prompt` in `before_prompt_build` contains `Conversation info: {"message_id":"...","sender_id":"...","conversation_label":"..."}` prefix
4. Auto-recall returns irrelevant memories because the metadata dominates the embedding

## Test plan

- [ ] Verify Slack messages trigger auto-recall with clean query text (no Conversation info JSON in embedding input)
- [ ] Verify non-Slack channels (Telegram, API) still work correctly (falls back to `event.prompt`)
- [ ] Verify `gatingText` and `recallQuery` now use the same source for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)