### PR TITLE
feat: add Hermes-native LanceDB memory provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
+__pycache__/
+*.py[cod]
 .venv-skill-tools
+.migration-venv/
 .memory-lancedb-pro/
 .DS_Store
 memory-plugin-feature-dev

--- a/integrations/hermes/lancedb_pro/OPENCLAW_MIGRATION.md
+++ b/integrations/hermes/lancedb_pro/OPENCLAW_MIGRATION.md
@@ -1,0 +1,176 @@
+# Safe OpenClaw LanceDB Pro -> Hermes lancedb_pro migration
+
+This guide covers an optional, experimental migration path from OpenClaw
+`memory-lancedb-pro` data into the isolated Hermes-native `lancedb_pro` provider.
+It copies rows into a separate Hermes schema without writing to the OpenClaw live
+database, without changing the OpenClaw runtime, and without editing Hermes main
+config.
+
+The Hermes provider is intentionally narrower than OpenClaw's advanced retrieval
+stack. Migration preserves useful memory content and metadata for Hermes
+store/search flows, but it is not full feature parity with OpenClaw retrieval,
+reranking, governance, or lifecycle behavior.
+
+## Safety rules
+
+- Treat the OpenClaw DB as read-only. The importer only reads the source table:
+  it validates that the source path exists and is a directory before calling
+  `lancedb.connect()`, verifies the source table is present, and opens the
+  source table before creating or connecting to the target directory.
+- Do not use the OpenClaw DB path as the Hermes target path.
+- Do not overwrite an existing Hermes DB. Use a timestamped target path.
+- Do not print API keys. Prefer `HERMES_MEMORY_JINA_API_KEY` or `JINA_API_KEY`;
+  otherwise the helper can read OpenClaw config in-process and masks logs.
+- Do not enable the migrated DB in Hermes until validation passes.
+
+## Source / target paths
+
+Default OpenClaw source:
+
+```text
+$OPENCLAW_HOME/memory/lancedb-pro, or ~/.openclaw/memory/lancedb-pro when OPENCLAW_HOME is unset
+```
+
+Recommended Hermes target pattern:
+
+```text
+$HERMES_HOME/memory/lancedb-pro-migrated-YYYYMMDD-HHMMSS, or ~/.hermes/memory/lancedb-pro-migrated-YYYYMMDD-HHMMSS when HERMES_HOME is unset
+```
+
+The importer writes Hermes provider rows to table `hermes_memories` by default.
+Use `--target-table memories` if you want the migrated Hermes table to keep the
+OpenClaw table name while still containing Hermes-schema rows. Compatible fields
+match `integrations/hermes/lancedb_pro/provider.py`: `id`, `content`, `vector`,
+`category`, `scope`, `source`, `created_at`, `updated_at`, `importance`,
+`embedding_model`, `dimensions`, `metadata_json`, and `session_id`. The importer
+preserves OpenClaw source values in `metadata_json` as `original_id`,
+`original_timestamp`, `original_category`, `original_scope`,
+`original_importance`, and `original_metadata`. OpenClaw millisecond timestamps
+are converted to Hermes Unix seconds for `created_at`/`updated_at`.
+
+## Install migration-only dependencies
+
+Use an isolated venv; do not install into Hermes runtime unless you intend to:
+
+```bash
+cd /path/to/memory-lancedb-pro
+python3 -m venv .migration-venv
+.migration-venv/bin/pip install lancedb pyarrow requests
+```
+
+For local test coverage of this integration, install pytest in the same isolated
+environment and run the focused Python tests from the repository root:
+
+```bash
+.migration-venv/bin/pip install pytest
+.migration-venv/bin/python -m pytest test/hermes_lancedb_pro_provider_test.py \
+  test/hermes_lancedb_pro_openclaw_migration_test.py
+```
+
+## Phase 0: read-only discovery
+
+If the source path might be missing, check it before ad-hoc LanceDB discovery;
+`lancedb.connect()` can create a missing directory in some LanceDB versions. The
+importer performs this preflight automatically before any source connect or
+target mkdir/connect.
+
+```bash
+.migration-venv/bin/python - <<'PY'
+import lancedb
+import os
+from pathlib import Path
+src=str(Path(os.getenv('OPENCLAW_HOME', '~/.openclaw')).expanduser() / 'memory' / 'lancedb-pro')
+db=lancedb.connect(src)
+print(db.table_names())
+t=db.open_table('memories')
+print(t.count_rows())
+print(t.schema)
+PY
+```
+
+Do not dump full memory content in logs.
+
+## Phase 1: real-Jina sample import
+
+```bash
+TS=$(date +%Y%m%d-%H%M%S)
+TARGET=/tmp/hermes-lancedb-pro-jina-sample-test-$TS
+MANIFEST=$HOME/.hermes/agent-runs/openclaw_lancedb_sample_$TS.json
+.migration-venv/bin/python integrations/hermes/lancedb_pro/scripts/import_openclaw_lancedb.py \
+  --target "$TARGET" \
+  --target-table hermes_memories \
+  --limit 50 \
+  --batch-size 10 \
+  --progress-every 50 \
+  --manifest "$MANIFEST"
+```
+
+The helper refuses to proceed without a Jina key. It uses Jina
+`jina-embeddings-v5-text-small`, 1024 dimensions, `retrieval.passage` task for
+stored memory vectors.
+
+## Validate through Hermes provider
+
+Run provider search with a temporary env only:
+
+```bash
+export HERMES_MEMORY_LANCEDB_PATH=/tmp/hermes-lancedb-pro-jina-sample-test-...
+# If imported with --target-table memories, set:
+# export HERMES_MEMORY_LANCEDB_TABLE=memories
+export HERMES_MEMORY_JINA_API_KEY=...  # do not echo this
+export HERMES_MEMORY_HASH_FALLBACK=false
+export HERMES_MEMORY_EMBED_BASE_URL=https://api.jina.ai/v1/embeddings
+export HERMES_MEMORY_EMBED_MODEL=jina-embeddings-v5-text-small
+python - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path('integrations/hermes').resolve()))
+from lancedb_pro.provider import LancedbProMemoryProvider
+p=LancedbProMemoryProvider()
+p.initialize('migration-validation', hermes_home='/tmp/hermes-validation-home')
+print(p.handle_tool_call('lancedb_pro_status', {}))
+print(p.handle_tool_call('lancedb_pro_search', {'query': 'memory governance', 'limit': 3}))
+PY
+```
+
+Provider search uses Jina `retrieval.query` task.
+
+## Phase 2: full import
+
+```bash
+TS=$(date +%Y%m%d-%H%M%S)
+TARGET=${HERMES_HOME:-$HOME/.hermes}/memory/lancedb-pro-migrated-$TS
+MANIFEST=$HOME/.hermes/agent-runs/openclaw_lancedb_full_$TS.json
+.migration-venv/bin/python integrations/hermes/lancedb_pro/scripts/import_openclaw_lancedb.py \
+  --target "$TARGET" \
+  --target-table hermes_memories \
+  --batch-size 32 \
+  --progress-every 512 \
+  --manifest "$MANIFEST"
+```
+
+## Enabling in Hermes after validation
+
+Do not edit the main Hermes config during migration. After validation, use the
+same plugin and set env/config explicitly:
+
+```bash
+export HERMES_MEMORY_LANCEDB_PATH=$HOME/.hermes/memory/lancedb-pro-migrated-YYYYMMDD-HHMMSS
+# Set only if you imported with --target-table memories:
+# export HERMES_MEMORY_LANCEDB_TABLE=memories
+export HERMES_MEMORY_JINA_API_KEY=...  # secret; do not log
+export HERMES_MEMORY_HASH_FALLBACK=false
+```
+
+Hermes config snippet:
+
+```yaml
+memory:
+  provider: lancedb_pro
+```
+
+The existing plugin symlink can point to:
+
+```text
+$HERMES_HOME/plugins/lancedb_pro -> /path/to/memory-lancedb-pro/integrations/hermes/lancedb_pro
+```

--- a/integrations/hermes/lancedb_pro/README.md
+++ b/integrations/hermes/lancedb_pro/README.md
@@ -1,0 +1,187 @@
+# Hermes provider: `lancedb_pro`
+
+This directory contains an optional, experimental Hermes-native memory provider
+for the upstream `memory-lancedb-pro` repository. It is intentionally isolated:
+it does **not** modify Hermes core, does **not** change the OpenClaw TypeScript
+runtime, and does **not** interact with any OpenClaw live database.
+
+This is not full feature parity with the OpenClaw advanced retrieval stack. The
+Hermes provider currently focuses on a small, explicit surface: status, manual
+store/search/delete, minimal prefetch recall, optional turn capture, and safe
+one-way import from OpenClaw LanceDB rows into a separate Hermes schema.
+
+## Install locally in Hermes
+
+```bash
+mkdir -p "$HERMES_HOME/plugins"
+ln -s /absolute/path/to/memory-lancedb-pro/integrations/hermes/lancedb_pro "$HERMES_HOME/plugins/lancedb_pro"
+```
+
+Then set the active provider in Hermes config:
+
+```yaml
+memory:
+  provider: lancedb_pro
+```
+
+## Optional dependencies
+
+For real LanceDB storage:
+
+```bash
+python -m pip install lancedb pyarrow
+```
+
+For tests and migration helper development, use an isolated Python environment
+and install only the Python dependencies you need, for example:
+
+```bash
+python -m venv .hermes-lancedb-venv
+. .hermes-lancedb-venv/bin/activate
+python -m pip install pytest lancedb pyarrow requests
+```
+
+The focused Python tests can run without Node/npm installation:
+
+```bash
+python -m pytest test/hermes_lancedb_pro_provider_test.py \
+  test/hermes_lancedb_pro_openclaw_migration_test.py
+```
+
+If Python `lancedb` is not installed, the provider remains importable and falls
+back to a small JSONL store for local smoke tests. The status tool reports the
+active backend and any LanceDB import/open error class.
+
+## Embeddings
+
+Preferred production path is Jina/OpenAI-compatible embeddings:
+
+```bash
+export HERMES_MEMORY_JINA_API_KEY=...
+# optional overrides
+export HERMES_MEMORY_EMBED_BASE_URL=https://api.jina.ai/v1/embeddings
+export HERMES_MEMORY_EMBED_MODEL=jina-embeddings-v5-text-small
+# defaults for Jina v5; override only if your provider requires different names
+export HERMES_MEMORY_EMBED_QUERY_TASK=retrieval.query
+export HERMES_MEMORY_EMBED_PASSAGE_TASK=retrieval.passage
+```
+
+If no `HERMES_MEMORY_JINA_API_KEY` is present, the provider uses deterministic
+hash embeddings with 1024 dimensions by default. This is only a dev/test fallback
+so manual `store`/`search` can be validated without secrets or network calls; it
+is not a production semantic embedding model.
+
+## Storage
+
+Default path:
+
+```text
+$HERMES_HOME/memory/lancedb-pro
+```
+
+Override with:
+
+```bash
+export HERMES_MEMORY_LANCEDB_PATH=/path/to/lancedb-dir
+```
+
+Default table is `hermes_memories`. You may override the table name, including to
+`memories` for continuity with an OpenClaw deployment, but the provider always
+writes Hermes-schema rows. When LanceDB is unavailable or
+`HERMES_MEMORY_LANCEDB_FORCE_JSON=true`, the JSON fallback stores rows in a
+per-table file named `<safe-table-name>.jsonl`; `memories` remains
+`memories.jsonl`, while `custom_table` uses `custom_table.jsonl`.
+
+```bash
+export HERMES_MEMORY_LANCEDB_TABLE=memories
+```
+
+Stored fields include:
+
+- `id`
+- `content`
+- `category`
+- `scope`
+- `source`
+- `created_at`
+- `updated_at`
+- `importance`
+- `embedding_model`
+- `dimensions`
+- `metadata_json`
+- `session_id`
+- `vector`
+
+## Exposed Hermes tools
+
+- `lancedb_pro_status()`
+- `lancedb_pro_store(content, category?, scope?, source?, importance?, metadata?)`
+- `lancedb_pro_search(query, limit?)`
+- `lancedb_pro_forget(id)` — deletes one exact id only.
+
+## Lifecycle behavior
+
+- `prefetch(query, session_id='')` performs minimal auto-recall by default.
+- `sync_turn()` is off by default to avoid surprise writes; enable with
+  `HERMES_MEMORY_LANCEDB_SYNC_TURN=true` or `HERMES_MEMORY_LANCEDB_AUTO_CAPTURE=true`.
+- `on_memory_write()` mirrors Hermes built-in memory writes into this provider.
+
+## Safe OpenClaw migration
+
+Migration support is optional and one-way. It copies OpenClaw rows into a new
+Hermes LanceDB path/table; it does not retrofit Hermes with OpenClaw's full
+retrieval/reranking/governance behavior and it must not be pointed at the live
+OpenClaw table as a writable target.
+
+OpenClaw legacy LanceDB rows use fields like `id`, `text`, `vector`,
+`category`, `scope`, `importance`, `timestamp`, and `metadata`. Do not point the
+Hermes provider at that legacy table directly. Instead, run the importer to copy
+rows into a separate Hermes LanceDB path and convert them to the Hermes provider
+schema (`content`, `metadata_json`, `created_at`, `updated_at`, etc.). The
+importer preflights source safety before writes: it rejects missing/non-directory
+source paths before `lancedb.connect()`, refuses target paths equal to or inside
+the source, and verifies the source table before creating/connecting the target.
+The original OpenClaw id/timestamp/scope/category/importance/metadata are preserved
+inside `metadata_json` as `original_*` keys.
+
+The target table can be overridden. This lets you use table name `memories` while
+keeping Hermes-schema row contents:
+
+```bash
+python integrations/hermes/lancedb_pro/scripts/import_openclaw_lancedb.py \
+  --source "$OPENCLAW_HOME/memory/lancedb-pro" \
+  --source-table memories \
+  --target "$HERMES_HOME/memory/lancedb-pro-migrated-$(date +%Y%m%d-%H%M%S)" \
+  --target-table memories \
+  --manifest "$HERMES_HOME/agent-runs/openclaw_lancedb_migration.json"
+```
+
+A migration helper and detailed runbook are available for copying OpenClaw
+`memory-lancedb-pro` rows into a separate Hermes `lancedb_pro` DB using real Jina
+embeddings, without writing to the OpenClaw live DB and without editing Hermes
+main config:
+
+- `integrations/hermes/lancedb_pro/scripts/import_openclaw_lancedb.py`
+- `integrations/hermes/lancedb_pro/OPENCLAW_MIGRATION.md`
+
+The helper requires a real Jina key and refuses hash-fallback migration.
+
+## Smoke test without touching live Hermes/OpenClaw state
+
+```bash
+TMP_HOME=$(mktemp -d)
+mkdir -p "$TMP_HOME/plugins"
+ln -s "$PWD/integrations/hermes/lancedb_pro" "$TMP_HOME/plugins/lancedb_pro"
+PYTHONPATH=/path/to/hermes-agent HERMES_HOME="$TMP_HOME" \
+  HERMES_MEMORY_LANCEDB_PATH="$TMP_HOME/memory/lancedb-pro" \
+  HERMES_MEMORY_LANCEDB_FORCE_JSON=true \
+  HERMES_MEMORY_EMBED_PROVIDER=hash python - <<'PY'
+from plugins.memory import load_memory_provider
+p = load_memory_provider('lancedb_pro')
+assert p is not None
+p.initialize('smoke', hermes_home=__import__('os').environ['HERMES_HOME'], platform='cli')
+print(p.handle_tool_call('lancedb_pro_status', {}))
+print(p.handle_tool_call('lancedb_pro_store', {'content': 'Hermes likes LanceDB memory'}))
+print(p.handle_tool_call('lancedb_pro_search', {'query': 'LanceDB memory', 'limit': 1}))
+PY
+```

--- a/integrations/hermes/lancedb_pro/__init__.py
+++ b/integrations/hermes/lancedb_pro/__init__.py
@@ -1,0 +1,5 @@
+"""Hermes-native memory provider entrypoint for memory-lancedb-pro."""
+
+from .provider import LancedbProMemoryProvider, MemoryProvider, register, register_memory_provider
+
+__all__ = ["LancedbProMemoryProvider", "MemoryProvider", "register", "register_memory_provider"]

--- a/integrations/hermes/lancedb_pro/plugin.yaml
+++ b/integrations/hermes/lancedb_pro/plugin.yaml
@@ -1,0 +1,29 @@
+name: lancedb_pro
+version: 0.1.0
+description: Optional experimental Hermes-native LanceDB memory provider; isolated from OpenClaw runtime changes.
+type: memory-provider
+entrypoint: __init__.py
+hermes:
+  provider: lancedb_pro
+  install_path: $HERMES_HOME/plugins/lancedb_pro
+capabilities:
+  - manual_store
+  - manual_search
+  - status
+  - forget_single_id
+  - prefetch_auto_recall
+configuration:
+  env:
+    HERMES_MEMORY_JINA_API_KEY: Optional Jina/OpenAI-compatible embedding API key. Never required for local tests.
+    HERMES_MEMORY_EMBED_BASE_URL: Optional embeddings endpoint; defaults to https://api.jina.ai/v1/embeddings.
+    HERMES_MEMORY_EMBED_MODEL: Optional embedding model; defaults to jina-embeddings-v5-text-small.
+    HERMES_MEMORY_EMBED_QUERY_TASK: Optional query embedding task; defaults to retrieval.query.
+    HERMES_MEMORY_EMBED_PASSAGE_TASK: Optional stored-memory embedding task; defaults to retrieval.passage.
+    HERMES_MEMORY_EMBED_DIM: Optional hash fallback dimensions; defaults to 1024.
+    HERMES_MEMORY_LANCEDB_PATH: Optional storage path; defaults to $HERMES_HOME/memory/lancedb-pro.
+    HERMES_MEMORY_LANCEDB_TABLE: Optional LanceDB table name; defaults to hermes_memories. The table always stores Hermes-schema rows.
+    HERMES_MEMORY_LANCEDB_SYNC_TURN: Optional; set true to store every completed turn. Default false.
+    HERMES_MEMORY_LANCEDB_AUTO_CAPTURE: Optional alias for enabling sync_turn. Default false.
+    HERMES_MEMORY_LANCEDB_AUTO_RECALL: Optional; set false to disable prefetch recall. Default true.
+    HERMES_MEMORY_HASH_FALLBACK: Optional; set false to fail instead of falling back to hash embeddings.
+    HERMES_MEMORY_LANCEDB_FORCE_JSON: Optional dev/test flag; set true to force JSONL fallback.

--- a/integrations/hermes/lancedb_pro/provider.py
+++ b/integrations/hermes/lancedb_pro/provider.py
@@ -1,0 +1,572 @@
+"""Hermes-native LanceDB memory provider for memory-lancedb-pro.
+
+Design goals:
+- no Hermes core changes;
+- no OpenClaw DB access;
+- LanceDB when installed, deterministic hash embeddings for offline tests/dev;
+- explicit manual tools: status/store/search/forget(single-id only);
+- sync_turn writes are disabled unless opted in via env.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+try:
+    from agent.memory_provider import MemoryProvider as _HermesMemoryProvider
+except Exception:  # pragma: no cover - allows local import outside Hermes.
+    class _HermesMemoryProvider:  # type: ignore[no-redef]
+        pass
+
+try:
+    import requests as _requests
+except Exception:  # pragma: no cover - requests is optional in minimal installs.
+    _requests = None
+
+DEFAULT_EMBED_MODEL = "jina-embeddings-v5-text-small"
+DEFAULT_EMBED_DIM = 1024
+DEFAULT_TABLE = "hermes_memories"
+
+
+def _json_result(**payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _safe_table_file_stem(table_name: str) -> str:
+    """Return a filesystem-safe JSON fallback file stem for a LanceDB table name."""
+    cleaned = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in table_name.strip())
+    cleaned = cleaned.strip("._-")
+    return cleaned or DEFAULT_TABLE
+
+
+def _safe_metadata(value: Any) -> Dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    try:
+        json.dumps(value, ensure_ascii=False)
+        return dict(value)
+    except Exception:
+        return {str(k): str(v) for k, v in value.items()}
+
+
+def _metadata_str(meta: Dict[str, Any], key: str, default: str = "") -> str:
+    value = meta.get(key, default)
+    return str(value) if value is not None else default
+
+
+def _metadata_float(meta: Dict[str, Any], key: str, default: float) -> float:
+    try:
+        return float(meta.get(key, default))
+    except Exception:
+        return default
+
+
+def _metadata_json(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return _safe_metadata(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            return {}
+        return _safe_metadata(parsed)
+    return {}
+
+
+def _tokenize(text: str) -> List[str]:
+    cleaned = "".join(ch.lower() if ch.isalnum() else " " for ch in text)
+    return cleaned.split()
+
+
+def _normalize(vec: Sequence[float]) -> List[float]:
+    norm = math.sqrt(sum(float(x) * float(x) for x in vec)) or 1.0
+    return [float(x) / norm for x in vec]
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    if not a or not b:
+        return 0.0
+    return float(sum(float(x) * float(y) for x, y in zip(a, b)))
+
+
+class _Embedder:
+    """Jina/OpenAI-compatible embeddings with deterministic hash fallback.
+
+    Hash mode is intentionally not production quality; it exists so tests and
+    first-run validation can run without secrets or network access.
+    """
+
+    def __init__(self) -> None:
+        self.dim = int(os.getenv("HERMES_MEMORY_EMBED_DIM", str(DEFAULT_EMBED_DIM)))
+        self.provider = os.getenv("HERMES_MEMORY_EMBED_PROVIDER", "jina").strip().lower()
+        self.api_key = os.getenv("HERMES_MEMORY_JINA_API_KEY") or ""
+        self.base_url = os.getenv("HERMES_MEMORY_EMBED_BASE_URL", "https://api.jina.ai/v1/embeddings")
+        self.model = os.getenv("HERMES_MEMORY_EMBED_MODEL", DEFAULT_EMBED_MODEL)
+        self.timeout = float(os.getenv("HERMES_MEMORY_EMBED_TIMEOUT", "20"))
+        self.allow_hash_fallback = _env_bool("HERMES_MEMORY_HASH_FALLBACK", True)
+
+    @property
+    def mode(self) -> str:
+        if self.provider == "hash" or not self.api_key:
+            return "hash"
+        return self.provider
+
+    def embed(self, text: str, *, task: str = "") -> List[float]:
+        if self.mode != "hash":
+            try:
+                return self._remote_embed(text, task=task)
+            except Exception:
+                if not self.allow_hash_fallback:
+                    raise
+        return self._hash_embed(text)
+
+    def _remote_embed(self, text: str, *, task: str = "") -> List[float]:
+        payload_obj = {"model": self.model, "input": [text]}
+        task_name = task or os.getenv("HERMES_MEMORY_EMBED_TASK", "")
+        if task_name:
+            payload_obj["task"] = task_name
+        if _requests is not None:
+            try:
+                response = _requests.post(
+                    self.base_url,
+                    headers={"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"},
+                    json=payload_obj,
+                    timeout=self.timeout,
+                )
+                if response.status_code != 200:
+                    raise RuntimeError(f"embedding endpoint returned HTTP {response.status_code}")
+                return self._extract_remote_vector(response.json())
+            except RuntimeError:
+                raise
+            except Exception:
+                if not self.allow_hash_fallback:
+                    raise
+        payload = json.dumps(payload_obj, ensure_ascii=False).encode("utf-8")
+        request = urllib.request.Request(
+            self.base_url,
+            data=payload,
+            headers={"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:  # nosec - configured endpoint
+                body = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(f"embedding endpoint returned HTTP {exc.code}") from exc
+        return self._extract_remote_vector(body)
+
+    def _extract_remote_vector(self, body: Dict[str, Any]) -> List[float]:
+        data = body.get("data") or []
+        if not data or "embedding" not in data[0]:
+            raise RuntimeError("embedding response missing data[0].embedding")
+        vector = [float(x) for x in data[0]["embedding"]]
+        self.dim = len(vector)
+        return _normalize(vector)
+
+    def _hash_embed(self, text: str) -> List[float]:
+        vec = [0.0] * self.dim
+        tokens = _tokenize(text) or [text or "empty"]
+        for token in tokens:
+            digest = hashlib.blake2b(token.encode("utf-8", "ignore"), digest_size=16).digest()
+            idx = int.from_bytes(digest[:4], "big") % self.dim
+            sign = 1.0 if digest[4] & 1 else -1.0
+            vec[idx] += sign
+        return _normalize(vec)
+
+
+class _JsonMemoryStore:
+    backend = "json_fallback"
+
+    def __init__(self, path: Path, table_name: str) -> None:
+        self.path = path
+        self.table_name = table_name
+        self.file = path / f"{_safe_table_file_stem(table_name)}.jsonl"
+        self.path.mkdir(parents=True, exist_ok=True)
+
+    def add(self, row: Dict[str, Any]) -> None:
+        with self.file.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    def search(self, vector: Sequence[float], limit: int) -> List[Dict[str, Any]]:
+        rows = self._rows()
+        for row in rows:
+            row["score"] = _cosine(vector, row.get("vector") or [])
+        rows.sort(key=lambda item: item.get("score", 0.0), reverse=True)
+        return rows[:limit]
+
+    def delete(self, memory_id: str) -> int:
+        rows = self._rows()
+        kept = [row for row in rows if row.get("id") != memory_id]
+        if len(kept) == len(rows):
+            return 0
+        with self.file.open("w", encoding="utf-8") as handle:
+            for row in kept:
+                handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+        return len(rows) - len(kept)
+
+    def count(self) -> int:
+        return len(self._rows())
+
+    def _rows(self) -> List[Dict[str, Any]]:
+        if not self.file.exists():
+            return []
+        rows: List[Dict[str, Any]] = []
+        with self.file.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    rows.append(json.loads(line))
+                except Exception:
+                    continue
+        return rows
+
+
+class _LanceMemoryStore:
+    backend = "lancedb"
+
+    def __init__(self, path: Path, table_name: str) -> None:
+        import lancedb
+
+        self.path = path
+        self.table_name = table_name
+        self.path.mkdir(parents=True, exist_ok=True)
+        self.db = lancedb.connect(str(path))
+        try:
+            self.table = self.db.open_table(table_name)
+        except Exception:
+            self.table = None
+
+    def add(self, row: Dict[str, Any]) -> None:
+        lance_row = dict(row)
+        if self.table is None:
+            self.table = self.db.create_table(self.table_name, data=[lance_row])
+        else:
+            self.table.add([lance_row])
+
+    def search(self, vector: Sequence[float], limit: int) -> List[Dict[str, Any]]:
+        if self.table is None:
+            return []
+        rows = self.table.search(list(vector)).limit(limit).to_list()
+        return [self._decode(row) for row in rows]
+
+    def delete(self, memory_id: str) -> int:
+        if self.table is None:
+            return 0
+        before = self.count()
+        escaped = memory_id.replace("'", "''")
+        self.table.delete(f"id = '{escaped}'")
+        return max(0, before - self.count())
+
+    def count(self) -> int:
+        if self.table is None:
+            return 0
+        try:
+            return int(self.table.count_rows())
+        except Exception:
+            return len(self.table.to_list())
+
+    def _decode(self, row: Dict[str, Any]) -> Dict[str, Any]:
+        decoded = dict(row)
+        if "metadata_json" in decoded:
+            decoded["metadata"] = _metadata_json(decoded.get("metadata_json"))
+        elif "metadata" in decoded:
+            decoded["metadata"] = _metadata_json(decoded.get("metadata"))
+        if "_distance" in decoded and "score" not in decoded:
+            decoded["score"] = 1.0 / (1.0 + float(decoded.get("_distance") or 0.0))
+        return decoded
+
+
+STORE_SCHEMA: Dict[str, Any] = {
+    "name": "lancedb_pro_store",
+    "description": "Store a durable memory in the Hermes lancedb_pro memory provider.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "Memory text to store."},
+            "category": {"type": "string", "description": "Optional category, e.g. preference/project/fact."},
+            "scope": {"type": "string", "description": "Optional scope, e.g. global/user/project/session."},
+            "source": {"type": "string", "description": "Optional source marker."},
+            "importance": {"type": "number", "description": "Optional importance from 0.0 to 1.0."},
+            "metadata": {"type": "object", "description": "Optional JSON metadata.", "additionalProperties": True},
+        },
+        "required": ["content"],
+    },
+}
+
+SEARCH_SCHEMA: Dict[str, Any] = {
+    "name": "lancedb_pro_search",
+    "description": "Search stored Hermes lancedb_pro memories by semantic similarity.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Search query."},
+            "limit": {"type": "integer", "description": "Maximum number of results.", "default": 5},
+        },
+        "required": ["query"],
+    },
+}
+
+STATUS_SCHEMA: Dict[str, Any] = {
+    "name": "lancedb_pro_status",
+    "description": "Return provider status, backend, storage path, and memory count.",
+    "parameters": {"type": "object", "properties": {}},
+}
+
+FORGET_SCHEMA: Dict[str, Any] = {
+    "name": "lancedb_pro_forget",
+    "description": "Delete one lancedb_pro memory by exact id only.",
+    "parameters": {
+        "type": "object",
+        "properties": {"id": {"type": "string", "description": "Memory id returned by store/search."}},
+        "required": ["id"],
+    },
+}
+
+
+class LancedbProMemoryProvider(_HermesMemoryProvider):
+    @property
+    def name(self) -> str:
+        return "lancedb_pro"
+
+    def __init__(self) -> None:
+        self._session_id = ""
+        self._hermes_home = Path(os.path.expanduser(os.getenv("HERMES_HOME", "~/.hermes")))
+        configured_path = os.getenv("HERMES_MEMORY_LANCEDB_PATH")
+        self._store_path = Path(os.path.expanduser(configured_path)) if configured_path else None
+        self._table_name = os.getenv("HERMES_MEMORY_LANCEDB_TABLE", DEFAULT_TABLE)
+        self._embedder = _Embedder()
+        self._store: Optional[Any] = None
+        self._last_prefetch = ""
+        self._sync_turn_enabled = _env_bool("HERMES_MEMORY_LANCEDB_SYNC_TURN", False) or _env_bool(
+            "HERMES_MEMORY_LANCEDB_AUTO_CAPTURE", False
+        )
+        self._auto_recall_enabled = _env_bool("HERMES_MEMORY_LANCEDB_AUTO_RECALL", True)
+        self._last_backend_error = ""
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        self._session_id = session_id or "default"
+        hermes_home = kwargs.get("hermes_home") or os.getenv("HERMES_HOME")
+        if hermes_home:
+            self._hermes_home = Path(str(hermes_home)).expanduser()
+        if self._store_path is None:
+            self._store_path = self._hermes_home / "memory" / "lancedb-pro"
+        self._store = self._open_store(self._store_path)
+
+    def _open_store(self, path: Path) -> Any:
+        force_json = _env_bool("HERMES_MEMORY_LANCEDB_FORCE_JSON", False)
+        if not force_json:
+            try:
+                return _LanceMemoryStore(path, self._table_name)
+            except Exception as exc:
+                self._last_backend_error = f"lancedb unavailable: {exc.__class__.__name__}"
+        return _JsonMemoryStore(path, self._table_name)
+
+    def system_prompt_block(self) -> str:
+        backend = getattr(self._store, "backend", "not_initialized")
+        return (
+            "Hermes lancedb_pro memory provider is active. "
+            "Use lancedb_pro_store for durable user/project facts and lancedb_pro_search for recall. "
+            f"Backend: {backend}. sync_turn auto-capture is disabled unless explicitly enabled."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not self._auto_recall_enabled or not query.strip():
+            return ""
+        limit = max(1, min(int(os.getenv("HERMES_MEMORY_LANCEDB_PREFETCH_LIMIT", "3")), 10))
+        results = self._search(query, limit=limit)
+        if not results:
+            return ""
+        lines = ["Relevant lancedb_pro memories:"]
+        for row in results:
+            score = row.get("score")
+            suffix = f" (score={score:.3f})" if isinstance(score, (float, int)) else ""
+            lines.append(f"- {row.get('content', '')}{suffix}")
+        self._last_prefetch = "\n".join(lines)
+        return self._last_prefetch
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if not self._sync_turn_enabled:
+            return
+        content = f"User: {user_content}\nAssistant: {assistant_content}".strip()
+        if content:
+            self._store_memory(content, {"category": "conversation", "scope": "session", "source": "sync_turn", "session_id": session_id or self._session_id})
+
+    def on_memory_write(self, action: str, target: str, content: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+        if action in {"add", "replace"} and content:
+            merged = {"category": target or "memory", "scope": "global", "source": "builtin_memory"}
+            merged.update(metadata or {})
+            self._store_memory(content, merged)
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [STORE_SCHEMA, SEARCH_SCHEMA, STATUS_SCHEMA, FORGET_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
+        args = args or {}
+        if tool_name == "lancedb_pro_store":
+            content = str(args.get("content") or "").strip()
+            if not content:
+                return _json_result(ok=False, error="content is required")
+            metadata = _safe_metadata(args.get("metadata"))
+            for key in ("category", "scope", "source", "importance"):
+                if key in args and args[key] is not None:
+                    metadata[key] = args[key]
+            memory_id = self._store_memory(content, metadata)
+            return _json_result(ok=True, id=memory_id, backend=self._backend_name())
+        if tool_name == "lancedb_pro_search":
+            query = str(args.get("query") or "").strip()
+            if not query:
+                return _json_result(ok=False, error="query is required")
+            limit = max(1, min(int(args.get("limit") or 5), 20))
+            return _json_result(ok=True, results=self._search(query, limit), backend=self._backend_name())
+        if tool_name == "lancedb_pro_status":
+            return _json_result(ok=True, **self._status())
+        if tool_name == "lancedb_pro_forget":
+            memory_id = str(args.get("id") or "").strip()
+            if not memory_id:
+                return _json_result(ok=False, error="id is required")
+            deleted = self._ensure_store().delete(memory_id)
+            return _json_result(ok=True, deleted=deleted, id=memory_id)
+        return _json_result(ok=False, error=f"unknown tool: {tool_name}")
+
+    def shutdown(self) -> None:
+        self._store = None
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "jina_api_key",
+                "description": "Jina/OpenAI-compatible embeddings API key. Optional; hash fallback works offline.",
+                "secret": True,
+                "required": False,
+                "env_var": "HERMES_MEMORY_JINA_API_KEY",
+            },
+            {
+                "key": "store_path",
+                "description": "LanceDB directory. Defaults to $HERMES_HOME/memory/lancedb-pro.",
+                "required": False,
+                "env_var": "HERMES_MEMORY_LANCEDB_PATH",
+            },
+            {
+                "key": "table",
+                "description": "LanceDB table name. Defaults to hermes_memories. The table always stores Hermes-schema rows.",
+                "required": False,
+                "env_var": "HERMES_MEMORY_LANCEDB_TABLE",
+            },
+        ]
+
+    def _ensure_store(self) -> Any:
+        if self._store is None:
+            base = self._store_path or (self._hermes_home / "memory" / "lancedb-pro")
+            self._store = self._open_store(base)
+        return self._store
+
+    def _store_memory(self, content: str, metadata: Optional[Dict[str, Any]] = None) -> str:
+        meta = _safe_metadata(metadata)
+        category = _metadata_str(meta, "category", "memory")
+        scope = _metadata_str(meta, "scope", "global")
+        source = _metadata_str(meta, "source", "manual")
+        importance = _metadata_float(meta, "importance", 0.5)
+        extra_meta = {k: v for k, v in meta.items() if k not in {"category", "scope", "source", "importance"}}
+        vector = self._embedder.embed(content, task=os.getenv("HERMES_MEMORY_EMBED_PASSAGE_TASK", "retrieval.passage"))
+        memory_id = str(uuid.uuid4())
+        now = time.time()
+        embedding_model = self._embedder.model if self._embedder.mode != "hash" else f"hash-dev-{self._embedder.dim}"
+        row = {
+            "id": memory_id,
+            "content": content,
+            "vector": vector,
+            "category": category,
+            "scope": scope,
+            "source": source,
+            "created_at": now,
+            "updated_at": now,
+            "importance": importance,
+            "embedding_model": embedding_model,
+            "dimensions": len(vector),
+            "metadata_json": json.dumps(extra_meta, ensure_ascii=False, sort_keys=True),
+            "session_id": self._session_id,
+        }
+        self._ensure_store().add(row)
+        return memory_id
+
+    def _search(self, query: str, limit: int) -> List[Dict[str, Any]]:
+        vector = self._embedder.embed(query, task=os.getenv("HERMES_MEMORY_EMBED_QUERY_TASK", "retrieval.query"))
+        rows = self._ensure_store().search(vector, limit)
+        clean: List[Dict[str, Any]] = []
+        for row in rows:
+            metadata = row.get("metadata")
+            if metadata is None and "metadata_json" in row:
+                metadata = row.get("metadata_json")
+            metadata = _metadata_json(metadata)
+            content = row.get("content") if row.get("content") is not None else row.get("text", "")
+            timestamp = row.get("timestamp")
+            created_at = row.get("created_at", metadata.get("created_at", timestamp))
+            updated_at = row.get("updated_at", metadata.get("updated_at", timestamp))
+            clean.append(
+                {
+                    "id": row.get("id"),
+                    "content": content,
+                    "score": row.get("score"),
+                    "category": row.get("category", ""),
+                    "scope": row.get("scope", ""),
+                    "source": row.get("source", metadata.get("source", "")),
+                    "created_at": created_at,
+                    "updated_at": updated_at,
+                    "importance": row.get("importance"),
+                    "embedding_model": row.get("embedding_model", metadata.get("embedding_model")),
+                    "dimensions": row.get("dimensions", metadata.get("dimensions", len(row.get("vector") or []))),
+                    "metadata": metadata,
+                    "session_id": row.get("session_id", metadata.get("session_id", "")),
+                }
+            )
+        return clean
+
+    def _backend_name(self) -> str:
+        return getattr(self._ensure_store(), "backend", "unknown")
+
+    def _status(self) -> Dict[str, Any]:
+        store = self._ensure_store()
+        return {
+            "name": self.name,
+            "backend": getattr(store, "backend", "unknown"),
+            "path": str(self._store_path or ""),
+            "schema": "hermes",
+            "table": self._table_name,
+            "count": int(store.count()),
+            "embedding_mode": self._embedder.mode,
+            "embedding_model": self._embedder.model,
+            "dimensions": self._embedder.dim,
+            "hash_fallback_note": "hash embeddings are deterministic dev/test fallback, not production semantic embeddings",
+            "sync_turn_enabled": self._sync_turn_enabled,
+            "auto_recall_enabled": self._auto_recall_enabled,
+            "backend_error": self._last_backend_error,
+        }
+
+
+MemoryProvider = LancedbProMemoryProvider
+
+
+def register(ctx: Any) -> None:
+    ctx.register_memory_provider(LancedbProMemoryProvider())
+
+
+def register_memory_provider() -> LancedbProMemoryProvider:
+    return LancedbProMemoryProvider()

--- a/integrations/hermes/lancedb_pro/scripts/import_openclaw_lancedb.py
+++ b/integrations/hermes/lancedb_pro/scripts/import_openclaw_lancedb.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Safely import OpenClaw memory-lancedb-pro rows into Hermes lancedb_pro.
+
+Safety defaults:
+- source LanceDB is opened read-only-by-convention and never written;
+- target path must be separate from the OpenClaw source;
+- existing non-empty target tables are not overwritten unless --append is set;
+- secrets are read from env/config but never printed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+DEFAULT_SOURCE = str(Path(os.getenv("OPENCLAW_HOME", "~/.openclaw")).expanduser() / "memory" / "lancedb-pro")
+DEFAULT_SOURCE_TABLE = "memories"
+DEFAULT_TARGET_TABLE = "hermes_memories"
+DEFAULT_MODEL = "jina-embeddings-v5-text-small"
+DEFAULT_BASE_URL = "https://api.jina.ai/v1"
+DEFAULT_DIM = 1024
+
+
+def eprint(*parts: Any) -> None:
+    print(*parts, file=sys.stderr, flush=True)
+
+
+def load_jina_config(path: str) -> Dict[str, Any]:
+    cfg = {"api_key": os.getenv("HERMES_MEMORY_JINA_API_KEY") or os.getenv("JINA_API_KEY") or ""}
+    if cfg["api_key"]:
+        cfg.update({"source": "env", "model": os.getenv("HERMES_MEMORY_EMBED_MODEL", DEFAULT_MODEL), "base_url": os.getenv("HERMES_MEMORY_EMBED_BASE_URL", DEFAULT_BASE_URL).removesuffix("/embeddings")})
+        return cfg
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception:
+        return cfg
+
+    found: Optional[Dict[str, Any]] = None
+
+    def walk(obj: Any) -> None:
+        nonlocal found
+        if found is not None:
+            return
+        if isinstance(obj, dict):
+            text = json.dumps(obj, ensure_ascii=False).lower()
+            if "jina" in text and ("apikey" in "".join(obj.keys()).lower() or "apiKey" in obj):
+                key = obj.get("apiKey") or obj.get("api_key") or obj.get("key")
+                if key:
+                    found = obj
+                    return
+            for value in obj.values():
+                walk(value)
+        elif isinstance(obj, list):
+            for value in obj:
+                walk(value)
+
+    walk(data)
+    if found:
+        cfg.update({
+            "api_key": found.get("apiKey") or found.get("api_key") or found.get("key") or "",
+            "source": path,
+            "model": found.get("model") or DEFAULT_MODEL,
+            "base_url": (found.get("baseURL") or found.get("base_url") or DEFAULT_BASE_URL).removesuffix("/embeddings"),
+        })
+    return cfg
+
+
+def chunks(items: List[Dict[str, Any]], size: int) -> Iterable[List[Dict[str, Any]]]:
+    for idx in range(0, len(items), size):
+        yield items[idx: idx + size]
+
+
+def embed_batch(texts: List[str], *, api_key: str, base_url: str, model: str, task: str, timeout: int) -> List[List[float]]:
+    import requests
+
+    url = base_url.rstrip("/") + "/embeddings"
+    response = requests.post(
+        url,
+        headers={"Authorization": "Bearer " + api_key, "Content-Type": "application/json"},
+        json={"model": model, "input": texts, "task": task},
+        timeout=timeout,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(f"embedding endpoint returned HTTP {response.status_code}")
+    data = response.json().get("data") or []
+    vectors = [row.get("embedding") for row in data]
+    if len(vectors) != len(texts) or any(not isinstance(v, list) for v in vectors):
+        raise RuntimeError("embedding response count/shape mismatch")
+    return [[float(x) for x in v] for v in vectors]  # type: ignore[arg-type]
+
+
+def parse_metadata(raw: Any) -> Dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw.strip():
+        try:
+            parsed = json.loads(raw)
+            return parsed if isinstance(parsed, dict) else {"raw_metadata": raw}
+        except Exception:
+            return {"raw_metadata": raw}
+    return {}
+
+
+def openclaw_timestamp_to_seconds(value: Any) -> float:
+    """Convert OpenClaw Unix millisecond timestamps to Hermes Unix seconds."""
+    try:
+        created_f = float(value)
+        if created_f > 10_000_000_000:  # ms -> seconds
+            created_f = created_f / 1000.0
+        return created_f
+    except Exception:
+        return time.time()
+
+
+def convert_row(row: Dict[str, Any], vector: List[float], model: str) -> Dict[str, Any]:
+    text = str(row.get("text") or row.get("content") or "").strip()
+    original_metadata = parse_metadata(row.get("metadata"))
+    metadata = dict(original_metadata)
+    metadata.setdefault("original_id", str(row.get("id")) if row.get("id") is not None else None)
+    metadata.setdefault("original_timestamp", row.get("timestamp"))
+    metadata.setdefault("original_category", row.get("category"))
+    metadata.setdefault("original_scope", row.get("scope"))
+    metadata.setdefault("original_importance", row.get("importance"))
+    metadata.setdefault("original_metadata", original_metadata)
+    created_f = openclaw_timestamp_to_seconds(row.get("timestamp"))
+    return {
+        "id": str(uuid.uuid4()),
+        "content": text,
+        "vector": vector,
+        "category": str(row.get("category") or metadata.get("category") or "memory"),
+        "scope": str(row.get("scope") or metadata.get("scope") or "global"),
+        "source": "openclaw_migration",
+        "created_at": created_f,
+        "updated_at": created_f,
+        "importance": float(row.get("importance") if row.get("importance") is not None else metadata.get("importance", 0.5)),
+        "embedding_model": model,
+        "dimensions": len(vector),
+        "metadata_json": json.dumps(metadata, ensure_ascii=False, sort_keys=True, default=str),
+        "session_id": "openclaw_migration",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", default=DEFAULT_SOURCE)
+    parser.add_argument("--source-table", default=DEFAULT_SOURCE_TABLE)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--target-table", default=DEFAULT_TARGET_TABLE)
+    parser.add_argument("--config", default=str(Path(os.getenv("OPENCLAW_HOME", "~/.openclaw")).expanduser() / "openclaw.json"))
+    parser.add_argument("--limit", type=int, default=0)
+    parser.add_argument("--offset", type=int, default=0)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--progress-every", type=int, default=250)
+    parser.add_argument("--append", action="store_true")
+    parser.add_argument("--manifest", default="")
+    parser.add_argument("--timeout", type=int, default=60)
+    args = parser.parse_args()
+
+    source = Path(args.source).expanduser().resolve()
+    target = Path(args.target).expanduser().resolve()
+    if source == target:
+        raise SystemExit("Refusing target inside/equal to OpenClaw source path")
+    try:
+        target.relative_to(source)
+    except ValueError:
+        pass
+    else:
+        raise SystemExit("Refusing target inside/equal to OpenClaw source path")
+    if not source.exists():
+        raise SystemExit(f"Source LanceDB path does not exist: {source}")
+    if not source.is_dir():
+        raise SystemExit(f"Source LanceDB path is not a directory: {source}")
+
+    import lancedb
+
+    src_db = lancedb.connect(str(source))
+    try:
+        source_tables = set(src_db.table_names())
+    except Exception as exc:
+        raise SystemExit(f"Unable to list source LanceDB tables in read-only preflight: {exc}") from exc
+    if args.source_table not in source_tables:
+        raise SystemExit(f"Source table {args.source_table!r} not found in {source}; available tables: {sorted(source_tables)}")
+    try:
+        src_table = src_db.open_table(args.source_table)
+    except Exception as exc:
+        raise SystemExit(f"Unable to open source table {args.source_table!r} during read-only preflight: {exc}") from exc
+
+    cfg = load_jina_config(args.config)
+    if not cfg.get("api_key"):
+        raise SystemExit("Jina API key not found in env/config; refusing hash fallback migration")
+
+    eprint("source", str(source), "table", args.source_table)
+    eprint("target", str(target), "table", args.target_table)
+    eprint("embedding", "provider=jina", "model=" + str(cfg.get("model", DEFAULT_MODEL)), "dims=" + str(DEFAULT_DIM), "key_present=True", "key_source=" + str(cfg.get("source", "unknown")))
+
+    total = int(src_table.count_rows())
+    arrow = src_table.to_arrow()
+    if args.offset:
+        arrow = arrow.slice(args.offset)
+    if args.limit:
+        arrow = arrow.slice(0, args.limit)
+    rows = [r for r in arrow.to_pylist() if str(r.get("text") or r.get("content") or "").strip()]
+
+    target.mkdir(parents=True, exist_ok=True)
+    tgt_db = lancedb.connect(str(target))
+    existing_tables = set(tgt_db.table_names())
+    table = None
+    if args.target_table in existing_tables:
+        table = tgt_db.open_table(args.target_table)
+        existing_count = int(table.count_rows())
+        if existing_count and not args.append:
+            raise SystemExit(f"Target table already has {existing_count} rows; use a new timestamped target or --append")
+
+    imported = skipped = errors = 0
+    started = time.time()
+    first_write = True if table is None else False
+    error_samples: List[str] = []
+
+    for batch in chunks(rows, max(1, args.batch_size)):
+        texts = [str(r.get("text") or r.get("content") or "") for r in batch]
+        try:
+            vectors = embed_batch(texts, api_key=cfg["api_key"], base_url=cfg.get("base_url", DEFAULT_BASE_URL), model=cfg.get("model", DEFAULT_MODEL), task="retrieval.passage", timeout=args.timeout)
+            out_rows = [convert_row(r, v, cfg.get("model", DEFAULT_MODEL)) for r, v in zip(batch, vectors)]
+            if first_write:
+                table = tgt_db.create_table(args.target_table, data=out_rows)
+                first_write = False
+            else:
+                assert table is not None
+                table.add(out_rows)
+            imported += len(out_rows)
+        except Exception as exc:
+            errors += len(batch)
+            if len(error_samples) < 5:
+                error_samples.append(exc.__class__.__name__ + ": " + str(exc)[:120])
+        done = imported + skipped + errors
+        if done and (done % args.progress_every == 0 or done == len(rows)):
+            eprint("progress", done, "/", len(rows), "imported", imported, "errors", errors)
+
+    final_count = int(table.count_rows()) if table is not None else 0
+    manifest = {
+        "source_path": str(source),
+        "source_table": args.source_table,
+        "source_total_rows": total,
+        "target_path": str(target),
+        "target_table": args.target_table,
+        "records_selected": len(rows),
+        "records_imported": imported,
+        "records_skipped": skipped,
+        "records_errors": errors,
+        "target_count": final_count,
+        "embedding_provider": "jina",
+        "embedding_model": cfg.get("model", DEFAULT_MODEL),
+        "embedding_dimensions_expected": DEFAULT_DIM,
+        "embedding_task": "retrieval.passage",
+        "api_key_present": True,
+        "api_key_source": cfg.get("source", "unknown"),
+        "duration_seconds": round(time.time() - started, 3),
+        "error_samples": error_samples,
+    }
+    if args.manifest:
+        Path(args.manifest).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.manifest).write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(manifest, ensure_ascii=False, sort_keys=True))
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/hermes_lancedb_pro_openclaw_migration_test.py
+++ b/test/hermes_lancedb_pro_openclaw_migration_test.py
@@ -1,0 +1,157 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PLUGIN = Path(__file__).resolve().parents[1] / "integrations" / "hermes" / "lancedb_pro"
+sys.path.insert(0, str(PLUGIN / "scripts"))
+
+from import_openclaw_lancedb import convert_row, main, openclaw_timestamp_to_seconds, parse_metadata  # noqa: E402
+
+
+def test_importer_missing_source_fails_without_creating_source_or_target(tmp_path, monkeypatch):
+    missing_source = tmp_path / "missing-source"
+    target = tmp_path / "target"
+
+    def fail_connect(path):  # pragma: no cover - should not be reached
+        Path(path).mkdir(parents=True, exist_ok=True)
+        raise AssertionError("lancedb.connect should not be called for a missing source")
+
+    monkeypatch.setitem(sys.modules, "lancedb", types.SimpleNamespace(connect=fail_connect))
+    monkeypatch.setenv("HERMES_MEMORY_JINA_API_KEY", "test-key")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "import_openclaw_lancedb.py",
+            "--source",
+            str(missing_source),
+            "--target",
+            str(target),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    assert "Source LanceDB path does not exist" in str(excinfo.value)
+    assert not missing_source.exists()
+    assert not target.exists()
+
+
+class _FakeSourceDb:
+    def table_names(self):
+        return ["other_table"]
+
+    def open_table(self, table_name):  # pragma: no cover - should not be reached
+        raise AssertionError(f"unexpected open_table({table_name!r})")
+
+
+def test_importer_missing_source_table_fails_before_target_created(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    source.mkdir()
+    target = tmp_path / "target"
+    connections = []
+
+    def fake_connect(path):
+        connections.append(Path(path))
+        assert Path(path) == source
+        return _FakeSourceDb()
+
+    monkeypatch.setitem(sys.modules, "lancedb", types.SimpleNamespace(connect=fake_connect))
+    monkeypatch.setenv("HERMES_MEMORY_JINA_API_KEY", "test-key")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "import_openclaw_lancedb.py",
+            "--source",
+            str(source),
+            "--source-table",
+            "memories",
+            "--target",
+            str(target),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    assert "Source table 'memories' not found" in str(excinfo.value)
+    assert connections == [source]
+    assert not target.exists()
+
+
+def test_parse_metadata_accepts_dict_json_string_and_raw_string():
+    assert parse_metadata({"a": 1}) == {"a": 1}
+    assert parse_metadata('{"a": 1}') == {"a": 1}
+    assert parse_metadata("not json") == {"raw_metadata": "not json"}
+    assert parse_metadata("") == {}
+
+
+def test_openclaw_timestamp_ms_converts_to_hermes_seconds():
+    assert openclaw_timestamp_to_seconds(1_700_000_000_123) == 1_700_000_000.123
+    assert openclaw_timestamp_to_seconds("1700000000.5") == 1_700_000_000.5
+
+
+def test_convert_openclaw_row_to_hermes_schema_preserves_originals():
+    row = {
+        "id": "openclaw-123",
+        "text": "Legacy OpenClaw memory text",
+        "vector": [9.0, 9.0, 9.0],
+        "category": "preference",
+        "scope": "project",
+        "importance": 0.75,
+        "timestamp": 1_700_000_000_123,
+        "metadata": json.dumps({"existing": "value", "scope": "metadata-scope"}),
+    }
+    out = convert_row(row, [0.1, 0.2, 0.3], "jina-test-model")
+
+    assert set(out) == {
+        "id",
+        "content",
+        "vector",
+        "category",
+        "scope",
+        "source",
+        "created_at",
+        "updated_at",
+        "importance",
+        "embedding_model",
+        "dimensions",
+        "metadata_json",
+        "session_id",
+    }
+    assert out["id"] != "openclaw-123"
+    assert out["content"] == "Legacy OpenClaw memory text"
+    assert out["vector"] == [0.1, 0.2, 0.3]
+    assert out["category"] == "preference"
+    assert out["scope"] == "project"
+    assert out["source"] == "openclaw_migration"
+    assert out["created_at"] == 1_700_000_000.123
+    assert out["updated_at"] == 1_700_000_000.123
+    assert out["importance"] == 0.75
+    assert out["embedding_model"] == "jina-test-model"
+    assert out["dimensions"] == 3
+    assert out["session_id"] == "openclaw_migration"
+
+    metadata = json.loads(out["metadata_json"])
+    assert metadata["existing"] == "value"
+    assert metadata["original_id"] == "openclaw-123"
+    assert metadata["original_timestamp"] == 1_700_000_000_123
+    assert metadata["original_category"] == "preference"
+    assert metadata["original_scope"] == "project"
+    assert metadata["original_importance"] == 0.75
+    assert metadata["original_metadata"] == {"existing": "value", "scope": "metadata-scope"}
+
+
+def test_convert_supports_target_table_named_memories_by_not_changing_row_schema():
+    # Target table selection is a CLI/storage concern. Converted rows remain
+    # Hermes schema even when the importer is run with --target-table memories.
+    out = convert_row({"id": "1", "text": "hello", "timestamp": 1_700_000_000_000}, [1.0], "model")
+    assert "content" in out
+    assert "metadata_json" in out
+    assert "text" not in out
+    assert "timestamp" not in out

--- a/test/hermes_lancedb_pro_provider_test.py
+++ b/test/hermes_lancedb_pro_provider_test.py
@@ -1,0 +1,239 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN = Path(__file__).resolve().parents[1] / "integrations" / "hermes" / "lancedb_pro"
+HERMES_SRC = os.getenv("HERMES_SRC")
+sys.path.insert(0, str(PLUGIN.parent))
+if HERMES_SRC:
+    sys.path.insert(0, str(Path(HERMES_SRC).expanduser()))
+
+from lancedb_pro import LancedbProMemoryProvider  # noqa: E402
+
+
+def test_manual_store_search_status_forced_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_FORCE_JSON", "true")
+    monkeypatch.setenv("HERMES_MEMORY_EMBED_PROVIDER", "hash")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_PATH", str(tmp_path / "memory" / "lancedb-pro"))
+    monkeypatch.delenv("HERMES_MEMORY_JINA_API_KEY", raising=False)
+    monkeypatch.delenv("HERMES_MEMORY_LANCEDB_TABLE", raising=False)
+    monkeypatch.delenv("HERMES_MEMORY_LANCEDB_SCHEMA", raising=False)
+
+    provider = LancedbProMemoryProvider()
+    provider.initialize("test-session", hermes_home=str(tmp_path), platform="cli")
+
+    status = json.loads(provider.handle_tool_call("lancedb_pro_status", {}))
+    assert status["ok"] is True
+    assert status["backend"] == "json_fallback"
+    assert status["schema"] == "hermes"
+    assert status["table"] == "hermes_memories"
+    assert status["count"] == 0
+    assert status["embedding_model"] == "jina-embeddings-v5-text-small"
+    assert status["dimensions"] == 1024
+
+    stored = json.loads(
+        provider.handle_tool_call(
+            "lancedb_pro_store",
+            {
+                "content": "Hermes uses LanceDB for durable semantic memory",
+                "category": "project",
+                "scope": "test",
+                "source": "pytest",
+                "importance": 0.9,
+                "metadata": {"tag": "smoke"},
+            },
+        )
+    )
+    assert stored["ok"] is True
+    assert stored["id"]
+
+    found = json.loads(provider.handle_tool_call("lancedb_pro_search", {"query": "durable LanceDB memory", "limit": 1}))
+    assert found["ok"] is True
+    assert found["results"]
+    result = found["results"][0]
+    assert result["id"] == stored["id"]
+    assert result["category"] == "project"
+    assert result["scope"] == "test"
+    assert result["source"] == "pytest"
+    assert result["importance"] == 0.9
+    assert result["embedding_model"] == "hash-dev-1024"
+    assert result["dimensions"] == 1024
+    assert result["metadata"] == {"tag": "smoke"}
+
+    prefetched = provider.prefetch("what memory backend does Hermes use?")
+    assert "Relevant lancedb_pro memories" in prefetched
+
+    forgotten = json.loads(provider.handle_tool_call("lancedb_pro_forget", {"id": stored["id"]}))
+    assert forgotten["ok"] is True
+    assert forgotten["deleted"] == 1
+
+
+def test_table_override_still_stores_hermes_schema_forced_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_FORCE_JSON", "true")
+    monkeypatch.setenv("HERMES_MEMORY_EMBED_PROVIDER", "hash")
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_SCHEMA", "openclaw")  # ignored legacy env; provider is Hermes-schema only.
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_TABLE", "memories")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_PATH", str(tmp_path / "memory" / "lancedb-pro"))
+    monkeypatch.delenv("HERMES_MEMORY_JINA_API_KEY", raising=False)
+
+    provider = LancedbProMemoryProvider()
+    provider.initialize("table-override-session", hermes_home=str(tmp_path), platform="cli")
+
+    status = json.loads(provider.handle_tool_call("lancedb_pro_status", {}))
+    assert status["ok"] is True
+    assert status["schema"] == "hermes"
+    assert status["table"] == "memories"
+
+    stored = json.loads(
+        provider.handle_tool_call(
+            "lancedb_pro_store",
+            {
+                "content": "Hermes schema can use the memories table name",
+                "category": "migration",
+                "scope": "project",
+                "source": "pytest",
+                "importance": 0.8,
+                "metadata": {"tag": "table-override"},
+            },
+        )
+    )
+    assert stored["ok"] is True
+
+    rows = [json.loads(line) for line in (tmp_path / "memory" / "lancedb-pro" / "memories.jsonl").read_text().splitlines()]
+    assert len(rows) == 1
+    row = rows[0]
+    assert set(row) == {
+        "id",
+        "content",
+        "vector",
+        "category",
+        "scope",
+        "source",
+        "created_at",
+        "updated_at",
+        "importance",
+        "embedding_model",
+        "dimensions",
+        "metadata_json",
+        "session_id",
+    }
+    assert row["content"] == "Hermes schema can use the memories table name"
+    assert row["source"] == "pytest"
+    assert json.loads(row["metadata_json"]) == {"tag": "table-override"}
+
+
+def test_forced_json_uses_table_specific_file_for_custom_table(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_FORCE_JSON", "true")
+    monkeypatch.setenv("HERMES_MEMORY_EMBED_PROVIDER", "hash")
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_TABLE", "custom_table")
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_PATH", str(tmp_path / "memory" / "lancedb-pro"))
+    monkeypatch.delenv("HERMES_MEMORY_JINA_API_KEY", raising=False)
+
+    provider = LancedbProMemoryProvider()
+    provider.initialize("custom-table-json-session", hermes_home=str(tmp_path), platform="cli")
+
+    stored = json.loads(provider.handle_tool_call("lancedb_pro_store", {"content": "custom table json fallback"}))
+    assert stored["ok"] is True
+
+    store_path = tmp_path / "memory" / "lancedb-pro"
+    assert (store_path / "custom_table.jsonl").exists()
+    assert not (store_path / "memories.jsonl").exists()
+
+
+def test_real_lancedb_table_override_uses_hermes_schema(tmp_path, monkeypatch):
+    pytest.importorskip("lancedb")
+    monkeypatch.delenv("HERMES_MEMORY_LANCEDB_FORCE_JSON", raising=False)
+    monkeypatch.delenv("HERMES_MEMORY_JINA_API_KEY", raising=False)
+    monkeypatch.setenv("HERMES_MEMORY_EMBED_PROVIDER", "hash")
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_SCHEMA", "openclaw")  # ignored legacy env; provider is Hermes-schema only.
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_TABLE", "memories")
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_PATH", str(tmp_path / "lancedb-real"))
+
+    provider = LancedbProMemoryProvider()
+    provider.initialize("real-hermes-session", hermes_home=str(tmp_path), platform="cli")
+
+    status = json.loads(provider.handle_tool_call("lancedb_pro_status", {}))
+    assert status["backend"] == "lancedb"
+    assert status["schema"] == "hermes"
+    assert status["table"] == "memories"
+
+    stored = json.loads(provider.handle_tool_call("lancedb_pro_store", {"content": "real LanceDB Hermes schema", "metadata": {"tag": "real"}}))
+    assert stored["ok"] is True
+
+    import lancedb
+
+    table = lancedb.connect(str(tmp_path / "lancedb-real")).open_table("memories")
+    raw = table.to_arrow().to_pylist()[0]
+    assert {"id", "content", "vector", "category", "scope", "source", "created_at", "updated_at", "importance", "embedding_model", "dimensions", "metadata_json", "session_id"}.issubset(raw)
+    assert "text" not in raw
+    assert "timestamp" not in raw
+    assert raw["content"] == "real LanceDB Hermes schema"
+    assert json.loads(raw["metadata_json"])["tag"] == "real"
+
+
+def test_sync_turn_default_off(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_FORCE_JSON", "true")
+    monkeypatch.setenv("HERMES_MEMORY_EMBED_PROVIDER", "hash")
+    monkeypatch.delenv("HERMES_MEMORY_LANCEDB_SYNC_TURN", raising=False)
+    monkeypatch.delenv("HERMES_MEMORY_LANCEDB_AUTO_CAPTURE", raising=False)
+
+    provider = LancedbProMemoryProvider()
+    provider.initialize("test-session", hermes_home=str(tmp_path), platform="cli")
+    provider.sync_turn("hello", "world")
+
+    status = json.loads(provider.handle_tool_call("lancedb_pro_status", {}))
+    assert status["sync_turn_enabled"] is False
+    assert status["count"] == 0
+
+
+def test_import_via_hermes_user_plugin_loader(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_MEMORY_LANCEDB_FORCE_JSON", "true")
+    monkeypatch.setenv("HERMES_MEMORY_EMBED_PROVIDER", "hash")
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / "lancedb_pro").symlink_to(PLUGIN, target_is_directory=True)
+
+    pytest.importorskip("plugins.memory")
+    from plugins.memory import load_memory_provider  # noqa: E402
+
+    provider = load_memory_provider("lancedb_pro")
+    assert provider is not None
+    assert provider.name == "lancedb_pro"
+    provider.initialize("loader-test", hermes_home=str(tmp_path), platform="cli")
+    status = json.loads(provider.handle_tool_call("lancedb_pro_status", {}))
+    assert status["ok"] is True
+
+
+def test_remote_jina_tasks_are_sent(monkeypatch):
+    import lancedb_pro.provider as provider_module
+
+    calls = []
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"data": [{"embedding": [1.0] * 1024}]}
+
+    class FakeRequests:
+        @staticmethod
+        def post(url, headers=None, json=None, timeout=None):
+            calls.append({"url": url, "headers": headers, "json": json, "timeout": timeout})
+            return FakeResponse()
+
+    monkeypatch.setattr(provider_module, "_requests", FakeRequests)
+    monkeypatch.setenv("HERMES_MEMORY_JINA_API_KEY", "test-key")
+    monkeypatch.setenv("HERMES_MEMORY_HASH_FALLBACK", "false")
+
+    embedder = provider_module._Embedder()
+    vector = embedder.embed("hello", task="retrieval.query")
+
+    assert len(vector) == 1024
+    assert calls[0]["json"]["task"] == "retrieval.query"
+    assert calls[0]["json"]["model"] == "jina-embeddings-v5-text-small"


### PR DESCRIPTION
## Summary

Adds a Hermes-native `lancedb_pro` memory provider under `integrations/hermes/lancedb_pro/`, plus a safe OpenClaw LanceDB importer for migrating legacy OpenClaw rows into a separate Hermes-schema database.

## What changed

- Adds/updates the Hermes provider implementation and metadata for `lancedb_pro`.
- Keeps provider runtime Hermes-schema only, regardless of table name.
- Supports `HERMES_MEMORY_LANCEDB_TABLE` override; default remains `hermes_memories`.
- Stores JSON fallback data per table (`<safe-table-name>.jsonl`) to match table override behavior.
- Adds an OpenClaw migration importer that converts legacy `text`/`timestamp`/`metadata` rows into Hermes `content`/`created_at`/`metadata_json` rows.
- Adds preflight safety checks before migration writes: missing/non-directory source is rejected before `lancedb.connect()`, source table existence is verified before target creation/connect, and target paths equal to or inside the source are refused.
- Preserves original OpenClaw values in `metadata_json` as `original_*` fields.
- Documents migration workflow, table override behavior, and local smoke-test commands.
- Adds regression tests for provider table override, Hermes schema output, JSON fallback file naming, migration conversion, timestamp conversion, metadata parsing, and migration preflight safety.

## Test plan

- `./.migration-venv/bin/python -m py_compile integrations/hermes/lancedb_pro/provider.py integrations/hermes/lancedb_pro/scripts/import_openclaw_lancedb.py test/hermes_lancedb_pro_provider_test.py test/hermes_lancedb_pro_openclaw_migration_test.py`
- `./.migration-venv/bin/python -m pytest test/hermes_lancedb_pro_provider_test.py test/hermes_lancedb_pro_openclaw_migration_test.py -q`
  - Result: `12 passed, 1 skipped`.
- `git diff --check`
  - Result: passed.
- `npm test`
  - Not run in this local checkout because `node_modules` is not present.

## Safety notes

- No Hermes core files are modified.
- No live OpenClaw DB writes are performed by the provider or tests.
- The importer reads an OpenClaw source only after explicit CLI invocation and writes only to a separate target path.
- The importer refuses source/target path overlap and verifies the source path/table before any target connect/create.
- No API keys or local private DB paths are included in docs or this PR body.
- `sync_turn`/auto-capture remains disabled by default.
- `lancedb_pro_forget` deletes only one exact memory id.

## Follow-ups

- Add CI coverage for the Python provider tests if upstream wants Python tests in this Node-centric repository.
- Consider richer category/scope ranking controls in a separate change.
