### PR TITLE
fix Windows reflection CLI fallback

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { homedir, tmpdir } from "node:os";
-import { join, dirname, basename } from "node:path";
+import { join, dirname, basename, win32 as winPath } from "node:path";
 import { readFile, readdir, writeFile, mkdir, appendFile, unlink, stat } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
@@ -536,50 +536,78 @@ function isLayer1CircuitOpen(): boolean {
   return recentFailures.length >= LAYER1_FAILURE_THRESHOLD;
 }
 
-export function toImportSpecifier(value: string): string {
+export function toImportSpecifier(
+  value: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
   const trimmed = value.trim();
   if (!trimmed) return "";
   if (trimmed.startsWith("file://")) return trimmed;
-  if (trimmed.startsWith("/")) return pathToFileURL(trimmed).href;
+  if (trimmed.startsWith("/")) return pathToFileURL(trimmed, { windows: false }).href;
   // Handle Windows absolute paths (e.g. C:\Users\... or D:/Program Files/...) — PR #593
-  if (process.platform === 'win32' && /^[a-zA-Z]:[/\\]/.test(trimmed)) return pathToFileURL(trimmed).href;
+  if (platform === 'win32' && /^[a-zA-Z]:[/\\]/.test(trimmed)) {
+    return pathToFileURL(trimmed, { windows: true }).href;
+  }
   // Handle UNC paths (\\server\share or \\?\UNC\\server\share) — PR #593
   // Regex breakdown: ^\\\\  = starts with \\
   //                  [^\\]+   = server name (one or more non-backslash chars)
   //                  \\[^\\]+ = \ + share name (one or more non-backslash chars)
   // Examples matched: \\server\share, \\fileserver\company-share, \\?\UNC\server\share
   // Examples NOT matched: C:\path (drive letter, handled above), /unix/path (POSIX)
-  if (process.platform === 'win32' && /^\\\\[^\\]+\\[^\\]+/.test(trimmed)) {
+  if (platform === 'win32' && /^\\\\[^\\]+\\[^\\]+/.test(trimmed)) {
     // Extended prefix \\?\UNC\\ means "long UNC name" — already normalized.
     // Pass directly so we don't double-normalize (e.g. avoid \\?\UNC\\?\UNC\\...).
-    if (trimmed.startsWith('\\\\?\\UNC\\')) return pathToFileURL(trimmed).href;
+    if (trimmed.startsWith('\\\\?\\UNC\\')) {
+      return pathToFileURL(trimmed, { windows: true }).href;
+    }
     // Standard UNC: \\server\share -> \\?\UNC\\server\share -> file://server/share
     // strip leading \\ (2 chars) -> server\share, then prefix \\?\UNC\\
     const normalized = '\\\\?\\UNC\\' + trimmed.slice(2);
-    return pathToFileURL(normalized).href;
+    return pathToFileURL(normalized, { windows: true }).href;
   }
   return trimmed;
 }
-export function getExtensionApiImportSpecifiers(): string[] {
-  const envPath = process.env.OPENCLAW_EXTENSION_API_PATH?.trim();
+
+type ExtensionImportSpecifierOptions = {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  resolveOpenClawExtensionApi?: () => string;
+};
+
+export function getExtensionApiImportSpecifiers(
+  options: ExtensionImportSpecifierOptions = {},
+): string[] {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  const envPath = env.OPENCLAW_EXTENSION_API_PATH?.trim();
+  const joinForPlatform = platform === "win32" ? winPath.join : join;
   const specifiers: string[] = [];
 
-  if (envPath) specifiers.push(toImportSpecifier(envPath));
+  if (envPath) specifiers.push(toImportSpecifier(envPath, platform));
   specifiers.push("openclaw/dist/extensionAPI.js");
 
   try {
-    specifiers.push(toImportSpecifier(requireFromHere.resolve("openclaw/dist/extensionAPI.js")));
+    const resolved = options.resolveOpenClawExtensionApi
+      ? options.resolveOpenClawExtensionApi()
+      : requireFromHere.resolve("openclaw/dist/extensionAPI.js");
+    specifiers.push(toImportSpecifier(resolved, platform));
   } catch {
     // ignore resolve failures and continue fallback probing
   }
 
-  specifiers.push(toImportSpecifier("/usr/lib/node_modules/openclaw/dist/extensionAPI.js"));
-  specifiers.push(toImportSpecifier("/usr/local/lib/node_modules/openclaw/dist/extensionAPI.js"));
-  specifiers.push(toImportSpecifier("/opt/homebrew/lib/node_modules/openclaw/dist/extensionAPI.js"));
-
-  if (process.platform === "win32" && process.env.APPDATA) {
-    const windowsNpmPath = join(process.env.APPDATA, "npm", "node_modules", "openclaw", "dist", "extensionAPI.js");
-    specifiers.push(toImportSpecifier(windowsNpmPath));
+  if (platform === "win32") {
+    if (env.APPDATA) {
+      const windowsNpmPath = joinForPlatform(env.APPDATA, "npm", "node_modules", "openclaw", "dist", "extensionAPI.js");
+      specifiers.push(toImportSpecifier(windowsNpmPath, platform));
+    }
+    if (env.ProgramFiles) {
+      const windowsProgramFilesPath = joinForPlatform(env.ProgramFiles, "nodejs", "node_modules", "openclaw", "dist", "extensionAPI.js");
+      specifiers.push(toImportSpecifier(windowsProgramFilesPath, platform));
+    }
+  } else {
+    specifiers.push(toImportSpecifier("/usr/lib/node_modules/openclaw/dist/extensionAPI.js", platform));
+    specifiers.push(toImportSpecifier("/usr/local/lib/node_modules/openclaw/dist/extensionAPI.js", platform));
+    specifiers.push(toImportSpecifier("/opt/homebrew/lib/node_modules/openclaw/dist/extensionAPI.js", platform));
   }
 
   return [...new Set(specifiers.filter(Boolean))];
@@ -734,7 +762,8 @@ async function runReflectionViaCli(params: {
   ];
 
   return await new Promise<string>((resolve, reject) => {
-    const child = spawn(cliBin, args, {
+    const spawnCommand = buildReflectionCliSpawnCommand(cliBin, args);
+    const child = spawn(spawnCommand.command, spawnCommand.args, {
       cwd: params.workspaceDir,
       env: { ...process.env, NO_COLOR: "1" },
       stdio: ["ignore", "pipe", "pipe"],
@@ -799,6 +828,22 @@ async function runReflectionViaCli(params: {
       }
     });
   });
+}
+
+export function buildReflectionCliSpawnCommand(
+  cliBin: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+  comSpec = process.env.ComSpec?.trim(),
+): { command: string; args: string[] } {
+  if (platform === "win32") {
+    return {
+      command: comSpec || "cmd.exe",
+      args: ["/c", cliBin, ...args],
+    };
+  }
+
+  return { command: cliBin, args };
 }
 
 async function loadSelfImprovementReminderContent(workspaceDir?: string): Promise<string> {

--- a/index.ts
+++ b/index.ts
@@ -529,7 +529,7 @@ export function reportLayer1Failure(): void {
   }
 }
 
-function isLayer1CircuitOpen(): boolean {
+export function isLayer1CircuitOpen(): boolean {
   const now = Date.now();
   const cutoff = now - LAYER1_FAILURE_WINDOW_MS;
   const recentFailures = layer1FailureTimestamps.filter((t) => t >= cutoff);

--- a/test/issue606_sdk-migration.test.mjs
+++ b/test/issue606_sdk-migration.test.mjs
@@ -14,9 +14,18 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
+import jitiFactory from "jiti";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH = resolve(__dirname, "..", "index.ts");
+const pluginSdkStubPath = resolve(__dirname, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+const loadIndexModule = () => jiti("../index.ts");
 
 // ---------------------------------------------------------------------------
 // Static analysis smoke tests — verify migration code is present
@@ -273,13 +282,13 @@ describe("loadEmbeddedPiRunner — F1/F2 behavioral integration", () => {
     // We can't easily reset module-level state, so we test the circuit breaker
     // function directly. The actual integration (Layer 1 blocked after N failures)
     // requires a fresh module instance per test which Node test runner doesn't give us.
-    const { isLayer1CircuitOpen } = await import("../index.ts");
+    const { isLayer1CircuitOpen } = loadIndexModule();
     // isLayer1CircuitOpen is internal; if it exists and returns boolean, the mechanism is wired
     assert.strictEqual(typeof isLayer1CircuitOpen, "function", "isLayer1CircuitOpen should be exported for testability");
   });
 
   it("F1: reportLayer1Failure is exported and callable", async () => {
-    const { reportLayer1Failure } = await import("../index.ts");
+    const { reportLayer1Failure } = loadIndexModule();
     assert.strictEqual(typeof reportLayer1Failure, "function", "reportLayer1Failure must be exported");
     // Calling it should not throw
     assert.doesNotThrow(() => reportLayer1Failure(), "reportLayer1Failure() must not throw");

--- a/test/windows-reflection-fallback.test.mjs
+++ b/test/windows-reflection-fallback.test.mjs
@@ -1,0 +1,77 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginSdkStubPath = path.resolve(testDir, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+
+const {
+  toImportSpecifier,
+  getExtensionApiImportSpecifiers,
+  buildReflectionCliSpawnCommand,
+} = jiti("../index.ts");
+
+describe("Windows reflection fallback helpers", () => {
+  it("converts Windows paths when platform is provided explicitly", () => {
+    const result = toImportSpecifier(
+      "C:\\Users\\admin\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\extensionAPI.js",
+      "win32",
+    );
+    assert.ok(result.startsWith("file:///C:/"), `Expected Windows file:// URL, got: ${result}`);
+    assert.ok(result.includes("AppData/Roaming/npm"));
+  });
+
+  it("converts UNC paths when platform is provided explicitly", () => {
+    const result = toImportSpecifier(
+      "\\\\server\\share\\openclaw\\dist\\extensionAPI.js",
+      "win32",
+    );
+    assert.ok(result.startsWith("file://"), `Expected file:// URL, got: ${result}`);
+    assert.ok(result.includes("server"));
+    assert.ok(result.includes("share"));
+  });
+
+  it("omits POSIX extension API fallbacks on Windows", () => {
+    const specifiers = getExtensionApiImportSpecifiers({
+      platform: "win32",
+      env: {
+        APPDATA: "C:\\Users\\admin\\AppData\\Roaming",
+        ProgramFiles: "C:\\Program Files",
+      },
+      resolveOpenClawExtensionApi: () => {
+        throw new Error("openclaw package not installed in test process");
+      },
+    });
+
+    assert.ok(!specifiers.some((s) => s.includes("/usr/lib")), `Unexpected /usr/lib fallback: ${JSON.stringify(specifiers)}`);
+    assert.ok(!specifiers.some((s) => s.includes("/usr/local")), `Unexpected /usr/local fallback: ${JSON.stringify(specifiers)}`);
+    assert.ok(!specifiers.some((s) => s.includes("/opt/homebrew")), `Unexpected /opt/homebrew fallback: ${JSON.stringify(specifiers)}`);
+    assert.ok(specifiers.some((s) => s.includes("AppData/Roaming/npm")), `Expected APPDATA fallback: ${JSON.stringify(specifiers)}`);
+    assert.ok(specifiers.some((s) => s.includes("Program%20Files/nodejs")), `Expected Program Files fallback: ${JSON.stringify(specifiers)}`);
+  });
+
+  it("spawns the OpenClaw CLI directly on POSIX platforms", () => {
+    const command = buildReflectionCliSpawnCommand("openclaw", ["agent", "--json"], "linux");
+    assert.equal(command.command, "openclaw");
+    assert.deepEqual(command.args, ["agent", "--json"]);
+  });
+
+  it("resolves the OpenClaw CLI through cmd on Windows", () => {
+    const command = buildReflectionCliSpawnCommand(
+      "openclaw",
+      ["agent", "--json"],
+      "win32",
+      "C:\\Windows\\System32\\cmd.exe",
+    );
+    assert.equal(command.command, "C:\\Windows\\System32\\cmd.exe");
+    assert.deepEqual(command.args, ["/c", "openclaw", "agent", "--json"]);
+  });
+});


### PR DESCRIPTION
## Summary

Fix the Windows `/reset` reflection fallback path so it does not try Unix-only extension API locations and can launch the OpenClaw CLI through Windows command resolution.

- Make extension API import fallback generation platform-aware.
- Skip `/usr/lib`, `/usr/local`, and `/opt/homebrew` fallbacks on Windows.
- Add Windows npm and Program Files/nodejs fallback paths for extension API probing.
- Run the CLI fallback through `cmd /c` on Windows instead of spawning `openclaw` directly.
- Add a Linux-runnable regression test that simulates Windows paths and spawn behavior.

Fixes #648

## Validation

- `node --test test/windows-reflection-fallback.test.mjs`
- `node --test test/to-import-specifier-windows.test.mjs`
- `git diff --check`

## Notes

`node --test test/issue606_sdk-migration.test.mjs` still fails on current `master` because it dynamically imports `index.ts` directly and Node resolves TypeScript-local `.js` imports such as `src/store.js` without the repository's Jiti test setup. This is unrelated to the Windows fallback change.