### PR TITLE
fix(cli-smoke): add missing count() mock method (Issue #596)

### DIFF
--- a/test/cli-smoke.mjs
+++ b/test/cli-smoke.mjs
@@ -300,6 +300,7 @@ async function runCliSmoke() {
     },
     store: {
       async patchMetadata() {},
+      async count() { return 1; },
     },
     scopeManager: {
       getAccessibleScopes() {


### PR DESCRIPTION
## Summary

The CLI smoke test (`test/cli-smoke.mjs`) mock store was missing the `async count()` method that the real store interface provides. This caused the assertion at line ~316 to fail with `undefined !== 1`.

## Root cause

When the lifecycle-aware memory decay feature added `count()` to the real store interface (commit 6e5f569), the test mock was never updated.

## Fix

Add `async count() { return 1; }` to the mock store in `test/cli-smoke.mjs`.

## Relation to other PRs

This failure was **observed during CI for PR #516** but is **not caused by PR #516** — it is a pre-existing gap in test coverage.

See also: Issue #596