### PR TITLE
fix: use absolute default path for mdMirror fallback directory

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1531,9 +1531,9 @@ function createMdMirrorWriter(
 ): MdMirrorWriter | null {
   if (config.mdMirror?.enabled !== true) return null;
 
-  const fallbackDir = config.mdMirror.dir
-    ? api.resolvePath(config.mdMirror.dir)
-    : getDefaultMdMirrorDir();
+  const fallbackDir = api.resolvePath(
+    config.mdMirror.dir ?? getDefaultMdMirrorDir(),
+  );
   const workspaceMap = resolveAgentWorkspaceMap(api);
 
   if (Object.keys(workspaceMap).length > 0) {
@@ -4055,13 +4055,13 @@ export function parsePluginConfig(value: unknown): PluginConfig {
   };
 }
 
+export { getDefaultMdMirrorDir };
+
 /**
  * Resets the registration state — primarily intended for use in tests that need
  * to unload/reload the plugin without restarting the process.
  * @public
  */
-export { getDefaultMdMirrorDir };
-
 export function resetRegistration() {
   // Note: WeakSets cannot be cleared by design. In test scenarios where the
   // same process reloads the module, a fresh module state means a new WeakSet.

--- a/index.ts
+++ b/index.ts
@@ -245,6 +245,11 @@ function getDefaultWorkspaceDir(): string {
   return join(home, ".openclaw", "workspace");
 }
 
+function getDefaultMdMirrorDir(): string {
+  const home = homedir();
+  return join(home, ".openclaw", "memory", "md-mirror");
+}
+
 function resolveWorkspaceDirFromContext(context: Record<string, unknown> | undefined): string {
   const runtimePath = typeof context?.workspaceDir === "string" ? context.workspaceDir.trim() : "";
   return runtimePath || getDefaultWorkspaceDir();
@@ -1526,7 +1531,9 @@ function createMdMirrorWriter(
 ): MdMirrorWriter | null {
   if (config.mdMirror?.enabled !== true) return null;
 
-  const fallbackDir = api.resolvePath(config.mdMirror.dir || "memory-md");
+  const fallbackDir = config.mdMirror.dir
+    ? api.resolvePath(config.mdMirror.dir)
+    : getDefaultMdMirrorDir();
   const workspaceMap = resolveAgentWorkspaceMap(api);
 
   if (Object.keys(workspaceMap).length > 0) {
@@ -4053,6 +4060,8 @@ export function parsePluginConfig(value: unknown): PluginConfig {
  * to unload/reload the plugin without restarting the process.
  * @public
  */
+export { getDefaultMdMirrorDir };
+
 export function resetRegistration() {
   // Note: WeakSets cannot be cleared by design. In test scenarios where the
   // same process reloads the module, a fresh module state means a new WeakSet.

--- a/test/mdmirror-fallback-dir.test.mjs
+++ b/test/mdmirror-fallback-dir.test.mjs
@@ -1,0 +1,53 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginSdkStubPath = path.resolve(testDir, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+const { getDefaultMdMirrorDir, parsePluginConfig } = jiti("../index.ts");
+
+describe("mdMirror fallback directory", () => {
+  it("returns an absolute path", () => {
+    const dir = getDefaultMdMirrorDir();
+    assert.ok(path.isAbsolute(dir), `expected absolute path, got: ${dir}`);
+  });
+
+  it("resolves inside ~/.openclaw/memory/md-mirror", () => {
+    const dir = getDefaultMdMirrorDir();
+    const expected = path.join(homedir(), ".openclaw", "memory", "md-mirror");
+    assert.equal(dir, expected);
+  });
+
+  it("does not use the old relative 'memory-md' default", () => {
+    const dir = getDefaultMdMirrorDir();
+    assert.ok(
+      !dir.endsWith("/memory-md") && !dir.endsWith("\\memory-md"),
+      `should not fall back to relative 'memory-md', got: ${dir}`,
+    );
+  });
+
+  it("parsePluginConfig preserves explicit mdMirror.dir", () => {
+    const parsed = parsePluginConfig({
+      embedding: { apiKey: "test-key" },
+      mdMirror: { enabled: true, dir: "/custom/mirror/path" },
+    });
+    assert.equal(parsed.mdMirror.dir, "/custom/mirror/path");
+  });
+
+  it("parsePluginConfig leaves mdMirror.dir undefined when not set", () => {
+    const parsed = parsePluginConfig({
+      embedding: { apiKey: "test-key" },
+      mdMirror: { enabled: true },
+    });
+    assert.equal(parsed.mdMirror.dir, undefined);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes the mdMirror fallback directory resolving to `{CWD}/memory-md` instead of a stable absolute path when `mdMirror.dir` is not configured
- Adds `getDefaultMdMirrorDir()` following the same pattern as the existing `getDefaultDbPath()` — resolves to `~/.openclaw/memory/md-mirror`
- Adds tests for the new default and config-override behavior

Closes #627

## Changes

**`index.ts`:**
- Added `getDefaultMdMirrorDir()` helper (returns `~/.openclaw/memory/md-mirror`)
- Updated `createMdMirrorWriter()` to use the new helper when `mdMirror.dir` is not set, instead of the CWD-relative `"memory-md"`
- Exported `getDefaultMdMirrorDir` for testability

**`test/mdmirror-fallback-dir.test.mjs`** (new):
- 5 test cases covering absolute path, correct default location, no legacy relative path, explicit dir override, and undefined-when-unset behavior

## Testing

- All 5 new tests pass (`node --test test/mdmirror-fallback-dir.test.mjs`)
- `test:core-regression` passes
- `test:storage-and-schema` passes
- `test:llm-clients-and-auth` passes
- `test:packaging-and-workflow` passes
- `test:cli-smoke` has a pre-existing failure on master (unrelated to this change)

This PR was created with the assistance of Claude Code (AI).