### PR TITLE
fix(backup): api.resolvePath() returns undefined on secondary register() calls

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4212,9 +4212,7 @@ const memoryLanceDBProPlugin = {
 
     async function runBackup() {
       try {
-        const backupDir = api.resolvePath(
-          join(resolvedDbPath, "..", "backups"),
-        );
+        const backupDir = join(resolvedDbPath, "..", "backups");
         await mkdir(backupDir, { recursive: true });
 
         const allMemories = await store.list(undefined, undefined, 10000, 0);


### PR DESCRIPTION
## Summary

Fix the daily backup failure caused by `api.resolvePath()` returning `undefined` when `register()` is called with a CLI-metadata API instance (the secondary call).

## Problem

`runBackup()` captures `api.resolvePath` from the `register()` closure. When openclaw calls `register()` multiple times with different API instances — first with the **runtime API** (valid `resolvePath`), then with a **cli-metadata API** (whose `resolvePath` may return `undefined`) — the backup timer's closure captures the wrong API, causing:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string
or an instance of Buffer or URL. Received undefined
```

This error appears in logs on every gateway restart, but the backup silently fails.

## Fix

Since `resolvedDbPath` is already an absolute path set during `_initPluginState()`, we can safely use `path.join()` directly — no need for `api.resolvePath()` to re-resolve it:

```diff
-        const backupDir = api.resolvePath(
-          join(resolvedDbPath, "..", "backups"),
-        );
+        const backupDir = join(resolvedDbPath, "..", "backups");
```

`path.join()` always returns a string, so the TypeError is eliminated.

## Verification

After this fix, the backup completes successfully:
```
memory-lancedb-pro: backup completed (2097 entries → /home/icamel/.openclaw/memory/backups/memory-backup-2026-05-09.jsonl)
```