### PR TITLE
fix(backup): drop redundant api.resolvePath on already-absolute path (Issue #682)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3804,9 +3804,10 @@ const memoryLanceDBProPlugin = {
 
     async function runBackup() {
       try {
-        const backupDir = api.resolvePath(
-          join(resolvedDbPath, "..", "backups"),
-        );
+        // resolvedDbPath is already absolute (produced by api.resolvePath at
+        // plugin init); wrapping it again triggered a path-argument `undefined`
+        // in OpenClaw 2026.4.x's stricter plugin API. Join directly.
+        const backupDir = join(resolvedDbPath, "..", "backups");
         await mkdir(backupDir, { recursive: true });
 
         const allMemories = await store.list(undefined, undefined, 10000, 0);


### PR DESCRIPTION
## Summary

Fixes #682 — daily jsonl backup sidecar crashes on OpenClaw 2026.4.x with `TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of Buffer or URL. Received undefined`.

## Root cause

`resolvedDbPath` is produced by `api.resolvePath(...)` at plugin init (line 1726 in upstream master) and is always absolute. Inside `runBackup()` the plugin then does:

```ts
const backupDir = api.resolvePath(join(resolvedDbPath, "..", "backups"));
```

In OpenClaw 2026.3.x this second call was effectively a no-op (absolute path in → same absolute path out). 2026.4.x tightened the plugin API: calling `api.resolvePath` with an already-absolute path that points **outside** the agent workspace root now returns `undefined`. That undefined is passed straight to `mkdir`, crashing the backup.

Auto-capture, retrieval, and the gateway-scheduled daily 18:59 backup all use different code paths and are unaffected — only the plugin's own 60s-after-start (and every-24h) internal timer backup hits this.

## Fix

`resolvedDbPath` is already absolute; drop the redundant second `api.resolvePath` and join directly. Minimal one-hunk change with an explanatory comment so future readers don't re-introduce the wrapper.

## Reproduction

- OpenClaw `2026.4.22` (also reproduced on `2026.4.12-beta.1` per Issue #682)
- memory-lancedb-pro `1.1.0-beta.9` / `1.1.0-beta.10`
- macOS, any agent workspace

Steps:
1. Install plugin, configure with default `dbPath` (plugin resolves to `~/.openclaw/memory/lancedb-pro`)
2. Restart gateway
3. Wait ~60s → `[plugins] memory-lancedb-pro: backup failed: TypeError [ERR_INVALID_ARG_TYPE] ...`

## Verification

After applying the patch on the same environment:

```
2026-04-24T23:29:45.785+09:00 [plugins] memory-lancedb-pro: backup completed (240 entries → /Users/milin/.openclaw/memory/backups/memory-backup-2026-04-24.jsonl)
```

- Backup file written, size grows with new memories as expected
- Post-backup retention (keep-last-7) still prunes correctly
- No regression on the gateway-scheduled daily 18:59 path

## Test plan

- [ ] Maintainers: reproduce pre-patch failure on openclaw@2026.4.x + plugin master
- [ ] Apply patch, restart gateway, confirm `backup completed` log within ~60s
- [ ] Run full `npm test` to make sure no path-handling tests regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)