### PR TITLE
fix: prevent memory leak by pruning lifecycleEntries and tierOverrides maps

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -417,6 +417,7 @@ const DEFAULT_REFLECTION_ERROR_REMINDER_MAX_ENTRIES = 3;
 const DEFAULT_REFLECTION_DEDUPE_ERROR_SIGNALS = true;
 const DEFAULT_REFLECTION_SESSION_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_REFLECTION_MAX_TRACKED_SESSIONS = 200;
+const DEFAULT_REFLECTION_AGENT_CACHE_MAX_SIZE = 50;
 const DEFAULT_REFLECTION_ERROR_SCAN_MAX_CHARS = 8_000;
 const REFLECTION_FALLBACK_MARKER = "(fallback) Reflection generation failed; storing minimal pointer only.";
 const DIAG_BUILD_TAG = "memory-lancedb-pro-diag-20260308-0058";
@@ -1987,6 +1988,8 @@ const memoryLanceDBProPlugin = {
         timestamp: number;
         metadata?: string;
       };
+      const LIFECYCLE_ENTRIES_MAX_SIZE = 500;
+      const TIER_OVERRIDES_MAX_SIZE = 200;
       const lifecycleEntries = new Map<string, LifecycleEntry>();
       const tierOverrides = new Map<string, string>();
 
@@ -2020,6 +2023,9 @@ const memoryLanceDBProPlugin = {
         api.logger.warn(`memory-lancedb-pro: tier maintenance preload failed: ${String(err)}`);
       }
 
+      // Prevent unbounded growth of lifecycleEntries (#345).
+      pruneMapIfOver(lifecycleEntries, LIFECYCLE_ENTRIES_MAX_SIZE);
+
       const candidates = Array.from(lifecycleEntries.values())
         .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry))
         .filter((entry) => parseSmartMetadata(entry.metadata, entry).type !== "session-summary");
@@ -2046,6 +2052,9 @@ const memoryLanceDBProPlugin = {
             tierOverrides.set(transition.memoryId, transition.toTier);
           }),
         );
+
+        // Prevent unbounded growth of tierOverrides (#345).
+        pruneMapIfOver(tierOverrides, TIER_OVERRIDES_MAX_SIZE);
 
         if (transitions.length > 0) {
           api.logger.info(
@@ -2161,6 +2170,8 @@ const memoryLanceDBProPlugin = {
       const { invariants, derived } = slices;
       const next = { updatedAt: Date.now(), invariants, derived };
       reflectionByAgentCache.set(cacheKey, next);
+      // Prevent unbounded growth of reflectionByAgentCache (#345).
+      pruneOldestByUpdatedAt(reflectionByAgentCache, DEFAULT_REFLECTION_AGENT_CACHE_MAX_SIZE);
       return next;
     };
 


### PR DESCRIPTION
## Summary

This PR fixes a memory leak in the Gateway caused by unbounded growth of `lifecycleEntries` and `tierOverrides` Map objects in `index.ts`.

## Problem

The `lifecycleEntries` and `tierOverrides` Maps were being populated on every lifecycle event and tier transition but never cleaned up, leading to continuous memory growth (approx. 150 MB/hour).

## Fix

- Added `LIFECYCLE_ENTRIES_MAX_SIZE` (500) and `TIER_OVERRIDES_MAX_SIZE` (200) constants.
- Called `pruneMapIfOver()` after populating both Maps to prevent unbounded growth.
- Added `DEFAULT_REFLECTION_AGENT_CACHE_MAX_SIZE` (50) constant for consistency.

## Impact

- **Memory stability**: GC troughs are now stable (~1335-1440 MB) instead of continuously rising.
- **Performance**: Negligible impact; pruning only runs when Maps exceed the safe limits.

## Verification

- Observed GC trough stability over 4+ hours post-fix.
- RSS growth rate reduced from ~150 MB/h to ~0 MB/h (stable).