### PR TITLE
test: restore master baseline CI coverage

### DIFF
--- a/scripts/verify-ci-test-manifest.mjs
+++ b/scripts/verify-ci-test-manifest.mjs
@@ -48,6 +48,8 @@ const EXPECTED_BASELINE = [
   { group: "core-regression", runner: "node", file: "test/store-serialization.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/access-tracker-retry.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/embedder-cache.test.mjs" },
+  // Issue #629 batch embedding fix
+  { group: "llm-clients-and-auth", runner: "node", file: "test/embedder-ollama-batch-routing.test.mjs" },
 ];
 
 function fail(message) {

--- a/test/embedder-ollama-batch-routing.test.mjs
+++ b/test/embedder-ollama-batch-routing.test.mjs
@@ -41,11 +41,13 @@ function readJson(req) {
 
 function makeOllamaMock(handler) {
   return http.createServer((req, res) => {
-    if (req.method === "POST" && req.url === "/api/embeddings") {
+    const requestPath = (req.url || "").replace(/^\/ollama\b/, "");
+
+    if (req.method === "POST" && requestPath === "/api/embeddings") {
       handler(req, res, "api");
       return;
     }
-    if (req.method === "POST" && req.url === "/v1/embeddings") {
+    if (req.method === "POST" && requestPath === "/v1/embeddings") {
       handler(req, res, "v1");
       return;
     }
@@ -76,6 +78,12 @@ async function startMockServer(server) {
   });
 }
 
+function makeOllamaBaseURL(port) {
+  // Use a path marker instead of the default Ollama port so the test still
+  // exercises isOllamaProvider() without colliding with a real local server.
+  return `http://127.0.0.1:${port}/ollama/v1`;
+}
+
 test("single requests use /api/embeddings with prompt field", async () => {
   let capturedBody = null;
 
@@ -86,7 +94,7 @@ test("single requests use /api/embeddings with prompt field", async () => {
   });
 
   const port = await startMockServer(server);
-  const baseURL = `http://127.0.0.1:${port}/v1`;
+  const baseURL = makeOllamaBaseURL(port);
 
   try {
     const embedder = new Embedder({
@@ -97,6 +105,7 @@ test("single requests use /api/embeddings with prompt field", async () => {
       dimensions: DIMS,
     });
 
+    assert.equal(embedder.isOllamaProvider(), true, "expected /ollama baseURL to use native fetch");
     const result = await embedder.embedPassage("hello world");
 
     assert.equal(capturedBody?.model, "mxbai-embed-large");
@@ -122,7 +131,7 @@ test("batch requests use /v1/embeddings with input array", async () => {
   });
 
   const port = await startMockServer(server);
-  const baseURL = `http://127.0.0.1:${port}/v1`;
+  const baseURL = makeOllamaBaseURL(port);
 
   try {
     const embedder = new Embedder({
@@ -164,7 +173,7 @@ test("batch rejects response with wrong number of embeddings", async () => {
   });
 
   const port = await startMockServer(server);
-  const baseURL = `http://127.0.0.1:${port}/v1`;
+  const baseURL = makeOllamaBaseURL(port);
 
   try {
     const embedder = new Embedder({
@@ -209,7 +218,7 @@ test("batch rejects response with empty embedding array", async () => {
   });
 
   const port = await startMockServer(server);
-  const baseURL = `http://127.0.0.1:${port}/v1`;
+  const baseURL = makeOllamaBaseURL(port);
 
   try {
     const embedder = new Embedder({
@@ -246,7 +255,7 @@ test("single-element batch still routes to /v1/embeddings", async () => {
   });
 
   const port = await startMockServer(server);
-  const baseURL = `http://127.0.0.1:${port}/v1`;
+  const baseURL = makeOllamaBaseURL(port);
 
   try {
     const embedder = new Embedder({

--- a/test/recall-text-cleanup.test.mjs
+++ b/test/recall-text-cleanup.test.mjs
@@ -25,6 +25,7 @@ const origCreateEmbedder = embedderModuleForMock.createEmbedder;
 
 const pluginModule = jiti("../index.ts");
 const memoryLanceDBProPlugin = pluginModule.default || pluginModule;
+const resetRegistration = pluginModule.resetRegistration ?? (() => {});
 const { registerMemoryRecallTool, registerMemoryStoreTool } = jiti("../src/tools.ts");
 const { MemoryRetriever } = jiti("../src/retriever.js");
 const { buildSmartMetadata, stringifySmartMetadata } = jiti("../src/smart-metadata.ts");
@@ -329,6 +330,7 @@ describe("recall text cleanup", () => {
   beforeEach(() => {
     workspaceDir = mkdtempSync(path.join(tmpdir(), "recall-text-cleanup-test-"));
     originalRetrieve = MemoryRetriever.prototype.retrieve;
+    resetRegistration();
   });
 
   afterEach(() => {
@@ -336,6 +338,7 @@ describe("recall text cleanup", () => {
     // Restore factory functions on the .js module (same cache as index.ts uses)
     retrieverModuleForMock.createRetriever = origCreateRetriever;
     embedderModuleForMock.createEmbedder = origCreateEmbedder;
+    resetRegistration();
     rmSync(workspaceDir, { recursive: true, force: true });
   });
 
@@ -1096,4 +1099,3 @@ describe("recall text cleanup", () => {
     }
   });
 });
-

--- a/test/smart-extractor-branches.mjs
+++ b/test/smart-extractor-branches.mjs
@@ -16,6 +16,7 @@ Module._initPaths();
 
 const jiti = jitiFactory(import.meta.url, { interopDefault: true });
 const plugin = jiti("../index.ts");
+const resetRegistration = plugin.resetRegistration ?? (() => {});
 const { MemoryStore } = jiti("../src/store.ts");
 const { createEmbedder } = jiti("../src/embedder.ts");
 const { buildSmartMetadata, stringifySmartMetadata } = jiti("../src/smart-metadata.ts");
@@ -151,6 +152,11 @@ async function runAgentEndHook(api, event, ctx) {
   }
 }
 
+function registerFreshPlugin(api) {
+  resetRegistration();
+  plugin.register(api);
+}
+
 async function seedPreference(dbPath) {
   const store = new MemoryStore({ dbPath, vectorDim: EMBEDDING_DIMENSIONS });
   const embedder = createEmbedder({
@@ -268,7 +274,7 @@ async function runScenario(mode) {
       `http://127.0.0.1:${port}`,
       logs,
     );
-    plugin.register(api);
+    registerFreshPlugin(api);
     await seedPreference(dbPath);
 
     await runAgentEndHook(
@@ -450,7 +456,7 @@ async function runMultiRoundScenario() {
       `http://127.0.0.1:${port}`,
       logs,
     );
-    plugin.register(api);
+    registerFreshPlugin(api);
 
     const rounds = [
       ["最近我在调整饮品偏好。", "我喜欢乌龙茶。", "这条偏好以后都有效。", "请记住。"],
@@ -549,7 +555,7 @@ async function runInjectedRecallScenario() {
       `http://127.0.0.1:${port}`,
       logs,
     );
-    plugin.register(api);
+    registerFreshPlugin(api);
 
     await runAgentEndHook(
       api,
@@ -643,7 +649,7 @@ async function runPrependedRecallWithUserTextScenario() {
       `http://127.0.0.1:${port}`,
       logs,
     );
-    plugin.register(api);
+    registerFreshPlugin(api);
 
     await runAgentEndHook(
       api,
@@ -735,7 +741,7 @@ async function runInboundMetadataWrappedScenario() {
       `http://127.0.0.1:${port}`,
       logs,
     );
-    plugin.register(api);
+    registerFreshPlugin(api);
 
     await runAgentEndHook(
       api,
@@ -791,7 +797,7 @@ async function runSessionDeltaScenario() {
       "http://127.0.0.1:9",
       logs,
     );
-    plugin.register(api);
+    registerFreshPlugin(api);
 
     await runAgentEndHook(
       api,
@@ -855,7 +861,7 @@ async function runPendingIngressScenario() {
       "http://127.0.0.1:9",
       logs,
     );
-    plugin.register(api);
+    registerFreshPlugin(api);
 
     await api.hooks.message_received(
       { from: "discord:channel:1", content: "@jige_claw_bot 我的饮品偏好是乌龙茶" },
@@ -911,7 +917,7 @@ async function runRememberCommandContextScenario() {
       "http://127.0.0.1:9",
       logs,
     );
-    plugin.register(api);
+    registerFreshPlugin(api);
 
     await api.hooks.message_received(
       { from: "discord:channel:1", content: "@jige_claw_bot 我的饮品偏好是乌龙茶" },
@@ -1036,7 +1042,7 @@ async function runUserMdExclusiveProfileScenario() {
         enabled: true,
       },
     };
-    plugin.register(api);
+    registerFreshPlugin(api);
 
     await runAgentEndHook(
       api,
@@ -1134,7 +1140,7 @@ async function runBoundarySkipKeepsRegexFallbackScenario() {
         enabled: true,
       },
     };
-    plugin.register(api);
+    registerFreshPlugin(api);
 
     await runAgentEndHook(
       api,
@@ -1236,7 +1242,7 @@ async function runInboundMetadataCleanupScenario() {
       `http://127.0.0.1:${port}`,
       logs,
     );
-    plugin.register(api);
+    registerFreshPlugin(api);
 
     await runAgentEndHook(
       api,


### PR DESCRIPTION
## Summary
- add the missing `embedder-ollama-batch-routing` baseline entry to the CI manifest verifier
- align the Ollama batch routing test with the existing `/ollama` provider-detection contract while keeping random-port mocks
- reset plugin singleton registration state between recall and smart-extractor regression scenarios so later cases do not inherit stale config, hooks, or stores

## Root causes fixed
- `scripts/verify-ci-test-manifest.mjs` was not updated when `test/embedder-ollama-batch-routing.test.mjs` was added to the CI manifest
- `test/embedder-ollama-batch-routing.test.mjs` assumed any random loopback port would hit the Ollama native-fetch path, but the implementation only treats `:11434` or `/ollama` URLs as Ollama
- `test/recall-text-cleanup.test.mjs` and `test/smart-extractor-branches.mjs` were reusing singleton plugin state across scenarios after the phase-2 singleton work, which caused stale retriever/LLM/store config to leak between cases

## Verification
- `node scripts/verify-ci-test-manifest.mjs`
- `node --test test/embedder-ollama-batch-routing.test.mjs`
- `node --test test/recall-text-cleanup.test.mjs`
- `node test/smart-extractor-branches.mjs`
- `npm run test:packaging-and-workflow`
- `npm run test:llm-clients-and-auth`
- `npm run test:core-regression`
- `npm test`
