### PR TITLE
feat(store+upgrader): Phase 2 lock serialization + rollback protection (Issue #632)

### DIFF
--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -23,6 +23,7 @@ export const CI_TEST_MANIFEST = [
   { group: "cli-smoke", runner: "node", file: "test/functional-e2e.mjs" },
   { group: "storage-and-schema", runner: "node", file: "test/per-agent-auto-recall.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/retriever-rerank-regression.mjs" },
+  { group: "core-regression", runner: "node", file: "test/retriever-auto-recall-signal.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/smart-memory-lifecycle.mjs" },
   { group: "core-regression", runner: "node", file: "test/smart-extractor-branches.mjs" },
   { group: "core-regression", runner: "node", file: "test/smart-extractor-batch-embed.test.mjs" },

--- a/src/redis-lock.ts
+++ b/src/redis-lock.ts
@@ -1,0 +1,327 @@
+/**
+ * Redis Lock Manager
+ *
+ * 實現分散式 lock，用於解決高並發寫入時的 lock contention 問題。
+ */
+
+// Issue 1 fix: 改用 dynamic import，ioredis 只在真的需要時才載入
+// 不再是 top-level static import，避免 consumer 沒裝 ioredis 時就 crash
+import type { Redis as IORedisType } from "ioredis";
+
+// ============================================================================
+// isRedisConnectionError：判斷錯誤是否為 Redis 連線問題（包含 wrapped error 遞迴檢查）
+// ============================================================================
+
+/**
+ * 判斷 err 是否為 Redis 連線錯誤。
+ * 包含 wrapped error（ioredis errors[] / cause）遞迴檢查，最多遞迴 depth=3 層。
+ *
+ * 注意：ReplyError（如 WRONGTYPE、NOPERM）不是連線錯誤，是 Redis 指令語法/權限問題，
+ * 不進 fallback，直接 throw。
+ */
+export function isRedisConnectionError(err: unknown, depth = 0): boolean {
+  if (depth >= 3) return false;
+  if (!(err instanceof Error)) return false;
+
+  const code = (err as any).code || "";
+  const name = err.name || "";
+
+  if (["ECONNREFUSED", "ETIMEDOUT", "ECONNRESET", "ENOTFOUND"].includes(code)) return true;
+  if (
+    ["MaxRetriesPerRequestError", "ConnectionTimeoutError", "ReconnectionAttemptsLimitError", "AbortedError"].includes(
+      name,
+    )
+  )
+    return true;
+
+  // 檢查 wrapped errors（ioredis 常見：errors[] 陣列或 cause）
+  const inner: unknown[] = Array.isArray((err as any).errors)
+    ? (err as any).errors
+    : (err as any).cause
+      ? [(err as any).cause]
+      : [];
+  return inner.some((e: unknown) => isRedisConnectionError(e, depth + 1));
+}
+
+// ============================================================================
+// RedisUnavailableError：Redis 連線失敗時的專用錯誤類型
+// ============================================================================
+
+/**
+ * Symbol.for 確保跨 module boundary 都能取得同一個 Symbol。
+ * store.ts 用 Symbol.for("RedisUnavailableError") in err 檢查，ESM-safe。
+ */
+const _MARKER = Symbol.for("RedisUnavailableError");
+
+export class RedisUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RedisUnavailableError";
+  }
+  /** Symbol marker — store.ts 用 Symbol.for("RedisUnavailableError") in err 檢查 */
+  get [_MARKER]() {
+    return true;
+  }
+}
+
+// ============================================================================
+// RedisOptions & parseRedisUrl
+// ============================================================================
+
+interface RedisOptions {
+  host: string;
+  port: number;
+  db: number;
+}
+
+/**
+ * Issue 3 fix: parseRedisUrl() now uses URL API to extract hostname/port/db
+ * separately. DB selection (/0, /1, /2...) is preserved instead of being
+ * eaten by replace().
+ *
+ * Examples:
+ *   redis://localhost:6379/0      → { host: "localhost", port: 6379, db: 0 }
+ *   redis://:password@host:6379/1 → { host: "host", port: 6379, db: 1 }  (password stripped)
+ *   localhost:6379              → { host: "localhost", port: 6379, db: 0 }  (legacy fallback)
+ */
+function parseRedisUrl(redisUrl: string): RedisOptions {
+  try {
+    const url = new URL(redisUrl);
+    const host = url.hostname;
+    const port = Number(url.port) || 6379;
+    const rawDb = url.pathname.replace("/", "");
+    // Issue 3 fix: 驗證 db 必須是數字，否則 fallback 到 0（不靜默接受 NaN）
+    const db = /^\d+$/.test(rawDb)
+      ? Number(rawDb)
+      : rawDb
+        ? (console.warn(`[RedisLock] Invalid DB in URL: ${rawDb}, fallback to 0`), 0)
+        : 0;
+    return { host, port, db };
+  } catch {
+    // Fallback：可能是 legacy 格式 "localhost:6379"，直接用 string constructor
+    const parts = redisUrl.replace("redis://", "").split(":");
+    return {
+      host: parts[0] || "localhost",
+      port: Number(parts[1]) || 6379,
+      db: 0,
+    };
+  }
+}
+
+// ============================================================================
+// LockConfig & RedisLockManager
+// ============================================================================
+
+export interface LockConfig {
+  redisUrl?: string;
+  ttl?: number; // lock 持有時間（毫秒）
+  maxWait?: number; // 最大等待時間（毫秒）
+  retryDelay?: number; // 重試延遲（毫秒）
+  /** Issue 4 fix: 用於 namespace Redis lock key，避免不同 dbPath 的 store 互相 blocking */
+  dbPath?: string;
+}
+
+export class RedisLockManager {
+  // ioredis client — 用 any 避免 type 不匹配問題
+  private redis: any = null;
+  private defaultTTL = 60000; // 60 秒
+  private maxWait = 60000; // 60 秒
+  private retryDelay = 100; // 初始重試延遲
+  private _connectionError: unknown = null;
+  private readonly _lockNamespace: string;
+
+  constructor(private readonly config?: LockConfig) {
+    // Issue 4 fix: namespace key with dbPath hash，避免不同 dbPath 的 store 互相 blocking
+    this._lockNamespace = config?.dbPath ? hashString(config.dbPath) : "default";
+  }
+
+  /**
+   * Issue 1 fix: 動態載入 ioredis，只在 connect() 時才 import。
+   * Issue 3 fix: 正確解析 URL，保留 DB selection（/0, /1, /2...）
+   * 用 any 避免 type cast 問題。
+   */
+  async connect(): Promise<void> {
+    try {
+      // Dynamic import — 用 any 避免 type mismatches
+      const RedisModule = await import("ioredis") as any;
+      const Redis = RedisModule.default;
+      const redisUrl = this.config?.redisUrl || process.env.REDIS_URL || "redis://localhost:6379";
+      const parsed = parseRedisUrl(redisUrl);
+
+      this.redis = new Redis({
+        host: parsed.host,
+        port: parsed.port,
+        db: parsed.db,
+        lazyConnect: true,
+        retryStrategy: (times: number) => {
+          if (times > 3) return null; // 停止重連
+          return Math.min(times * 200, 2000);
+        },
+      });
+
+      // N5：注册 error event listener，捕捉非同步連線錯誤
+      this.redis.on("error", (err: unknown) => {
+        if (isRedisConnectionError(err)) {
+          this._connectionError = err;
+        }
+      });
+
+      await this.redis.connect();
+    } catch (err) {
+      console.warn(`[RedisLock] Could not connect to Redis: ${err}`);
+      this.redis = null;
+    }
+  }
+
+  /**
+   * 取得 lock。
+   * 連線錯誤（如 ECONNREFUSED、ETIMEDOUT）時立即 throw RedisUnavailableError，
+   * 讓 store.ts 進 file-lock fallback。
+   *
+   * H4 fix: 移除 pre-flight ping，直接讓第一個 SET() 自然失敗
+   * 避免 TOCTOU (ping ok 但 set 前 Redis 掛掉)，並節省一次 round-trip
+   */
+  async acquire(key: string, ttl?: number): Promise<() => Promise<void>> {
+    if (!this.redis) {
+      throw new RedisUnavailableError("Redis client not initialized");
+    }
+
+    const lockKey = `memory-lock:${this._lockNamespace}:${key}`;
+    const token = generateToken();
+    const startTime = Date.now();
+    const lockTTL = ttl || this.defaultTTL;
+
+    // MAX_ATTEMPTS circuit breaker：防止無限期重試
+    const MAX_ATTEMPTS = 600;
+    let attempts = 0;
+
+    while (true) {
+      attempts++;
+
+      try {
+        const result = await this.redis.set(lockKey, token, "PX", lockTTL, "NX");
+
+        if (result === "OK") {
+          return async () => {
+            const script = `
+              if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("del", KEYS[1])
+              else
+                return 0
+              end
+            `;
+            try {
+              await this.redis.eval(script, 1, lockKey, token);
+            } catch (err) {
+              console.warn(`[RedisLock] Failed to release lock: ${err}`);
+            }
+          };
+        }
+      } catch (err) {
+        // M4：連線錯誤立即進 fallback，不走一般重試
+        if (isRedisConnectionError(err)) {
+          throw new RedisUnavailableError(`Redis connection failed: ${err}`);
+        }
+        console.warn(`[RedisLock] Redis error during acquire (attempt ${attempts}): ${err}`);
+      }
+
+      if (Date.now() - startTime > this.maxWait || attempts >= MAX_ATTEMPTS) {
+        throw new Error(
+          attempts >= MAX_ATTEMPTS
+            ? `Lock acquisition hard-cap reached: ${key} after ${attempts} attempts`
+            : `Lock acquisition timeout: ${key} after ${attempts} attempts (${Date.now() - startTime}ms)`,
+        );
+      }
+
+      const delay = Math.min(this.retryDelay * Math.pow(1.5, Math.min(attempts, 10)), 2000);
+      await this.sleep(delay + Math.random() * 100);
+    }
+  }
+
+  async isHealthy(): Promise<boolean> {
+    if (!this.redis) return false;
+    try {
+      await this.redis.ping();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.redis) {
+      await this.redis.quit();
+      this.redis = null;
+    }
+  }
+
+  get connectionError(): unknown {
+    return this._connectionError;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+// ============================================================================
+// Token Generator
+// ============================================================================
+
+function generateToken(): string {
+  return `${Date.now()}-${Math.random().toString(36).substring(2, 10)}`;
+}
+
+// ============================================================================
+// String Hash（Issue 4 fix）
+// ============================================================================
+
+/**
+ * Issue 4 fix: 將 dbPath 轉為短 hash，用於 namespace Redis lock key。
+ * 避免不同 dbPath 的 store instances 互相 blocking。
+ */
+function hashString(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // convert to 32bit integer
+  }
+  // 轉為正數並取末 8 位，轉成 base36
+  return Math.abs(hash).toString(36).padStart(4, "0");
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * 建立 RedisLockManager 工廠。
+ *
+ * 重要：這個工廠的回傳值決定了「整個 process 的 lock domain」。
+ * createRedisLockManager() 回傳 null → 這個 process 用 file lock
+ * createRedisLockManager() 回傳 manager → 這個 process 用 Redis lock
+ * 一旦決定，整個 process 生命週期內不再改變（Option E）。
+ *
+ * 區分兩種失敗模式：
+ * - Init failure（連不上 Redis）：回傳 null → file lock fallback（合理）
+ * - Runtime failure（acquire() 時 Redis 瞬斷）：拋出 RedisUnavailableError → 直接 throw（安全）
+ */
+export async function createRedisLockManager(config?: LockConfig): Promise<RedisLockManager | null> {
+  const manager = new RedisLockManager(config);
+
+  try {
+    await manager.connect();
+    const isHealthy = await manager.isHealthy();
+    if (isHealthy) {
+      return manager;
+    } else {
+      console.warn("[RedisLock] Redis not healthy, will use file lock fallback");
+      await manager.disconnect();
+      return null;
+    }
+  } catch (err) {
+    console.warn(`[RedisLock] Failed to initialize: ${err}`);
+    return null;
+  }
+}

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -559,7 +559,7 @@ export class MemoryRetriever {
   }
 
   async retrieve(context: RetrievalContext): Promise<RetrievalResult[]> {
-    const { query, limit, scopeFilter, category, source } = context;
+    const { query, limit, scopeFilter, category, source, signal } = context;
     const safeLimit = clampInt(limit, 1, 20);
     this.lastDiagnostics = null;
     const diagnostics: RetrievalDiagnostics = {
@@ -596,35 +596,24 @@ export class MemoryRetriever {
 
       // Check if query contains tag prefixes -> use BM25-only + mustContain
       const tagTokens = this.extractTagTokens(query);
+      const useLightweightAutoRecall = source === "auto-recall";
       let results: RetrievalResult[];
-      if (tagTokens.length > 0) {
+      let mode: "bm25" | "vector" | "hybrid";
+
+      if (tagTokens.length > 0 || useLightweightAutoRecall) {
+        mode = "bm25";
         results = await this.bm25OnlyRetrieval(
-          query,
-          tagTokens,
-          safeLimit,
-          scopeFilter,
-          category,
-          trace,
-          diagnostics,
+          query, tagTokens, safeLimit, scopeFilter, category, trace, diagnostics,
         );
       } else if (this.config.mode === "vector" || !this.store.hasFtsSupport) {
+        mode = "vector";
         results = await this.vectorOnlyRetrieval(
-          query,
-          safeLimit,
-          scopeFilter,
-          category,
-          trace,
-          diagnostics,
+          query, safeLimit, scopeFilter, category, trace, diagnostics, signal,
         );
       } else {
+        mode = "hybrid";
         results = await this.hybridRetrieval(
-          query,
-          safeLimit,
-          scopeFilter,
-          category,
-          trace,
-          source,
-          diagnostics,
+          query, safeLimit, scopeFilter, category, trace, source, diagnostics, signal,
         );
       }
 
@@ -633,11 +622,6 @@ export class MemoryRetriever {
       this.lastDiagnostics = diagnostics;
 
       if (trace && this._statsCollector) {
-        const mode = tagTokens.length > 0
-          ? "bm25"
-          : (this.config.mode === "vector" || !this.store.hasFtsSupport)
-            ? "vector"
-            : "hybrid";
         const finalTrace = trace.finalize(query, mode);
         this._statsCollector.recordQuery(finalTrace, source || "unknown");
       }
@@ -665,29 +649,31 @@ export class MemoryRetriever {
   async retrieveWithTrace(
     context: RetrievalContext,
   ): Promise<{ results: RetrievalResult[]; trace: RetrievalTrace }> {
-    const { query, limit, scopeFilter, category, source } = context;
+    const { query, limit, scopeFilter, category, source, signal } = context;
     const safeLimit = clampInt(limit, 1, 20);
     const trace = new TraceCollector();
 
     const tagTokens = this.extractTagTokens(query);
+    const useLightweightAutoRecall = source === "auto-recall";
     let results: RetrievalResult[];
 
-    if (tagTokens.length > 0) {
+    if (tagTokens.length > 0 || useLightweightAutoRecall) {
+      mode = "bm25";
       results = await this.bm25OnlyRetrieval(
-        query, tagTokens, safeLimit, scopeFilter, category, trace,
+        query, tagTokens, safeLimit, scopeFilter, category, trace, diagnostics,
       );
     } else if (this.config.mode === "vector" || !this.store.hasFtsSupport) {
+      mode = "vector";
       results = await this.vectorOnlyRetrieval(
-        query, safeLimit, scopeFilter, category, trace,
+        query, safeLimit, scopeFilter, category, trace, diagnostics, signal,
       );
     } else {
+      mode = "hybrid";
       results = await this.hybridRetrieval(
-        query, safeLimit, scopeFilter, category, trace,
+        query, safeLimit, scopeFilter, category, trace, source, diagnostics, signal,
       );
     }
 
-    const mode = tagTokens.length > 0 ? "bm25"
-      : (this.config.mode === "vector" || !this.store.hasFtsSupport) ? "vector" : "hybrid";
     const finalTrace = trace.finalize(query, mode);
 
     if (this._statsCollector) {

--- a/test/redis-lock-concurrent-init.test.mjs
+++ b/test/redis-lock-concurrent-init.test.mjs
@@ -1,0 +1,84 @@
+/**
+ * Redis Lock Concurrent Init Tests
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jitiImport = jitiFactory(import.meta.url, { interopDefault: true });
+const mod = jitiImport("../src/redis-lock.ts");
+
+describe("RedisLockManager concurrent init", () => {
+  it("createRedisLockManager returns null when Redis is unavailable", async () => {
+    const manager = await mod.createRedisLockManager({
+      redisUrl: "redis://255.255.255.255:65535",
+      maxWait: 1000,
+    });
+    assert.strictEqual(manager, null);
+  });
+
+  it("createRedisLockManager accepts config without crashing", async () => {
+    const manager = await mod.createRedisLockManager({
+      redisUrl: "redis://localhost:9999",
+      ttl: 30000,
+      maxWait: 1000,
+      retryDelay: 50,
+      dbPath: "/tmp/test-db",
+    });
+    if (manager === null) {
+      // Expected when no Redis server is running
+    } else {
+      assert.ok(manager instanceof mod.RedisLockManager);
+      await manager.disconnect();
+    }
+  });
+
+  it("RedisUnavailableError has Symbol marker", async () => {
+    const err = new mod.RedisUnavailableError("test error");
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.name, "RedisUnavailableError");
+    const marker = Symbol.for("RedisUnavailableError");
+    assert.strictEqual(err[marker], true);
+  });
+
+  it("isRedisConnectionError classifies connection errors", async () => {
+    // ECONNREFUSED
+    const connRefused = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+    assert.strictEqual(mod.isRedisConnectionError(connRefused), true);
+
+    // ETIMEDOUT
+    const timedOut = Object.assign(new Error("connect ETIMEDOUT"), { code: "ETIMEDOUT" });
+    assert.strictEqual(mod.isRedisConnectionError(timedOut), true);
+
+    // ECONNRESET
+    const reset = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    assert.strictEqual(mod.isRedisConnectionError(reset), true);
+
+    // ENOTFOUND
+    const notFound = Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" });
+    assert.strictEqual(mod.isRedisConnectionError(notFound), true);
+
+    // Non-connection error (ReplyError with WRONGTYPE)
+    const replyErr = new Error("WRONGTYPE Operation against a key holding the wrong kind of value");
+    replyErr.name = "ReplyError";
+    assert.strictEqual(mod.isRedisConnectionError(replyErr), false);
+  });
+
+  it("isRedisConnectionError handles nested errors", async () => {
+    const inner = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+    const outer = Object.assign(new Error("Aggregate error"), { errors: [inner] });
+    assert.strictEqual(mod.isRedisConnectionError(outer), true);
+  });
+
+  it("isRedisConnectionError respects depth limit", async () => {
+    const err1 = new Error("level 1");
+    const err2 = new Error("level 2");
+    const err3 = new Error("level 3");
+    const err4 = new Error("level 4");
+    err1.cause = err2;
+    err2.cause = err3;
+    err3.cause = err4;
+    assert.strictEqual(mod.isRedisConnectionError(err1, 0), false);
+  });
+});

--- a/test/redis-lock-error-types.test.mjs
+++ b/test/redis-lock-error-types.test.mjs
@@ -1,0 +1,138 @@
+/**
+ * Redis Lock Error Types Tests
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jitiImport = jitiFactory(import.meta.url, { interopDefault: true });
+const mod = jitiImport("../src/redis-lock.ts");
+
+describe("RedisUnavailableError", () => {
+  it("is an Error subclass", () => {
+    const err = new mod.RedisUnavailableError("Redis is down");
+    assert.ok(err instanceof Error, "should be an Error instance");
+    assert.ok(err instanceof mod.RedisUnavailableError, "should be RedisUnavailableError instance");
+  });
+
+  it("has correct name", () => {
+    const err = new mod.RedisUnavailableError("connection refused");
+    assert.strictEqual(err.name, "RedisUnavailableError");
+  });
+
+  it("preserves message", () => {
+    const msg = "Redis at localhost:6379 refused connection";
+    const err = new mod.RedisUnavailableError(msg);
+    assert.strictEqual(err.message, msg);
+  });
+
+  it("has Symbol.for marker", () => {
+    const err = new mod.RedisUnavailableError("test");
+    const marker = Symbol.for("RedisUnavailableError");
+    assert.strictEqual(err[marker], true);
+  });
+
+  it("marker is same across module instances", () => {
+    const err1 = new mod.RedisUnavailableError("first");
+    const err2 = new mod.RedisUnavailableError("second");
+    const marker = Symbol.for("RedisUnavailableError");
+    assert.strictEqual(err1[marker], true);
+    assert.strictEqual(err2[marker], true);
+  });
+
+  it("toString() includes name and message", () => {
+    const err = new mod.RedisUnavailableError("test message");
+    const str = err.toString();
+    assert.ok(str.includes("RedisUnavailableError"), `toString() should include name: ${str}`);
+    assert.ok(str.includes("test message"), `toString() should include message: ${str}`);
+  });
+});
+
+describe("isRedisConnectionError", () => {
+  it("returns false for null/undefined", () => {
+    assert.strictEqual(mod.isRedisConnectionError(null), false);
+    assert.strictEqual(mod.isRedisConnectionError(undefined), false);
+  });
+
+  it("returns false for non-Error values", () => {
+    assert.strictEqual(mod.isRedisConnectionError("not an error"), false);
+    assert.strictEqual(mod.isRedisConnectionError(42), false);
+    assert.strictEqual(mod.isRedisConnectionError({}), false);
+  });
+
+  it("returns false for ReplyError (Redis command error)", () => {
+    const err = new Error("WRONGTYPE Operation against a key holding the wrong kind of value");
+    err.name = "ReplyError";
+    assert.strictEqual(mod.isRedisConnectionError(err), false);
+  });
+
+  it("returns false for NOPERM (Redis permission error)", () => {
+    const err = Object.assign(new Error("NOPERM this user has no permissions"), { name: "ReplyError", code: "NOPERM" });
+    assert.strictEqual(mod.isRedisConnectionError(err), false);
+  });
+
+  it("returns true for MaxRetriesPerRequestError", () => {
+    const err = new Error("MAX_RETRIES_PER_REQUEST_ERROR");
+    err.name = "MaxRetriesPerRequestError";
+    assert.strictEqual(mod.isRedisConnectionError(err), true);
+  });
+
+  it("returns true for ConnectionTimeoutError", () => {
+    const err = new Error("Connection timed out");
+    err.name = "ConnectionTimeoutError";
+    assert.strictEqual(mod.isRedisConnectionError(err), true);
+  });
+
+  it("returns true for ReconnectionAttemptsLimitError", () => {
+    const err = new Error("Reconnection limit reached");
+    err.name = "ReconnectionAttemptsLimitError";
+    assert.strictEqual(mod.isRedisConnectionError(err), true);
+  });
+
+  it("returns true for AbortedError", () => {
+    const err = new Error("Connection aborted");
+    err.name = "AbortedError";
+    assert.strictEqual(mod.isRedisConnectionError(err), true);
+  });
+
+  it("returns true for cause chain with ECONNREFUSED", () => {
+    const inner = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+    const outer = Object.assign(new Error("Redis connection failed"), { cause: inner });
+    assert.strictEqual(mod.isRedisConnectionError(outer), true);
+  });
+
+  it("returns true for errors[] array (ioredis AggregateError)", () => {
+    const inner = Object.assign(new Error("connect ETIMEDOUT"), { code: "ETIMEDOUT" });
+    const outer = Object.assign(new Error("Aggregate error"), { errors: [inner] });
+    assert.strictEqual(mod.isRedisConnectionError(outer), true);
+  });
+
+  it("returns false for deeply nested non-connection error", () => {
+    const inner = Object.assign(new Error("deep error"), { code: "UNKNOWN" });
+    const level2 = Object.assign(new Error("level 2"), { cause: inner });
+    const level3 = Object.assign(new Error("level 3"), { cause: level2 });
+    assert.strictEqual(mod.isRedisConnectionError(level3), false);
+  });
+});
+
+describe("LockConfig", () => {
+  it("dbPath is stored in RedisLockManager", async () => {
+    const manager = new mod.RedisLockManager({
+      redisUrl: "redis://localhost:6379",
+      dbPath: "/custom/db/path",
+    });
+    assert.ok(manager instanceof mod.RedisLockManager);
+  });
+
+  it("accepts all LockConfig fields", async () => {
+    const manager = new mod.RedisLockManager({
+      redisUrl: "redis://redis.example.com:6380/2",
+      ttl: 30000,
+      maxWait: 15000,
+      retryDelay: 200,
+      dbPath: "/tmp/memory-test",
+    });
+    assert.ok(manager instanceof mod.RedisLockManager);
+  });
+});

--- a/test/redis-lock-url-parse.test.mjs
+++ b/test/redis-lock-url-parse.test.mjs
@@ -1,0 +1,125 @@
+/**
+ * Redis Lock URL Parse Tests
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jitiImport = jitiFactory(import.meta.url, { interopDefault: true });
+const mod = jitiImport("../src/redis-lock.ts");
+
+describe("Redis URL parsing", () => {
+  it("handles standard redis:// URL", async () => {
+    const manager = new mod.RedisLockManager({
+      redisUrl: "redis://localhost:6379/0",
+    });
+    assert.ok(manager instanceof mod.RedisLockManager);
+  });
+
+  it("handles redis:// with custom port", async () => {
+    const manager = new mod.RedisLockManager({
+      redisUrl: "redis://localhost:6380/1",
+    });
+    assert.ok(manager instanceof mod.RedisLockManager);
+  });
+
+  it("handles redis:// with password (password stripped from host)", async () => {
+    const manager = new mod.RedisLockManager({
+      redisUrl: "redis://:secretpassword@redis.example.com:6379/3",
+    });
+    assert.ok(manager instanceof mod.RedisLockManager);
+  });
+
+  it("handles legacy host:port format (no scheme)", async () => {
+    const manager = new mod.RedisLockManager({
+      redisUrl: "localhost:6379",
+    });
+    assert.ok(manager instanceof mod.RedisLockManager);
+  });
+
+  it("handles URL with numeric DB selection", async () => {
+    const manager = new mod.RedisLockManager({
+      redisUrl: "redis://localhost:6379/15",
+    });
+    assert.ok(manager instanceof mod.RedisLockManager);
+  });
+
+  it("handles URL with invalid DB (non-numeric)", async () => {
+    const manager = new mod.RedisLockManager({
+      redisUrl: "redis://localhost:6379/abc",
+    });
+    assert.ok(manager instanceof mod.RedisLockManager);
+  });
+
+  it("handles URL with empty DB", async () => {
+    const manager = new mod.RedisLockManager({
+      redisUrl: "redis://localhost:6379/",
+    });
+    assert.ok(manager instanceof mod.RedisLockManager);
+  });
+
+  it("handles rediss:// (TLS) URL", async () => {
+    const manager = new mod.RedisLockManager({
+      redisUrl: "rediss://localhost:6380",
+    });
+    assert.ok(manager instanceof mod.RedisLockManager);
+  });
+
+  it("uses REDIS_URL env var when no redisUrl provided", async () => {
+    const manager = new mod.RedisLockManager({});
+    assert.ok(manager instanceof mod.RedisLockManager);
+  });
+
+  it("constructor accepts no arguments", async () => {
+    const manager = new mod.RedisLockManager();
+    assert.ok(manager instanceof mod.RedisLockManager);
+  });
+
+  it("connect() handles unreachable Redis gracefully", async () => {
+    const manager = new mod.RedisLockManager({
+      redisUrl: "redis://255.255.255.255:65535",
+    });
+    await manager.connect();
+    const healthy = await manager.isHealthy();
+    assert.strictEqual(healthy, false);
+  });
+
+  it("createRedisLockManager returns null for unreachable Redis", async () => {
+    const manager = await mod.createRedisLockManager({
+      redisUrl: "redis://255.255.255.255:65535",
+      maxWait: 500,
+    });
+    assert.strictEqual(manager, null);
+  });
+
+  it("createRedisLockManager disconnects when not healthy", async () => {
+    const manager = await mod.createRedisLockManager({
+      redisUrl: "redis://localhost:9999",
+      maxWait: 500,
+    });
+    assert.strictEqual(manager, null);
+  });
+
+  it("isHealthy returns false when not connected", async () => {
+    const manager = new mod.RedisLockManager({
+      redisUrl: "redis://localhost:9999",
+    });
+    await manager.connect();
+    const healthy = await manager.isHealthy();
+    assert.strictEqual(healthy, false);
+  });
+
+  it("dbPath namespaces lock keys", async () => {
+    const manager1 = new mod.RedisLockManager({
+      redisUrl: "redis://localhost:6379",
+      dbPath: "/path/to/db1",
+    });
+    const manager2 = new mod.RedisLockManager({
+      redisUrl: "redis://localhost:6379",
+      dbPath: "/path/to/db2",
+    });
+    assert.ok(manager1 instanceof mod.RedisLockManager);
+    assert.ok(manager2 instanceof mod.RedisLockManager);
+  });
+});

--- a/test/retriever-auto-recall-signal.test.mjs
+++ b/test/retriever-auto-recall-signal.test.mjs
@@ -1,0 +1,87 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const { MemoryRetriever, DEFAULT_RETRIEVAL_CONFIG } = jiti("../src/retriever.ts");
+
+function createMockStore(entries = []) {
+  const entriesMap = new Map(entries.map((e) => [e.id, e]));
+  return {
+    hasFtsSupport: true,
+    async bm25Search(query, limit, scopeFilter) {
+      return Array.from(entriesMap.values())
+        .filter((e) => !scopeFilter || scopeFilter.includes(e.scope))
+        .filter((e) => e.text.toLowerCase().includes(query.toLowerCase()))
+        .map((entry, index) => ({ entry, score: 0.8 - index * 0.1 }))
+        .slice(0, limit);
+    },
+    async vectorSearch() { return []; },
+    async hasId(id) { return entriesMap.has(id); },
+  };
+}
+
+function createMockEmbedder() {
+  return { async embedQuery() { return new Array(384).fill(0.1); } };
+}
+
+describe("MemoryRetriever - PR746 signal extraction + auto-recall BM25 mode", () => {
+  describe("signal parameter propagation", () => {
+    it("should accept signal in RetrievalContext", async () => {
+      const store = createMockStore([{ id: "1", text: "architecture decision", scope: "global", category: "decision", timestamp: Date.now(), vector: new Array(384).fill(0.1) }]);
+      const retriever = new MemoryRetriever(store, createMockEmbedder(), { ...DEFAULT_RETRIEVAL_CONFIG, mode: "hybrid", tagPrefixes: [] });
+      const controller = new AbortController();
+      const results = await retriever.retrieve({ query: "architecture", limit: 5, source: "manual", signal: controller.signal });
+      assert.ok(Array.isArray(results));
+    });
+
+    it("should handle cancelled signal without throwing", async () => {
+      const store = createMockStore([{ id: "1", text: "test memory", scope: "global", category: "fact", timestamp: Date.now(), vector: new Array(384).fill(0.1) }]);
+      const retriever = new MemoryRetriever(store, createMockEmbedder(), { ...DEFAULT_RETRIEVAL_CONFIG, mode: "hybrid", tagPrefixes: [] });
+      const controller = new AbortController();
+      controller.abort();
+      const results = await retriever.retrieve({ query: "test", limit: 5, source: "manual", signal: controller.signal });
+      assert.ok(Array.isArray(results));
+    });
+  });
+
+  describe("useLightweightAutoRecall (BM25-only for auto-recall source)", () => {
+    it("should use BM25-only mode when source is 'auto-recall' even without tag tokens", async () => {
+      const entries = [
+        { id: "1", text: "memory about project decisions", scope: "global", category: "decision", timestamp: Date.now(), vector: new Array(384).fill(0.1) },
+        { id: "2", text: "another memory about project", scope: "global", category: "fact", timestamp: Date.now(), vector: new Array(384).fill(0.1) },
+      ];
+      const store = createMockStore(entries);
+      const retriever = new MemoryRetriever(store, createMockEmbedder(), { ...DEFAULT_RETRIEVAL_CONFIG, mode: "hybrid", tagPrefixes: [] });
+      const results = await retriever.retrieve({ query: "project", limit: 5, source: "auto-recall" });
+      assert.ok(Array.isArray(results));
+      assert.ok(results.length >= 1);
+      assert.ok(results.some((r) => r.entry.text.includes("project")));
+    });
+
+    it("should NOT trigger BM25-only when source is 'manual' without tag tokens", async () => {
+      const store = createMockStore([{ id: "1", text: "memory about project", scope: "global", category: "decision", timestamp: Date.now(), vector: new Array(384).fill(0.1) }]);
+      const retriever = new MemoryRetriever(store, createMockEmbedder(), { ...DEFAULT_RETRIEVAL_CONFIG, mode: "hybrid", tagPrefixes: [] });
+      const results = await retriever.retrieve({ query: "project", limit: 5, source: "manual" });
+      assert.ok(Array.isArray(results));
+    });
+
+    it("should prioritize tag tokens over useLightweightAutoRecall", async () => {
+      const store = createMockStore([{ id: "1", text: "proj:AI memory", scope: "global", category: "decision", timestamp: Date.now(), vector: new Array(384).fill(0.1) }]);
+      const retriever = new MemoryRetriever(store, createMockEmbedder(), { ...DEFAULT_RETRIEVAL_CONFIG, tagPrefixes: ["proj"], mode: "hybrid" });
+      const results = await retriever.retrieve({ query: "proj:AI", limit: 5, source: "auto-recall" });
+      assert.ok(Array.isArray(results));
+      assert.ok(results.some((r) => r.entry.text.includes("proj:AI")));
+    });
+  });
+
+  describe("retrieveWithTrace supports signal + useLightweightAutoRecall", () => {
+    it("should accept signal in retrieveWithTrace context", async () => {
+      const store = createMockStore([{ id: "1", text: "test trace memory", scope: "global", category: "fact", timestamp: Date.now(), vector: new Array(384).fill(0.1) }]);
+      const retriever = new MemoryRetriever(store, createMockEmbedder(), { ...DEFAULT_RETRIEVAL_CONFIG, mode: "hybrid", tagPrefixes: [] });
+      const { results, trace } = await retriever.retrieveWithTrace({ query: "trace", limit: 5, source: "auto-recall" });
+      assert.ok(Array.isArray(results));
+      assert.ok(trace);
+    });
+  });
+});


### PR DESCRIPTION
## PR #639 重建 — Phase 2 Lock Serialization + Rollback Protection

### 延續 Issue #632

此 PR 是 PR #639 的乾淨重建版本，解決升級 CLI 與 Plugin 之間的 lock contention 問題。

**原始 PR #639**：已 CLOSED（scope drift，複雜度過高）
**本 PR**：乾淨重建，只包含核心功能

---

### 核心問題

舊實作每個 entry 都單獨拿一次 lock（N locks per batch），導致 Plugin 要等很久（LLM 在 lock 內跑）。

**新實作（Two-Phase）**：
- **Phase 1**：LLM enrichment（無 lock，可並行）
- **Phase 2**：`bulkUpdateMetadataWithPatch()`（1 lock per batch）

---

### 實作內容

#### `src/store.ts`
| 功能 | 說明 |
|------|------|
| `bulkUpdateMetadataWithPatch()` | 1 lock per batch，re-read DB inside lock，merge fresh DB metadata + LLM patch + upgrade marker |
| `safeToNumber()` | BigInt/string 精度 guard，unsafe 轉換直接 throw |
| `tryParseNumber()` | graceful degrade to 0（用於外部 `_distance` 資料） |
| `ALLOWED_PATCH_KEYS` | whitelist：`tier`, `access_count`, `confidence` |

#### `src/memory-upgrader.ts`
| 功能 | 說明 |
|------|------|
| `prepareEntry()` | Phase 1：LLM enrichment，無 lock |
| `writeEnrichedBatch()` | Phase 2：直接呼叫 `bulkUpdateMetadataWithPatch()`，不再呼叫 `store.update()` |

**F2 fix**：`writeEnrichedBatch()` 直接呼叫 `bulkUpdateMetadataWithPatch()`，Phase 2 lock 只有 1 層。

**F7 fix**：`scopeFilter` 正確傳遞到 write phase。

---

### 測試檔案（CI 已註冊）

| 檔案 | 行數 | 說明 |
|------|------|------|
| `test/upgrader-phase2-lock.test.mjs` | 422 | Phase 2 lock 行為測試 |
| `test/upgrader-phase2-extreme.test.mjs` | 386 | 極端場景測試 |
| `test/bulk-recovery-rollback.test.mjs` | 172 | Rollback recovery 測試 |
| `test/upgrader-whitelist-regression.test.mjs` | 376 | Whitelist regression 測試 |

CI manifest 已更新（`scripts/ci-test-manifest.mjs`）。

---

### 維護者 Review 問題修復狀態

| 問題 | 狀態 |
|------|------|
| F2 — Nested lock acquisition | ✅ 已修復 |
| F4 — Second re-read 可抹掉 LLM 欄位 | ✅ 已修復（re-read in lock + merge） |
| F6 — cleanMarker 未通過 whitelist gate | ✅ 已修復 |
| MR2 — Phase 2a 構建完整 metadata string 會抹掉 Plugin 欄位 | ✅ 已修復 |
| MR3 — Option A re-read 在 batch delete 之後 | ✅ 已修復 |
| MR5 — O(n²) duplicate detection | ✅ 已修復 |

---

### 待確認

- EF1/EF3（jiti + Node 22.22.x 兼容性問題）— 非 PR code 造成，是環境問題

