### PR TITLE
fix(auto-recall): thread AbortSignal to cancel embedding on timeout

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1942,10 +1942,12 @@ const memoryLanceDBProPlugin = {
       limit: number;
       scopeFilter?: string[];
       category?: string;
+      signal?: AbortSignal;
     }) {
       let results = await retriever.retrieve(params);
       if (results.length === 0) {
         await sleep(75);
+        if (params.signal?.aborted) return results;
         results = await retriever.retrieve(params);
       }
       return results;
@@ -2407,7 +2409,13 @@ const memoryLanceDBProPlugin = {
         // (embedding → rerank → lifecycle), which can silently drop messages on
         // channels like Telegram when subsequent requests hit lock timeouts.
         // See: https://github.com/CortexReach/memory-lancedb-pro/issues/253
-        const recallWork = async (): Promise<{ prependContext: string } | undefined> => {
+        //
+        // The timeout also aborts the in-flight embedding HTTP call via the
+        // abortController below, so the underlying work doesn't continue to hold
+        // resources (lancedb connection, per-agent memory-runtime mutex) past
+        // the timeout boundary.
+        const abortController = new AbortController();
+        const recallWork = async (signal: AbortSignal): Promise<{ prependContext: string } | undefined> => {
           // Determine agent ID and accessible scopes
           const agentId = resolveHookAgentId(ctx?.agentId, (event as any).sessionKey);
           const accessibleScopes = resolveScopeFilter(scopeManager, agentId);
@@ -2450,6 +2458,7 @@ const memoryLanceDBProPlugin = {
             limit: retrieveLimit,
             scopeFilter: accessibleScopes,
             source: "auto-recall",
+            signal,
           }), config.workspaceBoundary);
 
           if (results.length === 0) {
@@ -2690,9 +2699,12 @@ const memoryLanceDBProPlugin = {
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         try {
           const result = await Promise.race([
-            recallWork().then((r) => { clearTimeout(timeoutId); return r; }),
+            recallWork(abortController.signal).then((r) => { clearTimeout(timeoutId); return r; }),
             new Promise<undefined>((resolve) => {
               timeoutId = setTimeout(() => {
+                // Cancel in-flight embedding/retrieval HTTP calls so they don't
+                // keep holding resources after we've given up on the result.
+                abortController.abort(new Error("auto-recall timeout"));
                 api.logger.warn(
                   `memory-lancedb-pro: auto-recall timed out after ${AUTO_RECALL_TIMEOUT_MS}ms; skipping memory injection to avoid stalling agent startup`,
                 );
@@ -2703,7 +2715,14 @@ const memoryLanceDBProPlugin = {
           return result;
         } catch (err) {
           clearTimeout(timeoutId);
-          api.logger.warn(`memory-lancedb-pro: recall failed: ${String(err)}`);
+          // Downgrade AbortError to debug — the timeout path already emitted
+          // a warn log, and the race has already resolved undefined.
+          const isAbort = err instanceof Error && (err.name === "AbortError" || /abort/i.test(err.message));
+          if (isAbort) {
+            api.logger.debug?.(`memory-lancedb-pro: recall aborted: ${String(err)}`);
+          } else {
+            api.logger.warn(`memory-lancedb-pro: recall failed: ${String(err)}`);
+          }
         }
       }, { priority: 10 });
 

--- a/index.ts
+++ b/index.ts
@@ -2715,11 +2715,12 @@ const memoryLanceDBProPlugin = {
           return result;
         } catch (err) {
           clearTimeout(timeoutId);
-          // Downgrade AbortError to debug — the timeout path already emitted
-          // a warn log, and the race has already resolved undefined.
-          const isAbort = err instanceof Error && (err.name === "AbortError" || /abort/i.test(err.message));
-          if (isAbort) {
-            api.logger.debug?.(`memory-lancedb-pro: recall aborted: ${String(err)}`);
+          // Downgrade to debug only when OUR controller aborted (i.e. the
+          // timeout callback fired). Aborts originating elsewhere — e.g. the
+          // embedder's own internal timeout — keep warn visibility so real
+          // failures aren't silenced.
+          if (abortController.signal.aborted) {
+            api.logger.debug?.(`memory-lancedb-pro: recall aborted by timeout: ${String(err)}`);
           } else {
             api.logger.warn(`memory-lancedb-pro: recall failed: ${String(err)}`);
           }

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -105,6 +105,10 @@ export interface RetrievalContext {
   category?: string;
   /** Retrieval source: "manual" for user-triggered, "auto-recall" for system-initiated, "cli" for CLI commands. */
   source?: "manual" | "auto-recall" | "cli";
+  /** Optional AbortSignal. When aborted, in-flight embedding calls cancel and
+   *  the method rejects with AbortError instead of holding the caller's session
+   *  lock while the underlying HTTP request runs to completion. */
+  signal?: AbortSignal;
 }
 
 export interface RetrievalResult extends MemorySearchResult {
@@ -559,7 +563,7 @@ export class MemoryRetriever {
   }
 
   async retrieve(context: RetrievalContext): Promise<RetrievalResult[]> {
-    const { query, limit, scopeFilter, category, source } = context;
+    const { query, limit, scopeFilter, category, source, signal } = context;
     const safeLimit = clampInt(limit, 1, 20);
     this.lastDiagnostics = null;
     const diagnostics: RetrievalDiagnostics = {
@@ -615,6 +619,7 @@ export class MemoryRetriever {
           category,
           trace,
           diagnostics,
+          signal,
         );
       } else {
         results = await this.hybridRetrieval(
@@ -625,6 +630,7 @@ export class MemoryRetriever {
           trace,
           source,
           diagnostics,
+          signal,
         );
       }
 
@@ -717,11 +723,12 @@ export class MemoryRetriever {
     category?: string,
     trace?: TraceCollector,
     diagnostics?: RetrievalDiagnostics,
+    signal?: AbortSignal,
   ): Promise<RetrievalResult[]> {
     let failureStage: RetrievalDiagnostics["failureStage"] = "vector.embedQuery";
     try {
       const candidatePoolSize = Math.max(this.config.candidatePoolSize, limit * 2);
-      const queryVector = await this.embedder.embedQuery(query);
+      const queryVector = await this.embedder.embedQuery(query, signal);
       failureStage = "vector.vectorSearch";
       const results = await this.store.vectorSearch(
         queryVector,
@@ -907,11 +914,12 @@ export class MemoryRetriever {
     trace?: TraceCollector,
     source?: RetrievalContext["source"],
     diagnostics?: RetrievalDiagnostics,
+    signal?: AbortSignal,
   ): Promise<RetrievalResult[]> {
     let failureStage: RetrievalDiagnostics["failureStage"] = "hybrid.embedQuery";
     try {
       const candidatePoolSize = Math.max(this.config.candidatePoolSize, limit * 2);
-      const queryVector = await this.embedder.embedQuery(query);
+      const queryVector = await this.embedder.embedQuery(query, signal);
       const bm25Query = this.buildBM25Query(query, source);
       if (diagnostics) {
         diagnostics.bm25Query = bm25Query;

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -106,8 +106,9 @@ export interface RetrievalContext {
   /** Retrieval source: "manual" for user-triggered, "auto-recall" for system-initiated, "cli" for CLI commands. */
   source?: "manual" | "auto-recall" | "cli";
   /** Optional AbortSignal. When aborted, in-flight embedding calls cancel and
-   *  the method rejects with AbortError instead of holding the caller's session
-   *  lock while the underlying HTTP request runs to completion. */
+   *  the method rejects due to abort (often with AbortError or the signal's
+   *  abort reason) instead of holding the caller's session lock while the
+   *  underlying HTTP request runs to completion. */
   signal?: AbortSignal;
 }
 


### PR DESCRIPTION
## Summary

The auto-recall `before_prompt_build` hook wraps `recallWork()` in `Promise.race` with a `setTimeout` resolver (`index.ts:~2690`). When the timer fires, the race resolves `undefined` — but the underlying embedding HTTP call **keeps running**. No `AbortController`/`AbortSignal` is threaded through. The lingering work holds the per-agent memory-runtime mutex, so subsequent hook invocations serialize behind it.

In production at the reporter's site, this manifested as `stuck session: state=processing age=219s queueDepth=0` with the gateway's session-write-lock watchdog firing repeatedly. The gateway's lock max-hold is `timeoutMs + 120s grace` (min 300s), so a single slow embedding call ends up holding the session lock for 2–5 minutes before forced release.

## Changes

- **`index.ts`** — create an `AbortController` in the hook; pass `controller.signal` into a new `recallWork(signal)` parameter; in the `setTimeout` callback, call `controller.abort(new Error("auto-recall timeout"))` before resolving. The `catch` branch downgrades `AbortError` to a `debug` log (the timeout path already emitted a `warn`). `retrieveWithRetry` now accepts an optional `signal` and early-returns after the 75 ms retry gap if the signal was aborted in the interim.
- **`src/retriever.ts`** — add `signal?: AbortSignal` to `RetrievalContext`; destructure in `retrieve()`; forward to `vectorOnlyRetrieval()` and `hybridRetrieval()`, which pass it to `this.embedder.embedQuery(query, signal)`. The embedder already accepts an `AbortSignal` throughout (`src/embedder.ts:794,798,806,810,865`), so no downstream changes are needed.

## Scope

- **In scope:** auto-recall hook → retriever → embedder cancellation.
- **Out of scope (follow-ups):**
  - Jina rerank HTTP calls (separate code path in the retriever's rerank stage). Should also accept the signal. Left for a focused follow-up that touches the rerank client interface.
  - BM25 path has no long-running HTTP call and doesn't invoke `embedQuery`, so no plumbing needed.

## Test plan

Verified locally:
- `tsc --noEmit` introduces no new type errors. Two pre-existing errors remain (notably `TS2353` on `retrieveWithRetry` where `source` is passed but not declared in the inline param type — introduced by #535, independent of this PR).
- The previously-deployed (stale) plugin exhibited the stuck-session symptom under slow-embedding conditions; after rolling to a build with this change applied, a contrived delayed-embedding scenario returns from the hook inside the configured `autoRecallTimeoutMs` and the in-flight embedding fetch sees `signal.aborted === true`.

Automated test not added in this PR — suggested follow-up: a unit test that stubs the embedder with a 30 s delay and asserts `recallWork` returns within 100 ms of the timeout AND the stub receives an aborted signal.

## Related

- RCA: stuck-session incident on 2026-04-18 (`proving-ground` agent, OpenClaw 2026.4.9) directly implicated this code path.
- Related upstream fixes already merged: #541 (duplicate `memory_compact` registration), #626 (stale lockfile). Those address adjacent failure modes but not the `Promise.race`-without-cancellation root cause fixed here.

---

🤖 Developed with Claude Code (Claude Opus 4.7, 1M context).