### PR TITLE
fix: preserve newlines and show metadata in auto-recall

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2399,7 +2399,23 @@ const memoryLanceDBProPlugin = {
             const summary = sanitizeForContext(contentText).slice(0, effectivePerItemMaxChars);
             return {
               id: r.entry.id,
-              prefix: (() => { const f = metaObj.folder ? `[${metaObj.folder}]` : ""; const s = metaObj.source ? `(${metaObj.source})` : ""; const d = r.entry.timestamp ? new Date(r.entry.timestamp).toISOString().slice(0, 10) : ""; return `${f} ${d} ${s}`.trim(); })(),
+              prefix: (() => {
+                // When the raw stored category is "other" and a folder name is available
+                // (e.g. Apple Notes import), use the folder name as the display category
+                // so the prefix is meaningful instead of showing "[other:...]".
+                // We check r.entry.category (not displayCategory) because parseSmartMetadata
+                // always enriches "other" to a semantic category via reverseMapLegacyCategory.
+                const effectiveCategory =
+                  r.entry.category === "other" && metaObj.folder
+                    ? metaObj.folder
+                    : displayCategory;
+                const base = `${tierPrefix}[${effectiveCategory}:${r.entry.scope}]`;
+                const parts: string[] = [base];
+                if (r.entry.timestamp)
+                  parts.push(new Date(r.entry.timestamp).toISOString().slice(0, 10));
+                if (metaObj.source) parts.push(`(${metaObj.source})`);
+                return parts.join(" ");
+              })(),
               summary,
               chars: summary.length,
               meta: metaObj,

--- a/index.ts
+++ b/index.ts
@@ -1357,7 +1357,7 @@ export function detectCategory(
 
 function sanitizeForContext(text: string): string {
   return text
-    .replace(/[\r\n]+/g, " ")
+    .replace(/[\r\n]+/g, "\\n")
     .replace(/<\/?[a-zA-Z][^>]*>/g, "")
     .replace(/</g, "\uFF1C")
     .replace(/>/g, "\uFF1E")
@@ -2399,7 +2399,7 @@ const memoryLanceDBProPlugin = {
             const summary = sanitizeForContext(contentText).slice(0, effectivePerItemMaxChars);
             return {
               id: r.entry.id,
-              prefix: `${tierPrefix}[${displayCategory}:${r.entry.scope}]`,
+              prefix: (() => { const f = metaObj.folder ? `[${metaObj.folder}]` : ""; const s = metaObj.source ? `(${metaObj.source})` : ""; const d = r.entry.timestamp ? new Date(r.entry.timestamp).toISOString().slice(0, 10) : ""; return `${f} ${d} ${s}`.trim(); })(),
               summary,
               chars: summary.length,
               meta: metaObj,

--- a/index.ts
+++ b/index.ts
@@ -225,6 +225,26 @@ interface PluginConfig {
     skipLowValue?: boolean;
     maxExtractionsPerHour?: number;
   };
+  recallPrefix?: {
+    /**
+     * Metadata field to use as the category label in auto-recall prefix lines.
+     * When set, the value of `metadata[categoryField]` replaces the built-in
+     * category in the `[category:scope]` prefix — if the field is present on
+     * the entry. Falls back to the built-in category when the field is absent.
+     *
+     * Useful for import-based workflows where entries carry a meaningful
+     * grouping label in a custom metadata field (e.g. "folder" for Apple Notes
+     * imports, "notebook" for Notion, "collection" for Obsidian).
+     *
+     * Default: unset — built-in category is used for all entries.
+     *
+     * @example
+     * recallPrefix: { categoryField: "folder" }
+     * // Entry with metadata.folder = "Goals" → prefix: [W][Goals:global]
+     * // Entry without metadata.folder       → prefix: [W][preference:global]
+     */
+    categoryField?: string;
+  };
 }
 
 type ReflectionThinkLevel = "off" | "minimal" | "low" | "medium" | "high";
@@ -2400,15 +2420,26 @@ const memoryLanceDBProPlugin = {
             return {
               id: r.entry.id,
               prefix: (() => {
-                // When the raw stored category is "other" and a folder name is available
-                // (e.g. Apple Notes import), use the folder name as the display category
-                // so the prefix is meaningful instead of showing "[other:...]".
-                // We check r.entry.category (not displayCategory) because parseSmartMetadata
-                // always enriches "other" to a semantic category via reverseMapLegacyCategory.
-                const effectiveCategory =
-                  r.entry.category === "other" && metaObj.folder
-                    ? metaObj.folder
-                    : displayCategory;
+                // If recallPrefix.categoryField is configured, read that field directly
+                // from the raw metadata JSON and use it as the category label when present.
+                // Falls back to displayCategory when the field is absent or unset.
+                // Reading from raw JSON (not metaObj) avoids relying on parseSmartMetadata
+                // passing through unknown fields.
+                const categoryFieldName = config.recallPrefix?.categoryField;
+                let effectiveCategory = displayCategory;
+                if (categoryFieldName) {
+                  try {
+                    const rawMeta: Record<string, unknown> = r.entry.metadata
+                      ? (JSON.parse(r.entry.metadata) as Record<string, unknown>)
+                      : {};
+                    const fieldValue = rawMeta[categoryFieldName];
+                    if (typeof fieldValue === "string" && fieldValue) {
+                      effectiveCategory = fieldValue;
+                    }
+                  } catch {
+                    // malformed metadata — keep displayCategory
+                  }
+                }
                 const base = `${tierPrefix}[${effectiveCategory}:${r.entry.scope}]`;
                 const parts: string[] = [base];
                 if (r.entry.timestamp)
@@ -4061,6 +4092,15 @@ export function parsePluginConfig(value: unknown): PluginConfig {
                 : 30,
           }
         : { skipLowValue: false, maxExtractionsPerHour: 30 },
+    recallPrefix:
+      typeof cfg.recallPrefix === "object" && cfg.recallPrefix !== null
+        ? {
+            categoryField:
+              typeof (cfg.recallPrefix as Record<string, unknown>).categoryField === "string"
+                ? ((cfg.recallPrefix as Record<string, unknown>).categoryField as string)
+                : undefined,
+          }
+        : undefined,
   };
 }
 

--- a/test/recall-text-cleanup.test.mjs
+++ b/test/recall-text-cleanup.test.mjs
@@ -927,7 +927,7 @@ describe("recall text cleanup", () => {
 
   // --- PR #602: recall prefix format tests ---
 
-  function makeAutoRecallHarness(workspaceDir, mockResults) {
+  function makeAutoRecallHarness(workspaceDir, mockResults, extraConfig = {}) {
     const retrieverMod = jiti("../src/retriever.js");
     retrieverMod.createRetriever = function mockCreateRetriever() {
       return {
@@ -954,6 +954,7 @@ describe("recall text cleanup", () => {
         autoRecall: true,
         autoRecallMinLength: 1,
         selfImprovement: { enabled: false, beforeResetNote: false, ensureLearningFiles: false },
+        ...extraConfig,
       },
     });
     memoryLanceDBProPlugin.register(harness.api);
@@ -961,7 +962,7 @@ describe("recall text cleanup", () => {
     return autoRecallHook;
   }
 
-  it("uses folder name as display category when category is 'other' (Apple Notes import)", async () => {
+  it("uses configured categoryField as display category when field is present in metadata", async () => {
     const ts = new Date("2024-05-30T00:00:00.000Z").getTime();
     const hook = makeAutoRecallHarness(workspaceDir, [
       {
@@ -972,13 +973,12 @@ describe("recall text cleanup", () => {
           scope: "global",
           importance: 0.8,
           timestamp: ts,
-          // "manual" is a recognized MemorySource; "apple_notes" would be normalized to "legacy"
           metadata: JSON.stringify({ folder: "Goals", source: "manual" }),
         },
         score: 0.9,
         sources: { vector: { score: 0.9, rank: 1 } },
       },
-    ]);
+    ], { recallPrefix: { categoryField: "folder" } });
 
     const output = await hook(
       { prompt: "What are my goals?" },
@@ -986,7 +986,7 @@ describe("recall text cleanup", () => {
     );
 
     assert.ok(output, "expected recall output");
-    // Folder name replaces "other" in the category position of the prefix
+    // metadata.folder replaces the built-in category in the prefix
     assert.match(output.prependContext, /\[Goals:/);
     assert.doesNotMatch(output.prependContext, /\[other:/);
     // Date is appended from timestamp
@@ -995,7 +995,7 @@ describe("recall text cleanup", () => {
     assert.match(output.prependContext, /\(manual\)/);
   });
 
-  it("does not apply folder override for entries without category 'other'", async () => {
+  it("falls back to built-in category when categoryField is configured but absent from metadata", async () => {
     const hook = makeAutoRecallHarness(workspaceDir, [
       {
         entry: {
@@ -1009,20 +1009,47 @@ describe("recall text cleanup", () => {
         score: 0.85,
         sources: { vector: { score: 0.85, rank: 1 } },
       },
-    ]);
+    ], { recallPrefix: { categoryField: "folder" } });
 
     const output = await hook(
       { prompt: "What are my preferences?" },
-      { sessionId: "no-metadata-test", sessionKey: "agent:main:session:no-metadata-test", agentId: "main" },
+      { sessionId: "no-folder-test", sessionKey: "agent:main:session:no-folder-test", agentId: "main" },
     );
 
     assert.ok(output, "expected recall output");
-    // Content is present
     assert.match(output.prependContext, /prefer short commit messages/);
-    // Category-based prefix is present (parseSmartMetadata maps "preference" → "preferences")
+    // Falls back to built-in category (parseSmartMetadata maps "preference" → "preferences")
     assert.match(output.prependContext, /\[preferences:global\]/);
-    // No folder override was applied (no folder in metadata, not "other" category)
     assert.doesNotMatch(output.prependContext, /\[Goals:/);
+  });
+
+  it("uses built-in category unchanged when recallPrefix.categoryField is not configured", async () => {
+    const hook = makeAutoRecallHarness(workspaceDir, [
+      {
+        entry: {
+          id: "default-1",
+          text: "prefer short commit messages",
+          category: "preference",
+          scope: "global",
+          importance: 0.7,
+          timestamp: Date.now(),
+          metadata: JSON.stringify({ folder: "Preferences", source: "manual" }),
+        },
+        score: 0.85,
+        sources: { vector: { score: 0.85, rank: 1 } },
+      },
+    ]); // no recallPrefix config
+
+    const output = await hook(
+      { prompt: "What are my preferences?" },
+      { sessionId: "default-prefix-test", sessionKey: "agent:main:session:default-prefix-test", agentId: "main" },
+    );
+
+    assert.ok(output, "expected recall output");
+    assert.match(output.prependContext, /prefer short commit messages/);
+    // No categoryField configured — folder is ignored, built-in category used
+    assert.match(output.prependContext, /\[preferences:global\]/);
+    assert.doesNotMatch(output.prependContext, /\[Preferences:/);
   });
 
   it("includes tier prefix in recall line when tier metadata is present", async () => {

--- a/test/recall-text-cleanup.test.mjs
+++ b/test/recall-text-cleanup.test.mjs
@@ -924,5 +924,149 @@ describe("recall text cleanup", () => {
     assert.equal(res.details.memories.length, 3);
     assert.match(res.content[0].text, /称呼偏好：宙斯/);
   });
+
+  // --- PR #602: recall prefix format tests ---
+
+  function makeAutoRecallHarness(workspaceDir, mockResults) {
+    const retrieverMod = jiti("../src/retriever.js");
+    retrieverMod.createRetriever = function mockCreateRetriever() {
+      return {
+        async retrieve() { return mockResults; },
+        getConfig() { return { mode: "hybrid" }; },
+        setAccessTracker() {},
+        setStatsCollector() {},
+      };
+    };
+    const embedderMod = jiti("../src/embedder.js");
+    embedderMod.createEmbedder = function mockCreateEmbedder() {
+      return {
+        async embedQuery() { return new Float32Array(384).fill(0); },
+        async embedPassage() { return new Float32Array(384).fill(0); },
+      };
+    };
+    const harness = createPluginApiHarness({
+      resolveRoot: workspaceDir,
+      pluginConfig: {
+        dbPath: path.join(workspaceDir, "db"),
+        embedding: { apiKey: "test-api-key" },
+        smartExtraction: false,
+        autoCapture: false,
+        autoRecall: true,
+        autoRecallMinLength: 1,
+        selfImprovement: { enabled: false, beforeResetNote: false, ensureLearningFiles: false },
+      },
+    });
+    memoryLanceDBProPlugin.register(harness.api);
+    const [{ handler: autoRecallHook }] = harness.eventHandlers.get("before_prompt_build") || [];
+    return autoRecallHook;
+  }
+
+  it("uses folder name as display category when category is 'other' (Apple Notes import)", async () => {
+    const ts = new Date("2024-05-30T00:00:00.000Z").getTime();
+    const hook = makeAutoRecallHarness(workspaceDir, [
+      {
+        entry: {
+          id: "apple-1",
+          text: "reach revenue goal of $1M ARR by end of 2025",
+          category: "other",
+          scope: "global",
+          importance: 0.8,
+          timestamp: ts,
+          // "manual" is a recognized MemorySource; "apple_notes" would be normalized to "legacy"
+          metadata: JSON.stringify({ folder: "Goals", source: "manual" }),
+        },
+        score: 0.9,
+        sources: { vector: { score: 0.9, rank: 1 } },
+      },
+    ]);
+
+    const output = await hook(
+      { prompt: "What are my goals?" },
+      { sessionId: "apple-prefix-test", sessionKey: "agent:main:session:apple-prefix-test", agentId: "main" },
+    );
+
+    assert.ok(output, "expected recall output");
+    // Folder name replaces "other" in the category position of the prefix
+    assert.match(output.prependContext, /\[Goals:/);
+    assert.doesNotMatch(output.prependContext, /\[other:/);
+    // Date is appended from timestamp
+    assert.match(output.prependContext, /2024-05-30/);
+    // Source suffix is present
+    assert.match(output.prependContext, /\(manual\)/);
+  });
+
+  it("does not apply folder override for entries without category 'other'", async () => {
+    const hook = makeAutoRecallHarness(workspaceDir, [
+      {
+        entry: {
+          id: "plain-1",
+          text: "prefer short commit messages",
+          category: "preference",
+          scope: "global",
+          importance: 0.7,
+          timestamp: Date.now(),
+        },
+        score: 0.85,
+        sources: { vector: { score: 0.85, rank: 1 } },
+      },
+    ]);
+
+    const output = await hook(
+      { prompt: "What are my preferences?" },
+      { sessionId: "no-metadata-test", sessionKey: "agent:main:session:no-metadata-test", agentId: "main" },
+    );
+
+    assert.ok(output, "expected recall output");
+    // Content is present
+    assert.match(output.prependContext, /prefer short commit messages/);
+    // Category-based prefix is present (parseSmartMetadata maps "preference" → "preferences")
+    assert.match(output.prependContext, /\[preferences:global\]/);
+    // No folder override was applied (no folder in metadata, not "other" category)
+    assert.doesNotMatch(output.prependContext, /\[Goals:/);
+  });
+
+  it("includes tier prefix in recall line when tier metadata is present", async () => {
+    const hook = makeAutoRecallHarness(workspaceDir, [
+      {
+        entry: {
+          id: "tiered-1",
+          text: "always use absolute imports",
+          category: "fact",
+          scope: "global",
+          importance: 0.9,
+          timestamp: Date.now(),
+          metadata: JSON.stringify({ tier: "l1" }),
+        },
+        score: 0.88,
+        sources: { vector: { score: 0.88, rank: 1 } },
+      },
+      {
+        entry: {
+          id: "tiered-2",
+          text: "prefer TypeScript strict mode",
+          category: "preference",
+          scope: "global",
+          importance: 0.85,
+          timestamp: Date.now(),
+          metadata: JSON.stringify({ tier: "l2" }),
+        },
+        score: 0.82,
+        sources: { vector: { score: 0.82, rank: 2 } },
+      },
+    ]);
+
+    const output = await hook(
+      { prompt: "What are my coding preferences?" },
+      { sessionId: "tier-prefix-test", sessionKey: "agent:main:session:tier-prefix-test", agentId: "main" },
+    );
+
+    assert.ok(output, "expected recall output");
+    // Both entries should have a tier prefix (first char of tier, uppercased, in brackets)
+    const lines = output.prependContext.split("\n").filter((l) => l.startsWith("- ["));
+    assert.ok(lines.length >= 2, "expected at least 2 recall lines");
+    for (const line of lines) {
+      assert.match(line, /^- \[[A-Z]\]\[/, "recall line should start with tier prefix [X][");
+    }
+  });
 });
 


### PR DESCRIPTION
## Summary

Two changes to improve auto-recall context injection quality:

1. **Preserve newlines in `sanitizeForContext`** — replace `\r\n` with literal `\n` instead of collapsing to a space. Line breaks carry semantic weight, especially in non-Latin scripts (Hebrew, CJK, Arabic) where a newline separates distinct thoughts. Collapsing to space merges them into an unreadable run-on.

2. **Show entry metadata in recall line format** — display `folder`, `date`, and `source` from entry metadata instead of the generic `[category:scope]`. Users who import memories via `memory-pro import` with rich metadata (folder organization, source tracking, timestamps) lose all of that context in the current display format. The agent can't tell where a recalled memory came from.

**Before:**
```
- [other:global] all text collapsed into one line no paragraph structure visible
```

**After:**
```
- [Goals] 2024-05-30 (apple_notes) text with\npreserved line breaks
```

## Context

Discovered while building an Apple Notes → memory-pro import pipeline. 1,800+ personal notes imported with folder, source, author, and date metadata. Auto-recall surfaced them with no attribution and destroyed the original formatting.

## Test plan

- [ ] Verify auto-recall injection preserves `\n` in recalled text
- [ ] Verify folder/date/source from metadata appear in the recall prefix
- [ ] Verify entries without metadata fields degrade gracefully (empty prefix parts omitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)