### PR TITLE
fix: declare memory tools and log auto-recall events

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2751,6 +2751,25 @@ const memoryLanceDBProPlugin = {
             return;
           }
 
+          // Write autoRecall event to JSONL for autodream's RecallTracker
+          const recallLogDir = (config as Record<string, unknown>).recallLogDir as string | undefined
+            ?? join(homedir(), ".openclaw", "memory", "autodream-reports");
+          const autoRecallLogPath = join(recallLogDir, "auto-recall-log.jsonl");
+          const recallEntry = JSON.stringify({
+            ts: Date.now(),
+            query: event.prompt.slice(0, 500),
+            agentId,
+            source: "auto-recall",
+            hits: results.map((r) => ({
+              id: r.entry.id,
+              score: r.score,
+              scope: r.entry.scope,
+            })),
+          });
+          mkdir(recallLogDir, { recursive: true })
+            .then(() => appendFile(autoRecallLogPath, recallEntry + "\n", "utf-8"))
+            .catch((err) => api.logger.warn?.(`memory-lancedb-pro: failed to write auto-recall log: ${err}`));
+
           // Apply intent-based category boost for adaptive mode
           const rankedResults = intent ? applyCategoryBoost(results, intent) : results;
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -194,13 +194,16 @@
       },
       "autoRecallExcludeAgents": {
         "type": "array",
-        "items": { "type": "string" },
-        "default": [],
-        "description": "Blacklist mode for auto-recall injection. Agents in this list are skipped. Agent resolution falls back to 'main' when no explicit agentId is available. If autoRecallIncludeAgents is also set, include wins."
+        "items": {
+          "type": "string"
+        },
+        "description": "Agent/session patterns excluded from auto-recall and reflection injection. Supports exact match, wildcard prefix (e.g. pi-), and temp:*."
       },
       "autoRecallIncludeAgents": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "default": [],
         "description": "Whitelist mode for auto-recall injection. Only agents in this list receive auto-recall. Agent resolution falls back to 'main' when no explicit agentId is available. If both include and exclude are set, autoRecallIncludeAgents takes precedence (whitelist wins)."
       },
@@ -959,13 +962,6 @@
             "description": "Maximum number of auto-capture extractions allowed per hour"
           }
         }
-      },
-      "autoRecallExcludeAgents": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "Agent/session patterns excluded from auto-recall and reflection injection. Supports exact match, wildcard prefix (e.g. pi-), and temp:*."
       }
     },
     "required": [
@@ -1509,5 +1505,23 @@
       "help": "Whitelist mode. Only these agents receive auto-recall. If agentId is unavailable it falls back to 'main'. Includes take precedence over excludes.",
       "advanced": true
     }
+  },
+  "contracts": {
+    "tools": [
+      "memory_recall",
+      "memory_store",
+      "memory_forget",
+      "memory_update",
+      "memory_stats",
+      "memory_debug",
+      "memory_list",
+      "memory_promote",
+      "memory_archive",
+      "memory_compact",
+      "memory_explain_rank",
+      "self_improvement_log",
+      "self_improvement_extract_skill",
+      "self_improvement_review"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Declare registered memory tools in `openclaw.plugin.json` via `contracts.tools`, including `memory_debug`.
- Add auto-recall JSONL logging for autodream/RecallTracker compatibility.
- Keep the patch minimal against current upstream instead of applying older conflicting stashes.

## Test Plan
- `node test/plugin-manifest-regression.mjs`
- Targeted checks for `contracts.tools` and `auto-recall-log.jsonl`

Note: full `npm test` was attempted locally but an existing service on port `11434` caused Test 8 to fail with `EADDRINUSE`; targeted regression checks passed.