### PR TITLE
fix: Issue #598 Phase 3 - EmbeddingCache LRU semantics

### DIFF
--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -69,6 +69,10 @@ class EmbeddingCache {
 
   set(text: string, task: string | undefined, vector: number[]): void {
     const k = this.key(text, task);
+    // If key already exists, delete to update insertion order for correct LRU semantics
+    if (this.cache.has(k)) {
+      this.cache.delete(k);
+    }
     // When cache is full, run TTL eviction first (removes expired + oldest).
     // This prevents unbounded growth from stale entries while keeping writes O(1).
     if (this.cache.size >= this.maxSize) {

--- a/test/embedder-lru.test.mjs
+++ b/test/embedder-lru.test.mjs
@@ -1,0 +1,32 @@
+/**
+ * Issue #598 Phase 3 - EmbeddingCache LRU Semantics Test
+ * Tests that re-setting an existing key updates its LRU position.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const jiti = require("jiti")(__filename);
+
+describe("EmbeddingCache LRU semantics", () => {
+  it("updates insertion order when re-setting existing key", async () => {
+    const { Embedder } = jiti("../src/embedder.ts");
+
+    const embedder = new Embedder({});
+    const cache = embedder["cache"];
+
+    // Set two keys
+    cache.set("key1", undefined, [1, 0, 0]);
+    cache.set("key2", undefined, [0, 1, 0]);
+
+    // Re-set key1 with different value (should move to most recent)
+    cache.set("key1", undefined, [1, 1, 0]);
+
+    // Evict one - should evict key2 (oldest), not key1 (which was re-set)
+    cache.set("key3", undefined, [0, 0, 1]);
+
+    assert.strictEqual(cache.cache.has("key1"), true, "key1 should remain after re-set");
+    assert.strictEqual(cache.cache.has("key2"), false, "key2 should be evicted (oldest)");
+    assert.strictEqual(cache.cache.has("key3"), true, "key3 should be added");
+  });
+});


### PR DESCRIPTION
## Summary

Issue #598 Phase 3: EmbeddingCache LRU semantics fix

**Note**: Phase 1 (hook deduplication) and Phase 2 (singleton state) were already merged in upstream master. This PR only adds the LRU improvement.

### Changes

| File | Fix |
|------|-----|
| \src/embedder.ts\ | Update LRU insertion order when re-setting existing key |
| \	est/embedder-lru.test.mjs\ | Add unit test for LRU semantics |

### Details

When an existing cache key is re-set, explicitly \delete()\ it first to maintain correct LRU ordering. Without this, the insertion order stays stale and the LRU eviction removes the wrong entry.

### Existing upstream fixes (already in master)

- ✅ EmbeddingCache TTL proactive cleanup (\_evictExpired()\)
- ✅ RetrievalStatsCollector Ring Buffer (O(1) write)
- ✅ NoisePrototypeBank DEDUP_THRESHOLD = 0.90

Closes #598 (Phase 3)