### PR TITLE
fix(esm): replace esbuild __require shim with native dynamic import

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -75,8 +75,7 @@ export const loadLanceDB = async (): Promise<
   typeof import("@lancedb/lancedb")
 > => {
   if (!lancedbImportPromise) {
-    // Use require() for CommonJS modules on Windows to avoid ESM URL scheme issues
-    lancedbImportPromise = Promise.resolve(require("@lancedb/lancedb"));
+    lancedbImportPromise = import("@lancedb/lancedb");
   }
   try {
     return await lancedbImportPromise;


### PR DESCRIPTION
## Summary

`dist/index.js` ships with esbuild's default `__require` shim, which throws
`Dynamic require of "@lancedb/lancedb" is not supported` when the bundle is
loaded as pure ESM (Node 22+, package.json declares `"type": "module"`).

The root cause is a bare `require("@lancedb/lancedb")` call in `src/store.ts`
inside `loadLanceDB()`. esbuild converts that to a `__require()` call, and
when the bundle loads under Node's ESM loader, the global `require` is
undefined — so the shim throws.

This PR replaces the bare `require()` call in `loadLanceDB()` with a native
`import("@lancedb/lancedb")`, which works regardless of how the file is
bundled. This aligns with how `loadLockfile` already loads `proper-lockfile`
in the same file.

Fixes #758

## Repro

See linked issue.

## Verification

- `npm install`
- `npm run test:cli-smoke` — passes locally
- Confirmed via fresh `openclaw doctor` run that `MemoryStore.stats` and
  `MemoryStore.doInitialize` paths no longer throw.

## Notes for maintainer

- Source-only change. The committed `dist/` bundle is not regenerated in
  this PR (no public build script in repo). Maintainer's release
  pipeline will pick up the fix in the next published bundle.
- Optional follow-up: pass `--external:@lancedb/lancedb` to the esbuild
  invocation so the native module is never bundled. Not strictly needed
  once `loadLanceDB` uses native `import()`, but cleaner.
