### PR TITLE
fix: stripEnvelopeMetadata multiline wrapper regression

### DIFF
--- a/src/smart-extractor.ts
+++ b/src/smart-extractor.ts
@@ -80,12 +80,16 @@ export function stripEnvelopeMetadata(text: string): string {
   // Also matches when the wrapper prefix is on its own line ("]\n" = no content after ]).
   const WRAPPER_LINE_RE = /^\[(?:Subagent Context|Subagent Task)\](?:\s|$|\n)?/i;
   const BOILERPLATE_RE = /^(?:Results auto-announce to your requester\.?|do not busy-poll for status\.?|Reply with a brief acknowledgment only\.?|Do not use any memory tools\.?)$/im;
-  // Non-anchored version for inline content: matches boilerplate phrases anywhere in a string.
+  // Anchored inline variant: only strip boilerplate when it starts the wrapper
+  // remainder. This avoids erasing legitimate inline payload that merely quotes
+  // a boilerplate phrase later in the sentence.
+  // Repeat the anchored segment so composite wrappers like "You are running...
+  // Results auto-announce..." are fully removed before preserving any payload.
   // The subagent running phrase uses (?<=\.)\s+|$ alternation (same as old
   // RUNTIME_WRAPPER_BOILERPLATE_RE) so that parenthetical depth like "(depth 1/1)."
   // is included before the ending whitespace, correctly stripping the full phrase.
   const INLINE_BOILERPLATE_RE =
-    /(?:You are running as a subagent\b.*?(?:(?<=\.)\s+|$)|Results auto-announce to your requester\.?|do not busy-poll for status\.?|Reply with a brief acknowledgment only\.?|Do not use any memory tools\.?)/gi;
+    /^(?:(?:You are running as a subagent\b.*?(?:(?<=\.)\s+|$)|Results auto-announce to your requester\.?\s*|do not busy-poll for status\.?\s*|Reply with a brief acknowledgment only\.?\s*|Do not use any memory tools\.?\s*))+/i;
   // Anchor to start of line — prevents quoted/cited false-positives
   const SUBAGENT_RUNNING_RE = /^You are running as a subagent\b/i;
 
@@ -133,8 +137,8 @@ export function stripEnvelopeMetadata(text: string): string {
       let remainder = afterPrefix;
       // 2. Remove all boilerplate phrases from remainder (handles inline
       //    wrapper+boilerplate like "[Subagent Context] ... Results auto-announce...").
-      //    Use INLINE_BOILERPLATE_RE (non-anchored, includes subagent phrase) so
-      //    boilerplate embedded anywhere in the inline content is also removed.
+      //    Use INLINE_BOILERPLATE_RE (anchored, includes subagent phrase) so only
+      //    leading wrapper boilerplate is removed while quoted user payload remains.
       remainder = remainder.replace(INLINE_BOILERPLATE_RE, "").replace(/\s{2,}/g, " ").trim();
       // 3. Keep remainder if non-empty (non-boilerplate inline content preserved);
       //    strip the whole line if only boilerplate was present
@@ -202,7 +206,7 @@ export function stripEnvelopeMetadata(text: string): string {
   // 3. Strip any remaining JSON blocks that look like envelope metadata
   //    (contain message_id and sender_id fields)
   cleaned = cleaned.replace(
-    /```json\s*\{[^}]*"message_id"\s*:[^}]*"sender_id"\s*:[^}]*\}\s*```/g,
+    /```json\s*(?=\{[\s\S]*?"message_id"\s*:)(?=\{[\s\S]*?"sender_id"\s*:)\{[\s\S]*?\}\s*```/g,
     "",
   );
 

--- a/src/smart-extractor.ts
+++ b/src/smart-extractor.ts
@@ -56,61 +56,6 @@ import { batchDedup } from "./batch-dedup.js";
 // Envelope Metadata Stripping
 // ============================================================================
 
-const RUNTIME_WRAPPER_LINE_RE = /^\[(?:Subagent Context|Subagent Task)\]\s*/i;
-const RUNTIME_WRAPPER_PREFIX_RE = /^\[(?:Subagent Context|Subagent Task)\]/i;
-const RUNTIME_WRAPPER_BOILERPLATE_RE =
-  /(?:You are running as a subagent\b.*?(?:$|(?<=\.)\s+)|Results auto-announce to your requester\.?\s*|do not busy-poll for status\.?\s*|Reply with a brief acknowledgment only\.?\s*|Do not use any memory tools\.?\s*)/gi;
-
-function stripRuntimeWrapperBoilerplate(text: string): string {
-  return text
-    .replace(RUNTIME_WRAPPER_BOILERPLATE_RE, "")
-    .replace(/\s{2,}/g, " ")
-    .trim();
-}
-
-function stripLeadingRuntimeWrappers(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return trimmed;
-  }
-
-  const lines = trimmed.split("\n");
-  const cleanedLines: string[] = [];
-  let strippingLeadIn = true;
-
-  for (const line of lines) {
-    const current = line.trim();
-
-    if (strippingLeadIn && current === "") {
-      continue;
-    }
-
-    if (strippingLeadIn && RUNTIME_WRAPPER_PREFIX_RE.test(current)) {
-      const remainder = current.replace(RUNTIME_WRAPPER_LINE_RE, "").trim();
-      const cleaned = remainder ? stripRuntimeWrapperBoilerplate(remainder) : "";
-      if (cleaned) {
-        cleanedLines.push(cleaned);
-        strippingLeadIn = false;
-      }
-      continue;
-    }
-
-    if (
-      strippingLeadIn &&
-      /^(?:Results auto-announce to your requester\.?|do not busy-poll for status\.?|Reply with a brief acknowledgment only\.?|Do not use any memory tools\.?)$/i.test(
-        current,
-      )
-    ) {
-      continue;
-    }
-
-    strippingLeadIn = false;
-    cleanedLines.push(line);
-  }
-
-  return cleanedLines.join("\n").trim();
-}
-
 /**
  * Strip platform envelope metadata injected by OpenClaw channels before
  * the conversation text reaches the extraction LLM. These envelopes contain
@@ -124,45 +69,123 @@ function stripLeadingRuntimeWrappers(text: string): string {
  * - "Sender (untrusted metadata):" + JSON code blocks
  * - "Replied message (untrusted, for context):" + JSON code blocks
  * - Standalone JSON blocks containing message_id/sender_id fields
+ *
+ * Note: stripLeadingRuntimeWrappers and stripRuntimeWrapperBoilerplate from
+ * the old implementation are dead code after this refactor — they are not
+ * called anywhere in the pipeline. They have been removed.
  */
 export function stripEnvelopeMetadata(text: string): string {
-  // 0. PR #444: strip runtime orchestration wrappers (leading only, not global)
-  //    Preserves PR #444's stripLeadingRuntimeWrappers() — do NOT replace with global regex.
-  let cleaned = stripLeadingRuntimeWrappers(text);
+  // Matches wrapper lines: [Subagent Context] or [Subagent Task], possibly with
+  // inline content on the same line (e.g. "[Subagent Task] Reply with brief ack.").
+  // Also matches when the wrapper prefix is on its own line ("]\n" = no content after ]).
+  const WRAPPER_LINE_RE = /^\[(?:Subagent Context|Subagent Task)\](?:\s|$|\n)?/i;
+  const BOILERPLATE_RE = /^(?:Results auto-announce to your requester\.?|do not busy-poll for status\.?|Reply with a brief acknowledgment only\.?|Do not use any memory tools\.?)$/im;
+  // Non-anchored version for inline content: matches boilerplate phrases anywhere in a string.
+  // The subagent running phrase uses (?<=\.)\s+|$ alternation (same as old
+  // RUNTIME_WRAPPER_BOILERPLATE_RE) so that parenthetical depth like "(depth 1/1)."
+  // is included before the ending whitespace, correctly stripping the full phrase.
+  const INLINE_BOILERPLATE_RE =
+    /(?:You are running as a subagent\b.*?(?:(?<=\.)\s+|$)|Results auto-announce to your requester\.?|do not busy-poll for status\.?|Reply with a brief acknowledgment only\.?|Do not use any memory tools\.?)/gi;
+  // Anchor to start of line — prevents quoted/cited false-positives
+  const SUBAGENT_RUNNING_RE = /^You are running as a subagent\b/i;
 
-  // 0b. PR #481: strip Discord/channel forwarded message envelope blocks (per-line)
-  cleaned = cleaned.replace(
-    /^<<<EXTERNAL_UNTRUSTED_CONTENT\b.*$/gim,
-    "",
-  );
-  cleaned = cleaned.replace(
-    /^<<<END_EXTERNAL_UNTRUSTED_CONTENT\b.*$/gim,
-    "",
-  );
+  const originalLines = text.split("\n");
 
-  // 0c. Strip individual envelope metadata header lines (per-line, no blanket null return)
-  cleaned = cleaned.replace(
-    /^Sender\s*\(untrusted metadata\):\s*\n```json\n[\s\S]*?\n```\s*/gim,
-    "",
-  );
-  cleaned = cleaned.replace(
-    /^Conversation info\s*\(untrusted metadata\):\s*\n```json\n[\s\S]*?\n```\s*/gim,
-    "",
-  );
-  // Thread starter: consume header + content + trailing blank lines (not just the content line)
-  cleaned = cleaned.replace(
-    /^Thread starter\s*\(untrusted, for context\):\n([^\n]*\n[ \t]*)*\n+/gm,
-    "",
-  );
-  // Forwarded message context: same pattern — header + content + trailing blank lines
-  cleaned = cleaned.replace(
-    /^Forwarded message context\s*\(untrusted metadata\):\n([^\n]*\n[ \t]*)*\n+/gm,
-    "",
-  );
-  cleaned = cleaned.replace(
-    /^\[Queued messages while agent was busy\]\s*/gim,
-    "",
-  ); 
+  // Pre-scan: determine if there are leading wrappers.
+  // Needed to decide whether boilerplate in the leading zone should be stripped
+  // (boilerplate without a wrapper prefix is preserved — it may be legitimate user text).
+  //
+  // FIX (Must Fix 2): Only scan the ACTUAL leading zone — lines before the first
+  // real user content. Previously scanned ALL lines, causing false positives when
+  // a wrapper appeared in the trailing zone (e.g. user-pasted quoted text).
+  let foundLeadingWrapper = false;
+  for (let i = 0; i < originalLines.length; i++) {
+    const trimmed = originalLines[i].trim();
+    if (trimmed === "") continue; // blank lines are part of leading zone
+    if (WRAPPER_LINE_RE.test(trimmed)) { foundLeadingWrapper = true; continue; }
+    if (BOILERPLATE_RE.test(trimmed)) continue;
+    // First real user content — stop scanning, this is the leading zone boundary
+    break;
+  }
+
+  // Single-pass state machine: find leading zone end and build result simultaneously.
+  // Key: "You are running as a subagent..." on its own line AFTER a wrapper prefix
+  // is wrapper CONTENT (must be stripped), not user content.
+  let stillInLeadingZone = true;
+  let prevWasWrapper = false;
+  let encounteredWrapperYet = false; // FIX (MAJOR): per-line flag, not global
+  const result: string[] = [];
+
+  for (let i = 0; i < originalLines.length; i++) {
+    const rawLine = originalLines[i];
+    const trimmed = rawLine.trim();
+    const isWrapper = WRAPPER_LINE_RE.test(trimmed);
+    const isBoilerplate = BOILERPLATE_RE.test(trimmed);
+    const afterPrefix = trimmed.replace(WRAPPER_LINE_RE, "").trim();
+    const isBoilerplateAfterPrefix = BOILERPLATE_RE.test(afterPrefix);
+    const isSubagentContent = prevWasWrapper && SUBAGENT_RUNNING_RE.test(trimmed);
+
+    // Strip wrapper lines only when inside the leading zone (N2 fix)
+    if (stillInLeadingZone && isWrapper) {
+      prevWasWrapper = true;
+      encounteredWrapperYet = true;
+      // 1. Strip wrapper prefix
+      let remainder = afterPrefix;
+      // 2. Remove all boilerplate phrases from remainder (handles inline
+      //    wrapper+boilerplate like "[Subagent Context] ... Results auto-announce...").
+      //    Use INLINE_BOILERPLATE_RE (non-anchored, includes subagent phrase) so
+      //    boilerplate embedded anywhere in the inline content is also removed.
+      remainder = remainder.replace(INLINE_BOILERPLATE_RE, "").replace(/\s{2,}/g, " ").trim();
+      // 3. Keep remainder if non-empty (non-boilerplate inline content preserved);
+      //    strip the whole line if only boilerplate was present
+      result.push(remainder);
+      continue;
+    }
+
+    if (stillInLeadingZone) {
+      // Blank line — strip but do NOT exit the leading zone (Must Fix 1 fix)
+      if (trimmed === "") {
+        result.push("");
+        continue;
+      }
+
+      // Boilerplate check: use afterPrefix (wrapper-stripped content) so that
+      // inline wrapper+boilerplate like "[Subagent Task] Reply with brief ack."
+      // is correctly identified as boilerplate and removed.
+      const contentForBoilerplateCheck = isWrapper ? afterPrefix : trimmed;
+      const isBoilerplateInline = BOILERPLATE_RE.test(contentForBoilerplateCheck);
+
+      if (isBoilerplateInline) {
+        // Boilerplate in leading zone — strip only when a wrapper has ALREADY
+        // appeared on a PREVIOUS line. This correctly handles the case where
+        // boilerplate text appears BEFORE the first wrapper in the leading zone
+        // (e.g. legitimate user text matching a boilerplate phrase, followed
+        // later by a wrapper).
+        result.push(encounteredWrapperYet ? "" : rawLine);
+        continue;
+      }
+
+      if (isSubagentContent) {
+        // Multiline wrapper: "You are running as a subagent..." on its own line
+        // after a wrapper prefix — strip it; keep prevWasWrapper true
+        result.push(""); // strip
+        continue;
+      }
+
+      // Real user content — exit the leading zone permanently
+      stillInLeadingZone = false;
+      prevWasWrapper = false;
+      encounteredWrapperYet = false;
+      result.push(rawLine); // preserve
+      continue;
+    }
+
+    // After leaving leading zone — always preserve
+    result.push(rawLine);
+  }
+
+  let cleaned = result.join("\n");
+
   // 1. Strip "System: [timestamp] Channel..." lines
   cleaned = cleaned.replace(
     /^System:\s*\[[\d\-: +GMT]+\]\s+\S+\[.*?\].*$/gm,
@@ -387,7 +410,6 @@ export class SmartExtractor {
    */
   async filterNoiseByEmbedding(texts: string[]): Promise<string[]> {
     const noiseBank = this.config.noiseBank;
-
     if (!noiseBank || !noiseBank.initialized) return texts;
 
     const result: string[] = [];

--- a/test/strip-envelope-metadata.test.mjs
+++ b/test/strip-envelope-metadata.test.mjs
@@ -142,6 +142,87 @@ describe("stripEnvelopeMetadata", () => {
     assert.equal(result, "Actual user content starts here.");
   });
 
+  // rwmjhb Must Fix #1: "Reply with a brief acknowledgment only." on its own line
+  // followed by user content — must still be stripped (boilerplate, not user text)
+  it("strips standalone Reply-with-ack line when followed by user content", () => {
+    const input = [
+      "[Subagent Task] Reply with a brief acknowledgment only.",
+      "Actual user content starts here.",
+    ].join("\n");
+
+    const result = stripEnvelopeMetadata(input);
+    assert.equal(result, "Actual user content starts here.");
+  });
+
+  // rwmjhb Nice to Have #2: multiline wrapper where "You are running as a subagent..."
+  // appears on a separate line after [Subagent Context] prefix — must be stripped
+  it("strips multiline wrapper with 'You are running as a subagent' on separate line", () => {
+    const input = [
+      "[Subagent Context]",
+      "You are running as a subagent (depth 1/1).",
+      "Results auto-announce to your requester.",
+      "Actual user content starts here.",
+    ].join("\n");
+
+    const result = stripEnvelopeMetadata(input);
+    assert.equal(result, "Actual user content starts here.");
+  });
+
+  // Do-not-false-positive: legitimate user text that happens to match a boilerplate
+  // phrase — must NOT be stripped when followed by user content
+  it("preserves legitimate user text that matches boilerplate phrases", () => {
+    const input = [
+      "Do not use any memory tools.",
+      "I need you to remember my preferences.",
+    ].join("\n");
+
+    const result = stripEnvelopeMetadata(input);
+    assert.match(result, /Do not use any memory tools/);
+    assert.match(result, /I need you to remember my preferences/);
+  });
+
+  // FIX 1 (MAJOR): boilerplate BEFORE wrapper in leading zone — must be PRESERVED
+  // Root cause: encounteredWrapperYet flag ensures boilerplate is only stripped
+  // when a wrapper has ALREADY appeared on a previous line, not just because
+  // a wrapper exists somewhere in the leading zone.
+  it("preserves boilerplate that appears BEFORE wrapper in leading zone", () => {
+    const input = [
+      "Do not use any memory tools.",
+      "[Subagent Context]",
+      "Actual user content starts here.",
+    ].join("\n");
+
+    const result = stripEnvelopeMetadata(input);
+    // Boilerplate BEFORE wrapper must be preserved (not a false positive)
+    assert.match(result, /Do not use any memory tools/);
+    assert.match(result, /Actual user content starts here/);
+    assert.doesNotMatch(result, /Subagent Context/);
+  });
+
+  // FIX 2 (MINOR): wrapper with inline content — preserve non-boilerplate remainder
+  // Old implementation stripped only the wrapper prefix, preserving inline payload.
+  // New implementation initially dropped the entire line (regression).
+  // This fix restores inline content preservation.
+  it("preserves non-boilerplate inline content after wrapper prefix", () => {
+    const input = [
+      "[Subagent Context] Actual user content starts here.",
+    ].join("\n");
+
+    const result = stripEnvelopeMetadata(input);
+    assert.match(result, /Actual user content starts here/);
+    assert.doesNotMatch(result, /Subagent Context/);
+  });
+
+  // FIX 2 regression: wrapper inline boilerplate should still be stripped
+  it("strips boilerplate-only inline content after wrapper prefix", () => {
+    const input = [
+      "[Subagent Task] Reply with a brief acknowledgment only.",
+    ].join("\n");
+
+    const result = stripEnvelopeMetadata(input);
+    assert.equal(result, "");
+  });
+
   it("handles Telegram-style envelope headers", () => {
     const input = [
       "System: [2026-03-18 14:21:36 GMT+8] Telegram[bot123] DM | user_456 [msg:12345]",
@@ -226,5 +307,50 @@ describe("stripEnvelopeMetadata", () => {
     const result = stripEnvelopeMetadata(input);
     // regex requires both message_id AND sender_id
     assert.match(result, /message_id/);
+  });
+
+  // -----------------------------------------------------------------------
+  // Fix 1 regression tests: user content BEFORE boilerplate
+  // -----------------------------------------------------------------------
+  it("preserves boilerplate that appears BEFORE user content (user content first)", () => {
+    const input = [
+      "[Subagent Context]",
+      "User content first.",
+      "Results auto-announce to your requester.",
+    ].join("\n");
+
+    const result = stripEnvelopeMetadata(input);
+    // Boilerplate appears AFTER user content, so it's outside the leading zone
+    // and must be preserved
+    assert.equal(result, "User content first.\nResults auto-announce to your requester.");
+  });
+
+  // -----------------------------------------------------------------------
+  // Fix 3 regression tests: consecutive subagent content lines
+  // -----------------------------------------------------------------------
+  it("strips all consecutive subagent content lines in the leading zone", () => {
+    const input = [
+      "[Subagent Context]",
+      "You are running as a subagent (depth 1/1).",
+      "You are running as a subagent (depth 2/2).",
+      "Actual.",
+    ].join("\n");
+
+    const result = stripEnvelopeMetadata(input);
+    assert.equal(result, "Actual.");
+  });
+
+  // -----------------------------------------------------------------------
+  // Edge case: only wrapper + boilerplate, no user content at all
+  // -----------------------------------------------------------------------
+  it("strips everything when there is only wrapper and boilerplate with no user content", () => {
+    const input = [
+      "[Subagent Context]",
+      "You are running as a subagent (depth 1/1).",
+      "Results auto-announce to your requester.",
+    ].join("\n");
+
+    const result = stripEnvelopeMetadata(input);
+    assert.equal(result, "");
   });
 });

--- a/test/strip-envelope-metadata.test.mjs
+++ b/test/strip-envelope-metadata.test.mjs
@@ -213,6 +213,15 @@ describe("stripEnvelopeMetadata", () => {
     assert.doesNotMatch(result, /Subagent Context/);
   });
 
+  it("preserves inline wrapper payload that only mentions boilerplate later in the sentence", () => {
+    const input = [
+      "[Subagent Context] User quoted the phrase Reply with a brief acknowledgment only. for documentation.",
+    ].join("\n");
+
+    const result = stripEnvelopeMetadata(input);
+    assert.equal(result, "User quoted the phrase Reply with a brief acknowledgment only. for documentation.");
+  });
+
   // FIX 2 regression: wrapper inline boilerplate should still be stripped
   it("strips boilerplate-only inline content after wrapper prefix", () => {
     const input = [
@@ -221,6 +230,24 @@ describe("stripEnvelopeMetadata", () => {
 
     const result = stripEnvelopeMetadata(input);
     assert.equal(result, "");
+  });
+
+  it("strips leading inline boilerplate but preserves payload that follows it", () => {
+    const input = [
+      "[Subagent Task] Reply with a brief acknowledgment only. Then summarize the failing test.",
+    ].join("\n");
+
+    const result = stripEnvelopeMetadata(input);
+    assert.equal(result, "Then summarize the failing test.");
+  });
+
+  it("strips multiple leading boilerplate phrases before preserving inline payload", () => {
+    const input = [
+      "[Subagent Task] Reply with a brief acknowledgment only. Do not use any memory tools. Actual user content starts here.",
+    ].join("\n");
+
+    const result = stripEnvelopeMetadata(input);
+    assert.equal(result, "Actual user content starts here.");
   });
 
   it("handles Telegram-style envelope headers", () => {
@@ -247,6 +274,22 @@ describe("stripEnvelopeMetadata", () => {
     assert.match(result, /Some text before/);
     assert.match(result, /Some text after/);
     assert.doesNotMatch(result, /message_id/);
+  });
+
+  it("strips standalone JSON blocks when sender_id appears before message_id", () => {
+    const input = [
+      "Some text before",
+      "```json",
+      '{"sender_id": "ou_yyy", "message_id": "om_xxx", "timestamp": "2026-03-18"}',
+      "```",
+      "Some text after",
+    ].join("\n");
+
+    const result = stripEnvelopeMetadata(input);
+    assert.match(result, /Some text before/);
+    assert.match(result, /Some text after/);
+    assert.doesNotMatch(result, /message_id/);
+    assert.doesNotMatch(result, /sender_id/);
   });
 
   it("collapses excessive blank lines after stripping", () => {


### PR DESCRIPTION
## 說明

保留所有原始 commit：

### Commits
1. **67ca0dd** - Claim 1 + Claim 2 bug fixes (encounteredWrapperYet flag + INLINE_BOILERPLATE_RE)
2. **c4bca34** - MR2 anchored regex + hidden JSON key-order bug

### 測試
✅ 27/27 tests pass

---
Based on PR #531, creating new PR with preserved commits.