### PR TITLE
test: fix baseline CI regressions after bulkStore migration

### DIFF
--- a/scripts/verify-ci-test-manifest.mjs
+++ b/scripts/verify-ci-test-manifest.mjs
@@ -19,6 +19,7 @@ const EXPECTED_BASELINE = [
   { group: "core-regression", runner: "node", file: "test/recall-text-cleanup.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/update-consistency-lancedb.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/strip-envelope-metadata.test.mjs", args: ["--test"] },
+  { group: "cli-smoke", runner: "node", file: "test/import-markdown/import-markdown.test.mjs", args: ["--test"] },
   { group: "cli-smoke", runner: "node", file: "test/cli-smoke.mjs" },
   { group: "cli-smoke", runner: "node", file: "test/functional-e2e.mjs" },
   { group: "storage-and-schema", runner: "node", file: "test/per-agent-auto-recall.test.mjs", args: ["--test"] },
@@ -52,6 +53,11 @@ const EXPECTED_BASELINE = [
   { group: "core-regression", runner: "node", file: "test/embedder-cache.test.mjs" },
   // Issue #629 batch embedding fix
   { group: "llm-clients-and-auth", runner: "node", file: "test/embedder-ollama-batch-routing.test.mjs" },
+  // Issue #665 bulkStore tests
+  { group: "storage-and-schema", runner: "node", file: "test/bulk-store.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/bulk-store-edge-cases.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/smart-extractor-bulk-store.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/smart-extractor-bulk-store-edge-cases.test.mjs", args: ["--test"] },
 ];
 
 function fail(message) {

--- a/test/preference-slots.test.mjs
+++ b/test/preference-slots.test.mjs
@@ -121,6 +121,10 @@ function makeGuardExtractor({ vectorSearchResults, onDedupCalled }) {
     async store(entry) {
       stored.push(entry);
     },
+    async bulkStore(entries) {
+      stored.push(...entries);
+      return entries;
+    },
   };
   const embedder = {
     async embed() {
@@ -236,6 +240,7 @@ test("dedup guard: non-preference category -> skips guard, goes to LLM", async (
       }];
     },
     async store() {},
+    async bulkStore() { return []; },
   };
   const embedder = {
     async embed() { return [0.1, 0.2, 0.3]; },

--- a/test/smart-extractor-batch-embed.test.mjs
+++ b/test/smart-extractor-batch-embed.test.mjs
@@ -87,6 +87,12 @@ function makeStore() {
       entries.push({ action: "store", entry });
       return entry;
     },
+    async bulkStore(batchEntries) {
+      for (const entry of batchEntries) {
+        entries.push({ action: "bulkStore", entry });
+      }
+      return batchEntries;
+    },
     async update(_id, _patch, _scopeFilter) {
       entries.push({ action: "update", id: _id });
     },

--- a/test/smart-extractor-branches.mjs
+++ b/test/smart-extractor-branches.mjs
@@ -495,9 +495,6 @@ assert.equal(multiRoundResult.extractionCall, 4);
 assert.equal(multiRoundResult.dedupCall, 3);
 assert.equal(multiRoundResult.mergeCall, 1);
 assert.ok(
-  multiRoundResult.logs.some((entry) => entry[1].includes("created [preferences] 饮品偏好：乌龙茶")),
-);
-assert.ok(
   multiRoundResult.logs.some((entry) => entry[1].includes("merged [preferences]")),
 );
 assert.ok(

--- a/test/smart-extractor-scope-filter.test.mjs
+++ b/test/smart-extractor-scope-filter.test.mjs
@@ -12,6 +12,7 @@ function makeExtractor(scopeFilters) {
       return [];
     },
     async store() {},
+    async bulkStore() {},
   };
 
   const embedder = {


### PR DESCRIPTION
## Summary
- remove the stale per-item created-log assertion in `test/smart-extractor-branches.mjs` after the bulkStore migration
- add missing `bulkStore()` methods to legacy SmartExtractor test doubles used by scope filter, batch embed, and preference-slot tests
- sync `verify-ci-test-manifest.mjs` with the current CI manifest entries

## Verification
- `node scripts/verify-ci-test-manifest.mjs`
- `node --test test/preference-slots.test.mjs`
- `node --test test/smart-extractor-scope-filter.test.mjs test/store-empty-scope-filter.test.mjs`
- `npm run test:core-regression`

## Notes
- the original `storage-and-schema` failure on PR #691 was the `smart-extractor-scope-filter` mock drift; that targeted path is green locally now
- a full local rerun of `storage-and-schema` stalled inside `test/update-consistency-lancedb.test.mjs` in the real LanceDB backend, so I kept verification focused on the red path from the CI log
