### PR TITLE
fix: skip 75ms retry when store is empty (Bug 2)

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -444,6 +444,12 @@ export class MemoryStore {
     return res.length > 0;
   }
 
+  /** Lightweight total row count via LanceDB countRows(). */
+  async count(): Promise<number> {
+    await this.ensureInitialized();
+    return await this.table!.countRows();
+  }
+
   async getById(id: string, scopeFilter?: string[]): Promise<MemoryEntry | null> {
     await this.ensureInitialized();
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -175,9 +175,15 @@ async function retrieveWithRetry(
     scopeFilter?: string[];
     category?: string;
   },
+  countStore?: () => Promise<number>,
 ): Promise<RetrievalResult[]> {
   let results = await retriever.retrieve(params);
   if (results.length === 0) {
+    // Skip retry if store is empty — nothing to catch up via write-ahead lag.
+    if (countStore) {
+      const total = await countStore();
+      if (total === 0) return results;
+    }
     await sleep(75);
     results = await retriever.retrieve(params);
   }
@@ -210,7 +216,7 @@ async function resolveMemoryId(
     query: trimmed,
     limit: 5,
     scopeFilter,
-  });
+  }, () => context.store.count());
   if (results.length === 0) {
     return {
       ok: false,
@@ -575,7 +581,7 @@ export function registerMemoryRecallTool(
             scopeFilter,
             category,
             source: "manual",
-          }), runtimeContext.workspaceBoundary);
+          }, () => runtimeContext.store.count()), runtimeContext.workspaceBoundary);
 
           if (results.length === 0) {
             return {
@@ -1079,7 +1085,7 @@ export function registerMemoryForgetTool(
               query,
               limit: 5,
               scopeFilter,
-            });
+            }, () => context.store.count());
 
             if (results.length === 0) {
               return {
@@ -1221,7 +1227,7 @@ export function registerMemoryUpdateTool(
               query: memoryId,
               limit: 3,
               scopeFilter,
-            });
+            }, () => context.store.count());
             if (results.length === 0) {
               return {
                 content: [
@@ -2142,7 +2148,7 @@ export function registerMemoryExplainRankTool(
             limit: safeLimit,
             scopeFilter,
             source: "manual",
-          });
+          }, () => runtimeContext.store.count());
           if (results.length === 0) {
             return {
               content: [{ type: "text", text: "No relevant memories found." }],


### PR DESCRIPTION
## Bug 2: 75ms retry on empty results

**Reported in community code audit**

### Problem
In `retrieveWithRetry()` (`tools.ts`), when the first retrieval returns 0 results, it always sleeps 75ms and retries — even when the store is completely empty. This 75ms is pure wasted latency on a cold/empty store.

### Fix
Added `count()` method to `MemoryStore` using LanceDB's `countRows()` (O(1) metadata operation). `retrieveWithRetry` now accepts an optional `countStore` callback — if the store has 0 rows, the retry is skipped entirely.

```ts
// store.ts
async count(): Promise<number> {
  await this.ensureInitialized();
  return await this.table!.countRows();
}

// tools.ts — retrieveWithRetry
if (results.length === 0) {
  if (countStore) {
    const total = await countStore();
    if (total === 0) return results;  // skip retry
  }
  await sleep(75);
  results = await retriever.retrieve(params);
}
```

### Testing
- TypeScript: 0 new errors on changed files
- Reviewed by Staff Engineer: APPROVED
- Backward compatible: `countStore` is optional, all 5 existing call sites still work

### Files changed
- `src/store.ts`: +6 lines (`count()` method)
- `src/tools.ts`: +11/-5 lines (optional param + guard + 5 call sites)

---
*Audit reference: memory-lancedb-pro code audit — Bug 2, reported 2026-04-11*
