### PR TITLE
fix: declare contracts.tools in plugin manifest (OpenClaw 5.2 compat)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4,6 +4,24 @@
   "description": "Enhanced LanceDB-backed long-term memory with hybrid retrieval, multi-scope isolation, long-context chunking, and management CLI",
   "version": "1.1.0-beta.10",
   "kind": "memory",
+  "contracts": {
+    "tools": [
+      "memory_recall",
+      "memory_store",
+      "memory_forget",
+      "memory_update",
+      "memory_list",
+      "memory_stats",
+      "memory_archive",
+      "memory_compact",
+      "memory_debug",
+      "memory_explain_rank",
+      "memory_promote",
+      "self_improvement_log",
+      "self_improvement_extract_skill",
+      "self_improvement_review"
+    ]
+  },
   "skills": [
     "./skills"
   ],


### PR DESCRIPTION
## Summary

OpenClaw 5.2+ enforces a new plugin manifest contract: any plugin that calls `api.registerTool()` must first declare the tool names in `contracts.tools: string[]`. Without it, the gateway rejects every tool registration with:

```
plugin must declare contracts.tools before registering agent tools
(plugin=memory-lancedb-pro, source=.../memory-lancedb-pro/index.ts)
```

## Impact on memory-lancedb-pro

All 14 agent tools fail to register on 5.2:

- `memory_recall`, `memory_store`, `memory_forget`, `memory_update`
- `memory_list`, `memory_stats`, `memory_archive`, `memory_compact`
- `memory_debug`, `memory_explain_rank`, `memory_promote`
- `self_improvement_log`, `self_improvement_extract_skill`, `self_improvement_review`

**This silently breaks agent-driven memory recall.** Agents lose `memory_recall` from their toolset entirely. The bug hides easily because:

- `autoRecall` (passive injection) bypasses the tool registry → still works
- Users see "memory still injects 3 items into context" and assume everything is fine
- But the agent has lost half the recall surface — it can no longer issue targeted queries via `memory_recall("specific topic")`

The only trace is 14 error lines in `gateway.err.log` per startup.

## Fix

Declare all 14 tool names in `openclaw.plugin.json` → `contracts.tools`. 18-line addition, no behavior change on older OpenClaw versions (field is ignored if not enforced).

## Verification

Tested on OpenClaw 2026.5.2 (npm `openclaw@2026.5.2`):

**Before:**
```
[gateway] [plugins] plugin must declare contracts.tools before registering agent tools (plugin=memory-lancedb-pro, ...)
```
×14 lines on each gateway start.

**After:**
```
[plugins] memory-lancedb-pro@1.1.0-beta.10: plugin registered
(db: ..., model: text-embedding-v4, smartExtraction: ON)
```
0 contracts.tools errors. All 14 tools available to agents.

## Related

Companion to #727 (`allowConversationAccess`) — same OpenClaw 5.2 compatibility surface, complementary fixes. After both land, memory-lancedb-pro is fully compatible with 5.2 non-bundled installation.

## Tool inventory source

The 14 tool names are extracted from `src/tools.ts`'s `api.registerTool({ name: ... })` calls (current master tip `0545c91`).