### PR TITLE
fix: preserve early conversation context — slice(0,maxChars)

### DIFF
--- a/src/smart-extractor.ts
+++ b/src/smart-extractor.ts
@@ -554,7 +554,7 @@ export class SmartExtractor {
     const maxChars = this.config.extractMaxChars ?? 8000;
     const truncated =
       conversationText.length > maxChars
-        ? conversationText.slice(-maxChars)
+        ? conversationText.slice(0, maxChars)
         : conversationText;
 
     // Strip platform envelope metadata injected by OpenClaw channels


### PR DESCRIPTION
## Summary

Fixes Bug 1 from #574.

## The bug

`conversationText.slice(-maxChars)` always kept the last 8000 chars and discarded everything earlier. An agent establishing context at the start of a long session lost it entirely — despite the README marketing "learns from every conversation".

## The fix

`conversationText.slice(0, maxChars)` keeps the first `maxChars` chars instead.

## Testing

- Unit test: verify long conversation (20k chars) truncates at start, not end
- Integration: confirm early session context is included in extraction prompt

## Related

#574 — 3 bugs + 4 hardening items found during code review