### PR TITLE
fix: add isInvalidAgentIdFormat guard to runMemoryReflection (Issue #686)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1911,9 +1911,8 @@ function isAgentOrSessionExcluded(
     }
 
     if (p.endsWith("-")) {
-      // Wildcard prefix match: "pi-" matches "pi-agent"
-      const prefix = p.slice(0, -1);
-      if (cleanAgentId.startsWith(prefix)) return true;
+      // Wildcard prefix match: "pi-" matches "pi-agent" but NOT "pilot" or "ping"
+      if (cleanAgentId.startsWith(p)) return true;
     } else if (p === cleanAgentId) {
       return true;
     }
@@ -2393,6 +2392,7 @@ const memoryLanceDBProPlugin = {
 
       const AUTO_RECALL_TIMEOUT_MS = parsePositiveInt(config.autoRecallTimeoutMs) ?? 5_000; // configurable; default raised from 3s to 5s for remote embedding APIs behind proxies
       api.on("before_prompt_build", async (event: any, ctx: any) => {
+<<<<<<< HEAD
         // Skip auto-recall for sub-agent sessions — their context comes from the parent.
         const sessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : "";
         if (sessionKey.includes(":subagent:")) return;
@@ -2410,10 +2410,10 @@ const memoryLanceDBProPlugin = {
             return;
           }
         } else if (
+          agentId !== undefined &&
           Array.isArray(config.autoRecallExcludeAgents) &&
           config.autoRecallExcludeAgents.length > 0 &&
           isAgentOrSessionExcluded(agentId, sessionKey, config.autoRecallExcludeAgents)
-        ) {
         ) {
           api.logger.debug?.(
             `memory-lancedb-pro: auto-recall skipped for excluded agent '${agentId}' (sessionKey=${sessionKey ?? "(none)"})`,

--- a/index.ts
+++ b/index.ts
@@ -449,6 +449,7 @@ const DEFAULT_REFLECTION_DEDUPE_ERROR_SIGNALS = true;
 const DEFAULT_REFLECTION_SESSION_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_REFLECTION_MAX_TRACKED_SESSIONS = 200;
 const DEFAULT_REFLECTION_ERROR_SCAN_MAX_CHARS = 8_000;
+const DEFAULT_SERIAL_GUARD_COOLDOWN_MS = 120_000;
 const REFLECTION_FALLBACK_MARKER = "(fallback) Reflection generation failed; storing minimal pointer only.";
 const DIAG_BUILD_TAG = "memory-lancedb-pro-diag-20260308-0058";
 
@@ -3454,7 +3455,7 @@ const memoryLanceDBProPlugin = {
         if (!g[REFLECTION_SERIAL_GUARD]) g[REFLECTION_SERIAL_GUARD] = new Map<string, number>();
         return g[REFLECTION_SERIAL_GUARD] as Map<string, number>;
       };
-      const SERIAL_GUARD_COOLDOWN_MS = 120_000; // 2 minutes cooldown per sessionKey
+      // SERIAL_GUARD_COOLDOWN_MS moved to DEFAULT_SERIAL_GUARD_COOLDOWN_MS
 
       const runMemoryReflection = async (event: any) => {
         const sessionKey = typeof event.sessionKey === "string" ? event.sessionKey : "";
@@ -3481,9 +3482,7 @@ const memoryLanceDBProPlugin = {
           const serialGuard = getSerialGuardMap();
           const lastRun = serialGuard.get(sessionKey);
           if (lastRun) {
-            const cooldownMs = typeof (cfg?.memoryReflection as Record<string, unknown> | undefined)?.serialCooldownMs === "number"
-              ? (cfg!.memoryReflection as Record<string, unknown>).serialCooldownMs as number
-              : 120_000;
+            const cooldownMs = config.memoryReflection?.serialCooldownMs ?? DEFAULT_SERIAL_GUARD_COOLDOWN_MS;
             if ((Date.now() - lastRun) < cooldownMs) {
               api.logger.info(`memory-reflection: command hook skipped (cooldown ${((Date.now() - lastRun) / 1000).toFixed(0)}s/${(cooldownMs / 1000).toFixed(0)}s, sessionKey=${sessionKey})`);
               return;
@@ -3506,9 +3505,7 @@ const memoryLanceDBProPlugin = {
           let currentSessionFile = typeof sessionEntry.sessionFile === "string" ? sessionEntry.sessionFile : undefined;
           const sourceAgentId = parseAgentIdFromSessionKey(sessionKey) || "main";
           // Exclude agents/sessions listed in memoryReflection.excludeAgents (supports wildcards)
-          const excludePatterns = (cfg as Record<string, unknown> | undefined)?.memoryReflection
-            ? ((cfg as Record<string, unknown>).memoryReflection as Record<string, unknown>)?.excludeAgents as string[] | undefined
-            : undefined;
+          const excludePatterns = config.memoryReflection?.excludeAgents;
           if (excludePatterns && isAgentOrSessionExcluded(sourceAgentId, sessionKey, excludePatterns)) {
             api.logger.debug?.(
               `memory-reflection: command hook skipped (excluded agent=${sourceAgentId}, sessionKey=${sessionKey ?? "(none)"})`,
@@ -4273,6 +4270,10 @@ export function parsePluginConfig(value: unknown): PluginConfig {
         })(),
         errorReminderMaxEntries: parsePositiveInt(memoryReflectionRaw.errorReminderMaxEntries) ?? DEFAULT_REFLECTION_ERROR_REMINDER_MAX_ENTRIES,
         dedupeErrorSignals: memoryReflectionRaw.dedupeErrorSignals !== false,
+        serialCooldownMs: parsePositiveInt(memoryReflectionRaw.serialCooldownMs) ?? DEFAULT_SERIAL_GUARD_COOLDOWN_MS,
+        excludeAgents: Array.isArray(memoryReflectionRaw.excludeAgents)
+          ? memoryReflectionRaw.excludeAgents.filter((id: unknown): id is string => typeof id === "string" && id.trim() !== "")
+          : undefined,
       }
       : {
         enabled: sessionStrategy === "memoryReflection",
@@ -4286,6 +4287,8 @@ export function parsePluginConfig(value: unknown): PluginConfig {
         thinkLevel: DEFAULT_REFLECTION_THINK_LEVEL,
         errorReminderMaxEntries: DEFAULT_REFLECTION_ERROR_REMINDER_MAX_ENTRIES,
         dedupeErrorSignals: DEFAULT_REFLECTION_DEDUPE_ERROR_SIGNALS,
+        serialCooldownMs: DEFAULT_SERIAL_GUARD_COOLDOWN_MS,
+        excludeAgents: undefined,
       },
     sessionMemory:
       typeof cfg.sessionMemory === "object" && cfg.sessionMemory !== null

--- a/index.ts
+++ b/index.ts
@@ -4299,7 +4299,13 @@ export function parsePluginConfig(value: unknown): PluginConfig {
         })(),
         errorReminderMaxEntries: parsePositiveInt(memoryReflectionRaw.errorReminderMaxEntries) ?? DEFAULT_REFLECTION_ERROR_REMINDER_MAX_ENTRIES,
         dedupeErrorSignals: memoryReflectionRaw.dedupeErrorSignals !== false,
-        serialCooldownMs: parsePositiveInt(memoryReflectionRaw.serialCooldownMs) ?? DEFAULT_SERIAL_GUARD_COOLDOWN_MS,
+        serialCooldownMs: (() => {
+          const raw = memoryReflectionRaw.serialCooldownMs;
+          // null/undefined → use default; explicitly 0 (any type) → disabled
+          if (raw == null) return DEFAULT_SERIAL_GUARD_COOLDOWN_MS;
+          if (Number(raw) === 0) return 0;
+          return parsePositiveInt(raw) ?? DEFAULT_SERIAL_GUARD_COOLDOWN_MS;
+        })(),
         excludeAgents: Array.isArray(memoryReflectionRaw.excludeAgents)
           ? memoryReflectionRaw.excludeAgents.filter((id: unknown): id is string => typeof id === "string" && id.trim() !== "")
           : undefined,

--- a/index.ts
+++ b/index.ts
@@ -211,6 +211,10 @@ interface PluginConfig {
     thinkLevel?: ReflectionThinkLevel;
     errorReminderMaxEntries?: number;
     dedupeErrorSignals?: boolean;
+    /** Cooldown in ms between reflection triggers for the same session. Default: 120000 (2 min). Set to 0 to disable. */
+    serialCooldownMs?: number;
+    /** Agent/session patterns excluded from reflection injection. Supports exact match, wildcard prefix (e.g. "pi-"), and "temp:*". */
+    excludeAgents?: string[];
   };
   mdMirror?: { enabled?: boolean; dir?: string };
   workspaceBoundary?: WorkspaceBoundaryConfig;
@@ -1886,6 +1890,38 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
   };
 }
 
+function isAgentOrSessionExcluded(
+  agentId: string,
+  sessionKey: string | undefined,
+  patterns: string[],
+): boolean {
+  if (!Array.isArray(patterns) || patterns.length === 0) return false;
+
+  const cleanAgentId = agentId.trim();
+  const isInternal = typeof sessionKey === "string" &&
+    sessionKey.trim().startsWith("temp:memory-reflection");
+
+  for (const pattern of patterns) {
+    const p = typeof pattern === "string" ? pattern.trim() : "";
+    if (!p) continue;
+
+    if (p === "temp:*") {
+      if (isInternal) return true;
+      continue;
+    }
+
+    if (p.endsWith("-")) {
+      // Wildcard prefix match: "pi-" matches "pi-agent"
+      const prefix = p.slice(0, -1);
+      if (cleanAgentId.startsWith(prefix)) return true;
+    } else if (p === cleanAgentId) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 const memoryLanceDBProPlugin = {
   id: "memory-lancedb-pro",
   name: "Memory (LanceDB Pro)",
@@ -2376,10 +2412,11 @@ const memoryLanceDBProPlugin = {
         } else if (
           Array.isArray(config.autoRecallExcludeAgents) &&
           config.autoRecallExcludeAgents.length > 0 &&
-          config.autoRecallExcludeAgents.includes(agentId)
+          isAgentOrSessionExcluded(agentId, sessionKey, config.autoRecallExcludeAgents)
+        ) {
         ) {
           api.logger.debug?.(
-            `memory-lancedb-pro: auto-recall skipped for excluded agent '${agentId}'`,
+            `memory-lancedb-pro: auto-recall skipped for excluded agent '${agentId}' (sessionKey=${sessionKey ?? "(none)"})`,
           );
           return;
         }
@@ -3388,13 +3425,21 @@ const memoryLanceDBProPlugin = {
           api.logger.info(`memory-reflection: skipping re-entrant call for sessionKey=${sessionKey}; already running (global guard)`);
           return;
         }
+        // Parse context before guards so cfg is available for serialCooldownMs
+        const context = (event.context || {}) as Record<string, unknown>;
+        const cfg = context.cfg;
         // Serial loop guard: skip if a reflection for this sessionKey completed recently
         if (sessionKey) {
           const serialGuard = getSerialGuardMap();
           const lastRun = serialGuard.get(sessionKey);
-          if (lastRun && (Date.now() - lastRun) < SERIAL_GUARD_COOLDOWN_MS) {
-            api.logger.info(`memory-reflection: skipping serial re-trigger for sessionKey=${sessionKey}; last run ${(Date.now() - lastRun) / 1000}s ago (cooldown=${SERIAL_GUARD_COOLDOWN_MS / 1000}s)`);
-            return;
+          if (lastRun) {
+            const cooldownMs = typeof (cfg?.memoryReflection as Record<string, unknown> | undefined)?.serialCooldownMs === "number"
+              ? (cfg!.memoryReflection as Record<string, unknown>).serialCooldownMs as number
+              : 120_000;
+            if ((Date.now() - lastRun) < cooldownMs) {
+              api.logger.info(`memory-reflection: command hook skipped (cooldown ${((Date.now() - lastRun) / 1000).toFixed(0)}s/${(cooldownMs / 1000).toFixed(0)}s, sessionKey=${sessionKey})`);
+              return;
+            }
           }
         }
         if (sessionKey) globalLock.set(sessionKey, true);
@@ -3402,8 +3447,6 @@ const memoryLanceDBProPlugin = {
         try {
           pruneReflectionSessionState();
           const action = String(event?.action || "unknown");
-          const context = (event.context || {}) as Record<string, unknown>;
-          const cfg = context.cfg;
           const workspaceDir = resolveWorkspaceDirFromContext(context);
           if (!cfg) {
             api.logger.warn(`memory-reflection: command:${action} missing cfg in hook context; skip reflection`);
@@ -3414,6 +3457,17 @@ const memoryLanceDBProPlugin = {
           const currentSessionId = typeof sessionEntry.sessionId === "string" ? sessionEntry.sessionId : "unknown";
           let currentSessionFile = typeof sessionEntry.sessionFile === "string" ? sessionEntry.sessionFile : undefined;
           const sourceAgentId = parseAgentIdFromSessionKey(sessionKey) || "main";
+          // Exclude agents/sessions listed in memoryReflection.excludeAgents (supports wildcards)
+          const excludePatterns = (cfg as Record<string, unknown> | undefined)?.memoryReflection
+            ? ((cfg as Record<string, unknown>).memoryReflection as Record<string, unknown>)?.excludeAgents as string[] | undefined
+            : undefined;
+          if (excludePatterns && isAgentOrSessionExcluded(sourceAgentId, sessionKey, excludePatterns)) {
+            api.logger.debug?.(
+              `memory-reflection: command hook skipped (excluded agent=${sourceAgentId}, sessionKey=${sessionKey ?? "(none)"})`,
+            );
+            return;
+          }
+
           const commandSource = typeof context.commandSource === "string" ? context.commandSource : "";
           api.logger.info(
             `memory-reflection: command:${action} hook start; sessionKey=${sessionKey || "(none)"}; source=${commandSource || "(unknown)"}; sessionId=${currentSessionId}; sessionFile=${currentSessionFile || "(none)"}`

--- a/index.ts
+++ b/index.ts
@@ -3504,6 +3504,13 @@ const memoryLanceDBProPlugin = {
           const currentSessionId = typeof sessionEntry.sessionId === "string" ? sessionEntry.sessionId : "unknown";
           let currentSessionFile = typeof sessionEntry.sessionFile === "string" ? sessionEntry.sessionFile : undefined;
           const sourceAgentId = parseAgentIdFromSessionKey(sessionKey) || "main";
+          // Guard: skip if agentId is invalid format (consistent with other hook sites)
+          if (isInvalidAgentIdFormat(sourceAgentId, config.declaredAgents)) {
+            api.logger.debug?.(
+              `memory-reflection: command hook skipped \u2014 invalid agentId '${sourceAgentId}'`,
+            );
+            return;
+          }
           // Exclude agents/sessions listed in memoryReflection.excludeAgents (supports wildcards)
           const excludePatterns = config.memoryReflection?.excludeAgents;
           if (excludePatterns && isAgentOrSessionExcluded(sourceAgentId, sessionKey, excludePatterns)) {

--- a/index.ts
+++ b/index.ts
@@ -345,6 +345,33 @@ function resolveHookAgentId(
     : parseAgentIdFromSessionKey(sessionKey)) || "main";
 }
 
+// Detect when agentId came from a chat_id / user: source (e.g. "657229412030480397").
+// These are numeric Discord/Telegram IDs mistakenly used as agent IDs and cause
+// auto-recall to timeout. We skip them rather than block all pure-numeric IDs
+// to avoid false positives for intentionally numeric agent names.
+function isChatIdBasedAgentId(agentId: string): boolean {
+  return /^\d+$/.test(agentId); // pure digits = almost certainly a chat_id, not a real agent
+}
+
+/**
+ * Returns true when agentId is invalid — either empty/undefined, detected as a
+ * numeric chat_id, or not present in the openclaw.json declared agents list.
+ * Pass `declaredAgents` (from config.declaredAgents) for authoritative validation.
+ */
+function isInvalidAgentIdFormat(
+  agentId: string | undefined,
+  declaredAgents?: Set<string>,
+): boolean {
+  if (!agentId) return true;
+  // Pure numeric IDs are almost always chat_id extractions, not real agent IDs.
+  if (isChatIdBasedAgentId(agentId)) return true;
+  // If we have a declared agents list, treat unknown IDs as invalid.
+  if (declaredAgents && declaredAgents.size > 0 && !declaredAgents.has(agentId)) {
+    return true;
+  }
+  return false;
+}
+
 function resolveSourceFromSessionKey(sessionKey: string | undefined): string {
   const trimmed = sessionKey?.trim() ?? "";
   const match = /^agent:[^:]+:([^:]+)/.exec(trimmed);
@@ -2392,7 +2419,6 @@ const memoryLanceDBProPlugin = {
 
       const AUTO_RECALL_TIMEOUT_MS = parsePositiveInt(config.autoRecallTimeoutMs) ?? 5_000; // configurable; default raised from 3s to 5s for remote embedding APIs behind proxies
       api.on("before_prompt_build", async (event: any, ctx: any) => {
-<<<<<<< HEAD
         // Skip auto-recall for sub-agent sessions — their context comes from the parent.
         const sessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : "";
         if (sessionKey.includes(":subagent:")) return;
@@ -2402,6 +2428,12 @@ const memoryLanceDBProPlugin = {
         // - Else if autoRecallExcludeAgents is set: all agents EXCEPT these receive auto-recall
 
         const agentId = resolveHookAgentId(ctx?.agentId, (event as any).sessionKey);
+        if (isInvalidAgentIdFormat(agentId, config.declaredAgents)) {
+          api.logger.debug?.(
+            `memory-lancedb-pro: auto-recall skipped \u2014 invalid agentId format '${agentId}'`,
+          );
+          return;
+        }
         if (Array.isArray(config.autoRecallIncludeAgents) && config.autoRecallIncludeAgents.length > 0) {
           if (!config.autoRecallIncludeAgents.includes(agentId)) {
             api.logger.debug?.(
@@ -2447,6 +2479,10 @@ const memoryLanceDBProPlugin = {
         const recallWork = async (): Promise<{ prependContext: string } | undefined> => {
           // Determine agent ID and accessible scopes
           const agentId = resolveHookAgentId(ctx?.agentId, (event as any).sessionKey);
+          if (isInvalidAgentIdFormat(agentId, config.declaredAgents)) {
+            api.logger.debug?.(`memory-lancedb-pro: auto-recall skip \u2014 invalid agentId '${agentId}'`);
+            return undefined;
+          }
           const accessibleScopes = resolveScopeFilter(scopeManager, agentId);
 
           // Use cached raw user message for the recall query to avoid channel
@@ -2790,6 +2826,10 @@ const memoryLanceDBProPlugin = {
 
           // Determine agent ID and default scope
           const agentId = resolveHookAgentId(ctx?.agentId, (event as any).sessionKey);
+          if (isInvalidAgentIdFormat(agentId, config.declaredAgents)) {
+            api.logger.debug(`memory-lancedb-pro: auto-capture skip \u2014 invalid agentId '${agentId}'`);
+            return;
+          }
           const accessibleScopes = resolveScopeFilter(scopeManager, agentId);
           const defaultScope = isSystemBypassId(agentId)
             ? config.scopes?.default ?? "global"
@@ -3308,6 +3348,10 @@ const memoryLanceDBProPlugin = {
             typeof ctx.agentId === "string" ? ctx.agentId : undefined,
             sessionKey,
           );
+          if (isInvalidAgentIdFormat(agentId, config.declaredAgents)) {
+            api.logger.debug?.(`memory-lancedb-pro: reflection inheritance skip \u2014 invalid agentId '${agentId}'`);
+            return;
+          }
           const scopes = resolveScopeFilter(scopeManager, agentId);
           const slices = await loadAgentReflectionSlices(agentId, scopes);
           if (slices.invariants.length === 0) return;
@@ -3334,6 +3378,10 @@ const memoryLanceDBProPlugin = {
           typeof ctx.agentId === "string" ? ctx.agentId : undefined,
           sessionKey,
         );
+        if (isInvalidAgentIdFormat(agentId, config.declaredAgents)) {
+          api.logger.debug?.(`memory-lancedb-pro: reflection derived+error skip \u2014 invalid agentId '${agentId}'`);
+          return;
+        }
         pruneReflectionSessionState();
 
         const blocks: string[] = [];
@@ -3811,6 +3859,10 @@ const memoryLanceDBProPlugin = {
             typeof ctx.agentId === "string" ? ctx.agentId : undefined,
             sessionKey,
           );
+          if (isInvalidAgentIdFormat(agentId, config.declaredAgents)) {
+            api.logger.debug?.(`session-memory [before_reset]: skip \u2014 invalid agentId '${agentId}'`);
+            return;
+          }
           const defaultScope = isSystemBypassId(agentId)
             ? config.scopes?.default ?? "global"
             : scopeManager.getDefaultScope(agentId);
@@ -4139,6 +4191,23 @@ export function parsePluginConfig(value: unknown): PluginConfig {
         .filter((id: unknown): id is string => typeof id === "string" && id.trim() !== "")
         .map((id) => id.trim())
       : undefined,
+    // Build declaredAgents Set from openclaw.json agents.list for fast validation.
+    declaredAgents: (() => {
+      const s = new Set<string>();
+      const agentsList = (cfg as Record<string, unknown>).agents as Record<string, unknown> | undefined;
+      if (agentsList) {
+        const list = agentsList.list as unknown;
+        if (Array.isArray(list)) {
+          for (const entry of list) {
+            if (entry && typeof entry === "object") {
+              const id = (entry as Record<string, unknown>).id;
+              if (typeof id === "string" && id.trim().length > 0) s.add(id.trim());
+            }
+          }
+        }
+      }
+      return s;
+    })(),
     captureAssistant: cfg.captureAssistant === true,
     retrieval:
       typeof cfg.retrieval === "object" && cfg.retrieval !== null

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -169,7 +169,12 @@
       },
       "recallMode": {
         "type": "string",
-        "enum": ["full", "summary", "adaptive", "off"],
+        "enum": [
+          "full",
+          "summary",
+          "adaptive",
+          "off"
+        ],
         "default": "full",
         "description": "Auto-recall depth mode. 'full': inject with configured per-item budget. 'summary': L0 abstracts only (compact). 'adaptive': analyze query intent to auto-select category and depth. 'off': disable auto-recall injection."
       },
@@ -280,23 +285,78 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "utility": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.1 },
-              "confidence": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.1 },
-              "novelty": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.1 },
-              "recency": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.1 },
-              "typePrior": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.6 }
+              "utility": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.1
+              },
+              "confidence": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.1
+              },
+              "novelty": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.1
+              },
+              "recency": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.1
+              },
+              "typePrior": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.6
+              }
             }
           },
           "typePriors": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "profile": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.95 },
-              "preferences": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.9 },
-              "entities": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.75 },
-              "events": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.45 },
-              "cases": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.8 },
-              "patterns": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.85 }
+              "profile": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.95
+              },
+              "preferences": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.9
+              },
+              "entities": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.75
+              },
+              "events": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.45
+              },
+              "cases": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.8
+              },
+              "patterns": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.85
+              }
             }
           }
         }
@@ -670,6 +730,18 @@
           "dedupeErrorSignals": {
             "type": "boolean",
             "default": true
+          },
+          "serialCooldownMs": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Cooldown in ms between reflection triggers for the same session. Default: 120000 (2 min). Set to 0 to disable."
+          },
+          "excludeAgents": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Agent/session patterns excluded from reflection injection. Supports exact match, wildcard prefix (e.g. pi-), and temp:*."
           }
         }
       },
@@ -873,6 +945,13 @@
             "description": "Maximum number of auto-capture extractions allowed per hour"
           }
         }
+      },
+      "autoRecallExcludeAgents": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Agent/session patterns excluded from auto-recall and reflection injection. Supports exact match, wildcard prefix (e.g. pi-), and temp:*."
       }
     },
     "required": [

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -32,6 +32,7 @@ export const CI_TEST_MANIFEST = [
   { group: "core-regression", runner: "node", file: "test/smart-metadata-v2.mjs" },
   { group: "storage-and-schema", runner: "node", file: "test/vector-search-cosine.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/context-support-e2e.mjs" },
+  { group: "core-regression", runner: "node", file: "test/agentid-validation.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/temporal-facts.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/memory-update-supersede.test.mjs" },
   { group: "llm-clients-and-auth", runner: "node", file: "test/memory-upgrader-diagnostics.test.mjs" },

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -32,7 +32,6 @@ export const CI_TEST_MANIFEST = [
   { group: "core-regression", runner: "node", file: "test/smart-metadata-v2.mjs" },
   { group: "storage-and-schema", runner: "node", file: "test/vector-search-cosine.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/context-support-e2e.mjs" },
-  { group: "core-regression", runner: "node", file: "test/agentid-validation.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/temporal-facts.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/memory-update-supersede.test.mjs" },
   { group: "llm-clients-and-auth", runner: "node", file: "test/memory-upgrader-diagnostics.test.mjs" },
@@ -58,6 +57,8 @@ export const CI_TEST_MANIFEST = [
   { group: "storage-and-schema", runner: "node", file: "test/bulk-store-edge-cases.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/smart-extractor-bulk-store.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/smart-extractor-bulk-store-edge-cases.test.mjs", args: ["--test"] },
+  // Issue #492 agentId validation tests
+  { group: "core-regression", runner: "node", file: "test/agentid-validation.test.mjs", args: ["--test"] },
 ];
 
 export function getEntriesForGroup(group) {

--- a/scripts/verify-ci-test-manifest.mjs
+++ b/scripts/verify-ci-test-manifest.mjs
@@ -52,6 +52,8 @@ const EXPECTED_BASELINE = [
   { group: "core-regression", runner: "node", file: "test/embedder-cache.test.mjs" },
   // Issue #629 batch embedding fix
   { group: "llm-clients-and-auth", runner: "node", file: "test/embedder-ollama-batch-routing.test.mjs" },
+  // Issue #492 agentId validation tests
+  { group: "core-regression", runner: "node", file: "test/agentid-validation.test.mjs", args: ["--test"] },
 ];
 
 function fail(message) {

--- a/test/agentid-validation.test.mjs
+++ b/test/agentid-validation.test.mjs
@@ -1,0 +1,210 @@
+/**
+ * agentid-validation.test.mjs
+ *
+ * Unit tests for the isInvalidAgentIdFormat() guard function.
+ * This function prevents hooks from running when agentId is:
+ *   1. Empty / undefined (Layer 1)
+ *   2. A pure numeric string = Discord/Telegram chat_id used as agentId (Layer 2)
+ *   3. Not present in openclaw.json agents.list (Layer 3)
+ *
+ * Run: node --test test/agentid-validation.test.mjs
+ * Or:  node test/agentid-validation.test.mjs
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const jitiInstance = jitiFactory(import.meta.url, {
+  interopDefault: true,
+});
+
+// We import index.ts purely for type-checking / jiti compilation.
+// The actual isInvalidAgentIdFormat is a private function.
+// We test it indirectly via the module's exported behavior, or directly
+// by accessing it through jiti's module object.
+const indexModule = jitiInstance("../index.ts");
+
+// isInvalidAgentIdFormat is a private (non-exported) function.
+// Access it from the jiti-loaded module if available; if not, skip to
+// integration-only tests.
+const isInvalidAgentIdFormat =
+  typeof indexModule.isInvalidAgentIdFormat === "function"
+    ? indexModule.isInvalidAgentIdFormat
+    : null;
+
+// ---------------------------------------------------------------------------
+// Helper builders (mirror the real helpers in index.ts)
+// ---------------------------------------------------------------------------
+const EMPTY_SET = new Set();
+
+/** @param {...string} ids */
+function makeSet(...ids) {
+  return new Set(ids);
+}
+
+// ---------------------------------------------------------------------------
+// isInvalidAgentIdFormat unit tests
+// ---------------------------------------------------------------------------
+if (isInvalidAgentIdFormat) {
+  describe("isInvalidAgentIdFormat", () => {
+    // Layer 1: empty / undefined
+    describe("Layer 1 — empty / undefined", () => {
+      it("returns true when agentId is undefined", () => {
+        assert.strictEqual(isInvalidAgentIdFormat(undefined), true);
+      });
+      it("returns true when agentId is null", () => {
+        // @ts-ignore
+        assert.strictEqual(isInvalidAgentIdFormat(null), true);
+      });
+      it("returns true when agentId is empty string", () => {
+        assert.strictEqual(isInvalidAgentIdFormat(""), true);
+      });
+    });
+
+    // Layer 2: pure numeric (chat_id pattern)
+    describe("Layer 2 — pure numeric = chat_id", () => {
+      it("returns true for a pure digit Discord user ID", () => {
+        assert.strictEqual(isInvalidAgentIdFormat("657229412030480397"), true);
+      });
+      it("returns true for a pure digit Telegram user ID", () => {
+        assert.strictEqual(isInvalidAgentIdFormat("123456789"), true);
+      });
+      it("returns false for an ID that starts with a letter (dc-channel--)", () => {
+        // This is a valid Discord channel agent ID format — should NOT be blocked
+        assert.strictEqual(isInvalidAgentIdFormat("dc-channel--1476858065914695741"), false);
+      });
+      it("returns false for an ID that starts with a letter (tg-group--)", () => {
+        assert.strictEqual(isInvalidAgentIdFormat("tg-group--5108601505"), false);
+      });
+      it("returns false for an ID with mixed alphanumeric characters", () => {
+        assert.strictEqual(isInvalidAgentIdFormat("agent-x-123"), false);
+      });
+    });
+
+    // Layer 3: declaredAgents Set membership
+    describe("Layer 3 — declaredAgents Set", () => {
+      const validAgents = makeSet("main", "dc-channel--1476858065914695741", "tg-group--5108601505");
+
+      it("returns false when agentId is in declaredAgents", () => {
+        assert.strictEqual(isInvalidAgentIdFormat("main", validAgents), false);
+      });
+      it("returns false when dc-channel--ID is in declaredAgents", () => {
+        assert.strictEqual(
+          isInvalidAgentIdFormat("dc-channel--1476858065914695741", validAgents),
+          false,
+        );
+      });
+      it("returns true when agentId is NOT in declaredAgents (numeric)", () => {
+        // Numeric ID caught by Layer 2 first, but Layer 3 also catches it
+        assert.strictEqual(isInvalidAgentIdFormat("999999999", validAgents), true);
+      });
+      it("returns true when agentId is NOT in declaredAgents (unknown string)", () => {
+        // Non-numeric but unknown agent ID — should still be invalid if Set is populated
+        assert.strictEqual(isInvalidAgentIdFormat("unknown-agent-xyz", validAgents), true);
+      });
+      it("returns false when declaredAgents is empty (no restrictions)", () => {
+        // When no agents list is configured, only Layer 1 & 2 apply
+        assert.strictEqual(isInvalidAgentIdFormat("some-random-id", EMPTY_SET), false);
+      });
+      it("returns false when declaredAgents is undefined (no config)", () => {
+        assert.strictEqual(isInvalidAgentIdFormat("main", undefined), false);
+      });
+    });
+
+    // Edge cases
+    describe("Edge cases", () => {
+      it("returns false for 'main' (the default agent)", () => {
+        assert.strictEqual(isInvalidAgentIdFormat("main"), false);
+      });
+      it("whitespace-only string is NOT caught by Layer 1 (treated as truthy)", () => {
+        // A whitespace-only string is not falsy, not pure digits, not in declaredAgents
+        // so it falls through to Layer 3 (invalid if Set is non-empty).
+        // This is arguably correct behavior — such IDs are garbage.
+        assert.strictEqual(isInvalidAgentIdFormat("   ", makeSet()), false);
+      });
+    });
+  });
+} else {
+  console.warn(
+    "[agentid-validation] isInvalidAgentIdFormat not exported — skipping direct unit tests." +
+    " Run integration tests instead.",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Integration test: verify declaredAgents Set is built correctly from config
+// ---------------------------------------------------------------------------
+describe("declaredAgents Set construction", () => {
+  it("builds declaredAgents Set from openclaw.json agents.list id field", () => {
+    // This mirrors the logic in index.ts config.declaredAgents initialization.
+    // Simulate: cfg.agents.list = [{ id: "main" }, { id: "dc-channel--1476858065914695741" }]
+    const cfgAgentsList = [
+      { id: "main" },
+      { id: "dc-channel--1476858065914695741" },
+      { id: "tg-group--5108601505" },
+    ];
+    const s = new Set();
+    for (const entry of cfgAgentsList) {
+      if (entry && typeof entry === "object") {
+        const id = entry.id;
+        if (typeof id === "string" && id.trim().length > 0) s.add(id.trim());
+      }
+    }
+    assert.strictEqual(s.has("main"), true);
+    assert.strictEqual(s.has("dc-channel--1476858065914695741"), true);
+    assert.strictEqual(s.has("tg-group--5108601505"), true);
+    assert.strictEqual(s.size, 3);
+  });
+
+  it("ignores entries without a valid string id", () => {
+    const cfgAgentsList = [
+      { id: "main" },
+      { id: "" },
+      { id: "  " },
+      {},
+      null,
+      undefined,
+    ];
+    const s = new Set();
+    for (const entry of cfgAgentsList) {
+      if (entry && typeof entry === "object") {
+        const id = entry.id;
+        if (typeof id === "string" && id.trim().length > 0) s.add(id.trim());
+      }
+    }
+    assert.strictEqual(s.size, 1);
+    assert.strictEqual(s.has("main"), true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regex unit tests (mirrors isChatIdBasedAgentId logic)
+// ---------------------------------------------------------------------------
+describe("isChatIdBasedAgentId regex", () => {
+  const RE = /^\d+$/;
+
+  const chatIdCases = [
+    ["657229412030480397", true],
+    ["123456789", true],
+    ["0", true],
+    ["9999999999999999999", true],
+    ["dc-channel--1476858065914695741", false],
+    ["tg-group--5108601505", false],
+    ["main", false],
+    ["agent-123", false],
+    ["z-fundamental", false],
+    ["dc-channel--123456789012345678", false],
+    ["", false],
+  ];
+
+  for (const [input, expected] of chatIdCases) {
+    it(`/${input}/ matches = ${expected}`, () => {
+      assert.strictEqual(RE.test(input), expected);
+    });
+  }
+});
+
+console.log("agentid-validation.test.mjs loaded");


### PR DESCRIPTION
## Closing in favor of PR #722

This PR (#687) became a mix of multiple PRs (#516 scope creep, serialCooldownMs, excludeAgents, reflection-store.ts mass reformat, CI manifest changes, etc.) — as noted in the maintainer review.

A clean replacement has been opened at **PR #722**: https://github.com/CortexReach/memory-lancedb-pro/pull/722

PR #722 contains only the minimal Issue #686 fix:
- `isInvalidAgentIdFormat()` guard on `runMemoryReflection` command hook (1 guard site, matching the issue scope)
- Production export for testability (14 tests, 0 skipped)
- No schema changes, no CI manifest changes, no unrelated feature additions