### PR TITLE
feat(phase2): Singleton State Management (PR #598, 4 commits)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2027,9 +2027,6 @@ const memoryLanceDBProPlugin = {
 
       return tierOverrides;
     }
-    const reflectionErrorStateBySession = new Map<string, ReflectionErrorState>();
-    const reflectionDerivedBySession = new Map<string, { updatedAt: number; derived: string[] }>();
-    const reflectionByAgentCache = new Map<string, { updatedAt: number; invariants: string[]; derived: string[] }>();
 
     const pruneOldestByUpdatedAt = <T extends { updatedAt: number }>(map: Map<string, T>, maxSize: number) => {
       if (map.size <= maxSize) return;
@@ -2135,20 +2132,6 @@ const memoryLanceDBProPlugin = {
       reflectionByAgentCache.set(cacheKey, next);
       return next;
     };
-
-    // Session-based recall history to prevent redundant injections
-    // Map<sessionId, Map<memoryId, turnIndex>>
-    const recallHistory = new Map<string, Map<string, number>>();
-
-    // Map<sessionId, turnCounter> - manual turn tracking per session
-    const turnCounter = new Map<string, number>();
-
-    // Track how many normalized user texts have already been seen per session snapshot.
-    // All three Maps are pruned to AUTO_CAPTURE_MAP_MAX_ENTRIES to prevent unbounded
-    // growth in long-running processes with many distinct sessions.
-    const autoCaptureSeenTextCount = new Map<string, number>();
-    const autoCapturePendingIngressTexts = new Map<string, string[]>();
-    const autoCaptureRecentTexts = new Map<string, string[]>();
 
     const logReg = isCliMode() ? api.logger.debug : api.logger.info;
     logReg(

--- a/index.ts
+++ b/index.ts
@@ -1736,149 +1736,35 @@ const memoryLanceDBProPlugin = {
     _registeredApis.add(api);
 
     // Parse and validate configuration
-    const config = parsePluginConfig(api.pluginConfig);
-
-    const resolvedDbPath = api.resolvePath(config.dbPath || getDefaultDbPath());
-
-    // Pre-flight: validate storage path (symlink resolution, mkdir, write check).
-    // Runs synchronously and logs warnings; does NOT block gateway startup.
-    try {
-      validateStoragePath(resolvedDbPath);
-    } catch (err) {
-      api.logger.warn(
-        `memory-lancedb-pro: storage path issue — ${String(err)}\n` +
-        `  The plugin will still attempt to start, but writes may fail.`,
-      );
-    }
-
-    const vectorDim = getVectorDimensions(
-      config.embedding.model || "text-embedding-3-small",
-      config.embedding.dimensions,
-    );
-
-    // Initialize core components
-    const store = new MemoryStore({ dbPath: resolvedDbPath, vectorDim });
-    const embedder = createEmbedder({
-      provider: "openai-compatible",
-      apiKey: config.embedding.apiKey,
-      model: config.embedding.model || "text-embedding-3-small",
-      baseURL: config.embedding.baseURL,
-      dimensions: config.embedding.dimensions,
-      omitDimensions: config.embedding.omitDimensions,
-      taskQuery: config.embedding.taskQuery,
-      taskPassage: config.embedding.taskPassage,
-      normalized: config.embedding.normalized,
-      chunking: config.embedding.chunking,
-    });
-    // Initialize decay engine
-    const decayEngine = createDecayEngine({
-      ...DEFAULT_DECAY_CONFIG,
-      ...(config.decay || {}),
-    });
-    const tierManager = createTierManager({
-      ...DEFAULT_TIER_CONFIG,
-      ...(config.tier || {}),
-    });
-    const retriever = createRetriever(
+    // ========================================================================
+    // Phase 2 — Singleton state: initialize heavy resources exactly once.
+    // First register() call runs _initPluginState(); subsequent calls reuse
+    // the same singleton via destructuring. This prevents:
+    //   - Memory heap growth from repeated resource creation (~9 calls/process)
+    //   - Accumulated session Maps being lost on re-registration
+    // ========================================================================
+    if (!_singletonState) { _singletonState = _initPluginState(api); }
+    const {
+      config,
+      resolvedDbPath,
       store,
       embedder,
-      {
-        ...DEFAULT_RETRIEVAL_CONFIG,
-        ...config.retrieval,
-      },
-      { decayEngine },
-    );
-    const scopeManager = createScopeManager(config.scopes);
+      retriever,
+      scopeManager,
+      smartExtractor,
+      decayEngine,
+      tierManager,
+      extractionRateLimiter,
+      reflectionErrorStateBySession,
+      reflectionDerivedBySession,
+      reflectionByAgentCache,
+      recallHistory,
+      turnCounter,
+      autoCaptureSeenTextCount,
+      autoCapturePendingIngressTexts,
+      autoCaptureRecentTexts,
+    } = _singletonState;
 
-    // ClawTeam integration: extend accessible scopes via env var
-    const clawteamScopes = parseClawteamScopes(process.env.CLAWTEAM_MEMORY_SCOPE);
-    if (clawteamScopes.length > 0) {
-      applyClawteamScopes(scopeManager, clawteamScopes);
-      api.logger.info(`memory-lancedb-pro: CLAWTEAM_MEMORY_SCOPE added scopes: ${clawteamScopes.join(", ")}`);
-    }
-
-    const migrator = createMigrator(store);
-
-    // Initialize smart extraction
-    let smartExtractor: SmartExtractor | null = null;
-    if (config.smartExtraction !== false) {
-      try {
-        const llmAuth = config.llm?.auth || "api-key";
-        const llmApiKey = llmAuth === "oauth"
-          ? undefined
-          : config.llm?.apiKey
-            ? resolveEnvVars(config.llm.apiKey)
-            : resolveFirstApiKey(config.embedding.apiKey);
-        const llmBaseURL = llmAuth === "oauth"
-          ? (config.llm?.baseURL ? resolveEnvVars(config.llm.baseURL) : undefined)
-          : config.llm?.baseURL
-            ? resolveEnvVars(config.llm.baseURL)
-            : config.embedding.baseURL;
-        const llmModel = config.llm?.model || "openai/gpt-oss-120b";
-        const llmOauthPath = llmAuth === "oauth"
-          ? resolveOptionalPathWithEnv(api, config.llm?.oauthPath, ".memory-lancedb-pro/oauth.json")
-          : undefined;
-        const llmOauthProvider = llmAuth === "oauth"
-          ? config.llm?.oauthProvider
-          : undefined;
-        const llmTimeoutMs = resolveLlmTimeoutMs(config);
-
-        const llmClient = createLlmClient({
-          auth: llmAuth,
-          apiKey: llmApiKey,
-          model: llmModel,
-          baseURL: llmBaseURL,
-          oauthProvider: llmOauthProvider,
-          oauthPath: llmOauthPath,
-          timeoutMs: llmTimeoutMs,
-          log: (msg: string) => api.logger.debug(msg),
-          warnLog: (msg: string) => api.logger.warn(msg),
-        });
-
-        // Initialize embedding-based noise prototype bank (async, non-blocking)
-        const noiseBank = new NoisePrototypeBank(
-          (msg: string) => api.logger.debug(msg),
-        );
-        noiseBank.init(embedder).catch((err) =>
-          api.logger.debug(`memory-lancedb-pro: noise bank init: ${String(err)}`),
-        );
-
-        const admissionRejectionAuditWriter = createAdmissionRejectionAuditWriter(
-          config,
-          resolvedDbPath,
-          api,
-        );
-
-        smartExtractor = new SmartExtractor(store, embedder, llmClient, {
-          user: "User",
-          extractMinMessages: config.extractMinMessages ?? 4,
-          extractMaxChars: config.extractMaxChars ?? 8000,
-          defaultScope: config.scopes?.default ?? "global",
-          workspaceBoundary: config.workspaceBoundary,
-          admissionControl: config.admissionControl,
-          onAdmissionRejected: admissionRejectionAuditWriter ?? undefined,
-          log: (msg: string) => api.logger.info(msg),
-          debugLog: (msg: string) => api.logger.debug(msg),
-          noiseBank,
-        });
-
-        (isCliMode() ? api.logger.debug : api.logger.info)(
-          "memory-lancedb-pro: smart extraction enabled (LLM model: "
-          + llmModel
-          + ", timeoutMs: "
-          + llmTimeoutMs
-          + ", noise bank: ON)",
-        );
-      } catch (err) {
-        api.logger.warn(`memory-lancedb-pro: smart extraction init failed, falling back to regex: ${String(err)}`);
-      }
-    }
-
-    // Extraction rate limiter (Feature 7: Adaptive Extraction Throttling)
-    // NOTE: This rate limiter is global — shared across all agents in multi-agent setups.
-    const extractionRateLimiter = createExtractionRateLimiter({
-      maxExtractionsPerHour: config.extractionThrottle?.maxExtractionsPerHour,
-    });
 
     async function sleep(ms: number): Promise<void> {
       await new Promise(resolve => setTimeout(resolve, ms));

--- a/index.ts
+++ b/index.ts
@@ -1686,6 +1686,40 @@ function _dedupHookEvent(handlerName: string, event: any): boolean {
   return false; // first occurrence — proceed
 }
 
+// ============================================================================
+// Phase 2 — Singleton State Management (PR #598)
+// ============================================================================
+
+interface PluginSingletonState {
+  config: ReturnType<typeof parsePluginConfig>;
+  resolvedDbPath: string;
+  store: MemoryStore;
+  embedder: ReturnType<typeof createEmbedder>;
+  decayEngine: ReturnType<typeof createDecayEngine>;
+  tierManager: ReturnType<typeof createTierManager>;
+  retriever: ReturnType<typeof createRetriever>;
+  scopeManager: ReturnType<typeof createScopeManager>;
+  migrator: ReturnType<typeof createMigrator>;
+  smartExtractor: SmartExtractor | null;
+  extractionRateLimiter: ReturnType<typeof createExtractionRateLimiter>;
+  // Session Maps — persist across scope refreshes instead of being recreated
+  reflectionErrorStateBySession: Map<string, ReflectionErrorState>;
+  reflectionDerivedBySession: Map<string, { updatedAt: number; derived: string[] }>;
+  reflectionByAgentCache: Map<string, { updatedAt: number; invariants: string[]; derived: string[] }>;
+  recallHistory: Map<string, Map<string, number>>;
+  turnCounter: Map<string, number>;
+  autoCaptureSeenTextCount: Map<string, number>;
+  autoCapturePendingIngressTexts: Map<string, string[]>;
+  autoCaptureRecentTexts: Map<string, string[]>;
+}
+
+let _singletonState: PluginSingletonState | null = null;
+
+function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
+  // Resources will be migrated here in next commit
+  return null!;
+}
+
 const memoryLanceDBProPlugin = {
   id: "memory-lancedb-pro",
   name: "Memory (LanceDB Pro)",

--- a/index.ts
+++ b/index.ts
@@ -1716,8 +1716,166 @@ interface PluginSingletonState {
 let _singletonState: PluginSingletonState | null = null;
 
 function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
-  // Resources will be migrated here in next commit
-  return null!;
+  const config = parsePluginConfig(api.pluginConfig);
+  const resolvedDbPath = api.resolvePath(config.dbPath || getDefaultDbPath());
+
+  try {
+    validateStoragePath(resolvedDbPath);
+  } catch (err) {
+    api.logger.warn(
+      `memory-lancedb-pro: storage path issue — ${String(err)}\n` +
+      `  The plugin will still attempt to start, but writes may fail.`,
+    );
+  }
+
+  const vectorDim = getVectorDimensions(
+    config.embedding.model || "text-embedding-3-small",
+    config.embedding.dimensions,
+  );
+  const store = new MemoryStore({ dbPath: resolvedDbPath, vectorDim });
+  const embedder = createEmbedder({
+    provider: "openai-compatible",
+    apiKey: config.embedding.apiKey,
+    model: config.embedding.model || "text-embedding-3-small",
+    baseURL: config.embedding.baseURL,
+    dimensions: config.embedding.dimensions,
+    omitDimensions: config.embedding.omitDimensions,
+    taskQuery: config.embedding.taskQuery,
+    taskPassage: config.embedding.taskPassage,
+    normalized: config.embedding.normalized,
+    chunking: config.embedding.chunking,
+  });
+  const decayEngine = createDecayEngine({
+    ...DEFAULT_DECAY_CONFIG,
+    ...(config.decay || {}),
+  });
+  const tierManager = createTierManager({
+    ...DEFAULT_TIER_CONFIG,
+    ...(config.tier || {}),
+  });
+  const retriever = createRetriever(
+    store,
+    embedder,
+    { ...DEFAULT_RETRIEVAL_CONFIG, ...config.retrieval },
+    { decayEngine },
+  );
+  const scopeManager = createScopeManager(config.scopes);
+
+  const clawteamScopes = parseClawteamScopes(process.env.CLAWTEAM_MEMORY_SCOPE);
+  if (clawteamScopes.length > 0) {
+    applyClawteamScopes(scopeManager, clawteamScopes);
+    api.logger.info(`memory-lancedb-pro: CLAWTEAM_MEMORY_SCOPE added scopes: ${clawteamScopes.join(", ")}`);
+  }
+
+  const migrator = createMigrator(store);
+
+  let smartExtractor: SmartExtractor | null = null;
+  if (config.smartExtraction !== false) {
+    try {
+      const llmAuth = config.llm?.auth || "api-key";
+      const llmApiKey = llmAuth === "oauth"
+        ? undefined
+        : config.llm?.apiKey
+          ? resolveEnvVars(config.llm.apiKey)
+          : resolveFirstApiKey(config.embedding.apiKey);
+      const llmBaseURL = llmAuth === "oauth"
+        ? (config.llm?.baseURL ? resolveEnvVars(config.llm.baseURL) : undefined)
+        : config.llm?.baseURL
+          ? resolveEnvVars(config.llm.baseURL)
+          : config.embedding.baseURL;
+      const llmModel = config.llm?.model || "openai/gpt-oss-120b";
+      const llmOauthPath = llmAuth === "oauth"
+        ? resolveOptionalPathWithEnv(api, config.llm?.oauthPath, ".memory-lancedb-pro/oauth.json")
+        : undefined;
+      const llmOauthProvider = llmAuth === "oauth" ? config.llm?.oauthProvider : undefined;
+      const llmTimeoutMs = resolveLlmTimeoutMs(config);
+
+      const llmClient = createLlmClient({
+        auth: llmAuth,
+        apiKey: llmApiKey,
+        model: llmModel,
+        baseURL: llmBaseURL,
+        oauthProvider: llmOauthProvider,
+        oauthPath: llmOauthPath,
+        timeoutMs: llmTimeoutMs,
+        log: (msg: string) => api.logger.debug(msg),
+        warnLog: (msg: string) => api.logger.warn(msg),
+      });
+
+      const noiseBank = new NoisePrototypeBank((msg: string) => api.logger.debug(msg));
+      noiseBank.init(embedder).catch((err) =>
+        api.logger.debug(`memory-lancedb-pro: noise bank init: ${String(err)}`),
+      );
+
+      const admissionRejectionAuditWriter = createAdmissionRejectionAuditWriter(config, resolvedDbPath, api);
+
+      smartExtractor = new SmartExtractor(store, embedder, llmClient, {
+        user: "User",
+        extractMinMessages: config.extractMinMessages ?? 4,
+        extractMaxChars: config.extractMaxChars ?? 8000,
+        defaultScope: config.scopes?.default ?? "global",
+        workspaceBoundary: config.workspaceBoundary,
+        admissionControl: config.admissionControl,
+        onAdmissionRejected: admissionRejectionAuditWriter ?? undefined,
+        log: (msg: string) => api.logger.info(msg),
+        debugLog: (msg: string) => api.logger.debug(msg),
+        noiseBank,
+      });
+
+      (isCliMode() ? api.logger.debug : api.logger.info)(
+        "memory-lancedb-pro: smart extraction enabled (LLM model: "
+        + llmModel
+        + ", timeoutMs: "
+        + llmTimeoutMs
+        + ", noise bank: ON)",
+      );
+    } catch (err) {
+      api.logger.warn(`memory-lancedb-pro: smart extraction init failed, falling back to regex: ${String(err)}`);
+    }
+  }
+
+  const extractionRateLimiter = createExtractionRateLimiter({
+    maxExtractionsPerHour: config.extractionThrottle?.maxExtractionsPerHour,
+  });
+
+  // Session Maps — MUST be in singleton state so they persist across scope refreshes
+  const reflectionErrorStateBySession = new Map<string, ReflectionErrorState>();
+  const reflectionDerivedBySession = new Map<string, { updatedAt: number; derived: string[] }>();
+  const reflectionByAgentCache = new Map<string, { updatedAt: number; invariants: string[]; derived: string[] }>();
+  const recallHistory = new Map<string, Map<string, number>>();
+  const turnCounter = new Map<string, number>();
+  const autoCaptureSeenTextCount = new Map<string, number>();
+  const autoCapturePendingIngressTexts = new Map<string, string[]>();
+  const autoCaptureRecentTexts = new Map<string, string[]>();
+
+  const logReg = isCliMode() ? api.logger.debug : api.logger.info;
+  logReg(
+    `memory-lancedb-pro@${pluginVersion}: plugin registered [singleton init] `
+    + `(db: ${resolvedDbPath}, model: ${config.embedding.model || "text-embedding-3-small"})`,
+  );
+  logReg(`memory-lancedb-pro: diagnostic build tag loaded (${DIAG_BUILD_TAG})`);
+
+  return {
+    config,
+    resolvedDbPath,
+    store,
+    embedder,
+    decayEngine,
+    tierManager,
+    retriever,
+    scopeManager,
+    migrator,
+    smartExtractor,
+    extractionRateLimiter,
+    reflectionErrorStateBySession,
+    reflectionDerivedBySession,
+    reflectionByAgentCache,
+    recallHistory,
+    turnCounter,
+    autoCaptureSeenTextCount,
+    autoCapturePendingIngressTexts,
+    autoCaptureRecentTexts,
+  };
 }
 
 const memoryLanceDBProPlugin = {

--- a/index.ts
+++ b/index.ts
@@ -1909,6 +1909,7 @@ const memoryLanceDBProPlugin = {
       embedder,
       retriever,
       scopeManager,
+      migrator,
       smartExtractor,
       decayEngine,
       tierManager,


### PR DESCRIPTION
## Phase 2: Singleton State Management

Split into 4 clean commits for reviewer convenience.

### Commits

| # | Commit | Description |
|---|--------|-------------|
| 1 | `0a74a95` | Add `PluginSingletonState` interface + `_singletonState` variable + empty `_initPluginState()` skeleton |
| 2 | `dc02799` | Replace register() init block with singleton guard + 18-property destructuring |
| 3 | `2bbab76` | Fill `_initPluginState()` body with all resources (store, embedder, tierManager, retriever, 8 Maps, etc.) |
| 4 | `9c466ab` | Remove 8 old duplicate Map declarations from helpers section |

### Motivation

The old `register()` function ran a ~140-line init block on **every call**. In multi-agent processes with 9 scope registrations per lifecycle, this created duplicate heavy resources (stores, embedders, tier managers) and accumulated session Maps across re-registrations.

### Solution

- Extract all resource creation into `_initPluginState(api)` factory function
- Guard with `if (!_singletonState)` — first call initializes, subsequent calls reuse
- 18 singleton state properties: 10 resources + 8 session Maps
- Helpers access via destructuring (Phase 1 dedup hooks unchanged)

### Testing

- CLI smoke: `openclaw memory-pro stats`
- Phase 1 dedup hooks: `_hookEventDedup` / `_dedupHookEvent` remain intact
- Session Maps appear **exactly once** in `_initPluginState` return

### Files Changed

- `index.ts`: single file refactor, no new tests required for infrastructure change

### Notes

- Intermediate commits (C2) intentionally leave factory body as `return null!` — breaks TypeScript compilation until C3 fills it. This is expected for the commit-split strategy.
- Final state (after all 4 commits): 4246 lines, 1013/1013 balanced braces
