### PR TITLE
fix: declare contracts.tools for OpenClaw 2026.5.x compatibility

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,4 +1,22 @@
 {
+  "contracts": {
+    "tools": [
+      "memory_recall",
+      "memory_store",
+      "memory_forget",
+      "memory_update",
+      "memory_stats",
+      "memory_debug",
+      "memory_list",
+      "memory_promote",
+      "memory_archive",
+      "memory_compact",
+      "memory_explain_rank",
+      "self_improvement_log",
+      "self_improvement_extract_skill",
+      "self_improvement_review"
+    ]
+  },
   "id": "memory-lancedb-pro",
   "name": "Memory (LanceDB Pro)",
   "description": "Enhanced LanceDB-backed long-term memory with hybrid retrieval, multi-scope isolation, long-context chunking, and management CLI",


### PR DESCRIPTION
Starting from OpenClaw 2026.5.x, plugins must declare every agent tool name in "contracts.tools" before the gateway will register them. Without this field, the plugin loads but agents see none of the memory_* / self_improvement_* tools — auto-recall still works (the runtime path), but explicit memory_store calls and the dual-write workflow break.

Gateway log when contracts.tools is missing:

  [gateway] [plugins] plugin must declare contracts.tools before registering
    agent tools (plugin=memory-lancedb-pro, source=...index.ts)

This commit declares the 14 agent tools registered in src/tools.ts:
- memory_recall / memory_store / memory_forget / memory_update
- memory_stats / memory_debug / memory_list
- memory_promote / memory_archive / memory_compact / memory_explain_rank
- self_improvement_log / self_improvement_extract_skill / self_improvement_review

Verified on OpenClaw 2026.5.3-1 + memory-lancedb-pro@1.1.0-beta.10: agent main can call memory_store/memory_recall round-trip after the patch.