### PR TITLE
fix(embedder): use /api/embeddings + prompt for Ollama 0.20.5+

### DIFF
--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -559,10 +559,20 @@ export class Embedder {
     if (!this._baseURL) {
       throw new Error("embedWithNativeFetch requires a baseURL");
     }
-    // Ollama's embeddings endpoint is at /v1/embeddings (OpenAI-compatible)
-    const endpoint = this._baseURL.replace(/\/$/, "") + "/embeddings";
+
+    // Fix for Ollama 0.20.5+: /v1/embeddings returns empty arrays for both `input` and `prompt`.
+    // Only /api/embeddings + `prompt` parameter works correctly.
+    // See: https://github.com/CortexReach/memory-lancedb-pro/issues/620
+    const base = this._baseURL.replace(/\/$/, "").replace(/\/v1$/, "");
+    const endpoint = base + "/api/embeddings";
 
     const apiKey = this.clients[0]?.apiKey ?? "ollama";
+
+    // Ollama's /api/embeddings requires "prompt" field, not "input"
+    const ollamaPayload = {
+      model: payload.model,
+      prompt: payload.input,
+    };
 
     const response = await fetch(endpoint, {
       method: "POST",
@@ -570,7 +580,7 @@ export class Embedder {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${apiKey}`,
       },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(ollamaPayload),
       signal: signal,
     });
 
@@ -580,7 +590,10 @@ export class Embedder {
     }
 
     const data = await response.json();
-    return data; // OpenAI-compatible shape: { data: [{ embedding: number[] }] }
+
+    // Ollama /api/embeddings returns { embedding: number[] },
+    // convert to OpenAI-compatible shape { data: [{ embedding: number[] }] }
+    return { data: [{ embedding: data.embedding }] };
   }
 
   /**


### PR DESCRIPTION
## 修復摘要

**根本原因**：Ollama 0.20.5 的 `/v1/embeddings` endpoint 對所有參數（`input`、`prompt`）都回傳空陣列。只有 legacy `/api/embeddings` + `prompt` 參數能正常運作。

**修改**：`src/embedder.ts` 的 `embedWithNativeFetch()` 方法：
1. 將 baseURL 的 `/v1` suffix 移除，改用 `/api/embeddings` endpoint
2. 將 payload 的 `input` 欄位改為 `prompt`
3. 將 Ollama 的 `{embedding: [...]}` 回應格式轉換為 OpenAI 的 `{data: [{embedding: [...]}]}`

**API 測試結果**：

| Endpoint | 參數 | 結果 |
|----------|------|------|
| `/v1/embeddings` | `input` | EMPTY (0 dims) |
| `/v1/embeddings` | `prompt` | EMPTY (0 dims) |
| `/api/embeddings` | `prompt` | **正常** (正確 dims) |

Closes #620
