### PR TITLE
drop late auto-recall results after timeout

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2698,6 +2698,8 @@ const memoryLanceDBProPlugin = {
         // (embedding → rerank → lifecycle), which can silently drop messages on
         // channels like Telegram when subsequent requests hit lock timeouts.
         // See: https://github.com/CortexReach/memory-lancedb-pro/issues/253
+        let autoRecallTimedOut = false;
+        let lateAutoRecallLogged = false;
         const recallWork = async (): Promise<{ prependContext: string } | undefined> => {
           // Determine agent ID and accessible scopes
           const agentId = resolveHookAgentId(ctx?.agentId, (event as any).sessionKey);
@@ -2706,6 +2708,16 @@ const memoryLanceDBProPlugin = {
             return undefined;
           }
           const accessibleScopes = resolveScopeFilter(scopeManager, agentId);
+          const shouldDropLateAutoRecall = (stage: string): boolean => {
+            if (!autoRecallTimedOut) return false;
+            if (!lateAutoRecallLogged) {
+              lateAutoRecallLogged = true;
+              api.logger.warn?.(
+                `memory-lancedb-pro: dropping late auto-recall result after timeout at ${stage} for agent ${agentId}`,
+              );
+            }
+            return true;
+          };
 
           // Use cached raw user message for the recall query to avoid channel
           // metadata noise (e.g. Slack's Conversation info JSON with message_id,
@@ -2746,6 +2758,8 @@ const memoryLanceDBProPlugin = {
             scopeFilter: accessibleScopes,
             source: "auto-recall",
           }), config.workspaceBoundary);
+
+          if (shouldDropLateAutoRecall("post-retrieve")) return;
 
           if (results.length === 0) {
             return;
@@ -2918,6 +2932,8 @@ const memoryLanceDBProPlugin = {
             return;
           }
 
+          if (shouldDropLateAutoRecall("pre-metadata")) return;
+
           if (minRepeated > 0) {
             const sessionHistory = recallHistory.get(sessionId) || new Map<string, number>();
             for (const item of selected) {
@@ -2944,6 +2960,8 @@ const memoryLanceDBProPlugin = {
               ),
             ),
           );
+
+          if (shouldDropLateAutoRecall("pre-context")) return;
 
           const memoryContext = selected.map((item) => item.line).join("\n");
 
@@ -2988,6 +3006,7 @@ const memoryLanceDBProPlugin = {
             recallWork().then((r) => { clearTimeout(timeoutId); return r; }),
             new Promise<undefined>((resolve) => {
               timeoutId = setTimeout(() => {
+                autoRecallTimedOut = true;
                 api.logger.warn(
                   `memory-lancedb-pro: auto-recall timed out after ${AUTO_RECALL_TIMEOUT_MS}ms; skipping memory injection to avoid stalling agent startup`,
                 );

--- a/index.ts
+++ b/index.ts
@@ -529,7 +529,7 @@ export function reportLayer1Failure(): void {
   }
 }
 
-function isLayer1CircuitOpen(): boolean {
+export function isLayer1CircuitOpen(): boolean {
   const now = Date.now();
   const cutoff = now - LAYER1_FAILURE_WINDOW_MS;
   const recentFailures = layer1FailureTimestamps.filter((t) => t >= cutoff);

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -18,6 +18,7 @@ export const CI_TEST_MANIFEST = [
   { group: "core-regression", runner: "node", file: "test/recall-text-cleanup.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/update-consistency-lancedb.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/strip-envelope-metadata.test.mjs", args: ["--test"] },
+  { group: "core-regression", runner: "node", file: "test/auto-recall-timeout.test.mjs", args: ["--test"] },
   { group: "cli-smoke", runner: "node", file: "test/import-markdown/import-markdown.test.mjs", args: ["--test"] },
   { group: "cli-smoke", runner: "node", file: "test/cli-smoke.mjs" },
   { group: "cli-smoke", runner: "node", file: "test/functional-e2e.mjs" },

--- a/test/auto-recall-timeout.test.mjs
+++ b/test/auto-recall-timeout.test.mjs
@@ -1,0 +1,227 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginSdkStubPath = path.resolve(testDir, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+
+const retrieverModuleForMock = jiti("../src/retriever.js");
+const embedderModuleForMock = jiti("../src/embedder.js");
+const storeModuleForMock = jiti("../src/store.js");
+const origCreateRetriever = retrieverModuleForMock.createRetriever;
+const origCreateEmbedder = embedderModuleForMock.createEmbedder;
+let activeCreateRetriever = origCreateRetriever;
+let activeCreateEmbedder = origCreateEmbedder;
+
+retrieverModuleForMock.createRetriever = (...args) => activeCreateRetriever(...args);
+embedderModuleForMock.createEmbedder = (...args) => activeCreateEmbedder(...args);
+
+const pluginModule = jiti("../index.ts");
+const memoryLanceDBProPlugin = pluginModule.default || pluginModule;
+const resetRegistration = pluginModule.resetRegistration ?? (() => {});
+const { MemoryStore } = storeModuleForMock;
+const origPatchMetadata = MemoryStore.prototype.patchMetadata;
+
+function createPluginApiHarness({ pluginConfig, resolveRoot, logs }) {
+  const eventHandlers = new Map();
+  const logSink = logs ?? { info: [], warn: [], debug: [] };
+
+  const api = {
+    pluginConfig,
+    resolvePath(target) {
+      if (typeof target !== "string") return target;
+      if (path.isAbsolute(target)) return target;
+      return path.join(resolveRoot, target);
+    },
+    logger: {
+      info(message) {
+        logSink.info.push(String(message));
+      },
+      warn(message) {
+        logSink.warn.push(String(message));
+      },
+      debug(message) {
+        logSink.debug.push(String(message));
+      },
+    },
+    registerTool() {},
+    registerCli() {},
+    registerService() {},
+    on(eventName, handler, meta) {
+      const list = eventHandlers.get(eventName) || [];
+      list.push({ handler, meta });
+      eventHandlers.set(eventName, list);
+    },
+    registerHook(eventName, handler, opts) {
+      const list = eventHandlers.get(eventName) || [];
+      list.push({ handler, meta: opts });
+      eventHandlers.set(eventName, list);
+    },
+  };
+
+  return { api, eventHandlers };
+}
+
+function getAutoRecallHook(eventHandlers) {
+  const hooks = eventHandlers.get("before_prompt_build") || [];
+  const autoRecallHook = hooks.find(({ meta }) => meta?.priority === 10)?.handler;
+  assert.equal(typeof autoRecallHook, "function", "expected an auto-recall before_prompt_build hook");
+  return autoRecallHook;
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeConfirmedMetadata() {
+  return JSON.stringify({
+    state: "confirmed",
+    memory_layer: "active",
+    injected_count: 0,
+    bad_recall_count: 0,
+    suppressed_until_turn: 0,
+  });
+}
+
+function makeResults() {
+  return [
+    {
+      entry: {
+        id: "m1",
+        text: "remember this",
+        category: "fact",
+        scope: "global",
+        importance: 0.7,
+        timestamp: Date.now(),
+        metadata: makeConfirmedMetadata(),
+      },
+      score: 0.82,
+      sources: {
+        vector: { score: 0.82, rank: 1 },
+        bm25: { score: 0.88, rank: 2 },
+      },
+    },
+    {
+      entry: {
+        id: "m2",
+        text: "prefer concise diffs",
+        category: "preference",
+        scope: "global",
+        importance: 0.8,
+        timestamp: Date.now(),
+        metadata: makeConfirmedMetadata(),
+      },
+      score: 0.77,
+      sources: {
+        vector: { score: 0.77, rank: 2 },
+        bm25: { score: 0.71, rank: 3 },
+      },
+    },
+  ];
+}
+
+describe("auto-recall timeout", () => {
+  let workspaceDir;
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(path.join(tmpdir(), "auto-recall-timeout-"));
+    activeCreateRetriever = origCreateRetriever;
+    activeCreateEmbedder = origCreateEmbedder;
+    MemoryStore.prototype.patchMetadata = origPatchMetadata;
+    resetRegistration();
+  });
+
+  afterEach(() => {
+    activeCreateRetriever = origCreateRetriever;
+    activeCreateEmbedder = origCreateEmbedder;
+    retrieverModuleForMock.createRetriever = origCreateRetriever;
+    embedderModuleForMock.createEmbedder = origCreateEmbedder;
+    MemoryStore.prototype.patchMetadata = origPatchMetadata;
+    resetRegistration();
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("drops late auto-recall results after the timeout", async () => {
+    const logs = { info: [], warn: [], debug: [] };
+    let patchMetadataCalls = 0;
+
+    activeCreateRetriever = function mockCreateRetriever() {
+      return {
+        async retrieve() {
+          await delay(25);
+          return makeResults();
+        },
+        getConfig() {
+          return { mode: "hybrid" };
+        },
+        setAccessTracker() {},
+        setStatsCollector() {},
+      };
+    };
+    activeCreateEmbedder = function mockCreateEmbedder() {
+      return {
+        async embedQuery() {
+          return new Float32Array(384).fill(0);
+        },
+        async embedPassage() {
+          return new Float32Array(384).fill(0);
+        },
+      };
+    };
+
+    MemoryStore.prototype.patchMetadata = async () => {
+      patchMetadataCalls++;
+    };
+
+    const harness = createPluginApiHarness({
+      resolveRoot: workspaceDir,
+      logs,
+      pluginConfig: {
+        dbPath: path.join(workspaceDir, "db"),
+        embedding: { apiKey: "test-api-key" },
+        smartExtraction: false,
+        autoCapture: false,
+        autoRecall: true,
+        autoRecallMinLength: 1,
+        autoRecallTimeoutMs: 1,
+        selfImprovement: { enabled: false, beforeResetNote: false, ensureLearningFiles: false },
+      },
+    });
+
+    memoryLanceDBProPlugin.register(harness.api);
+
+    const autoRecallHook = getAutoRecallHook(harness.eventHandlers);
+    const output = await autoRecallHook(
+      { prompt: "Please recall what I mentioned before about this task." },
+      { sessionId: "auto-timeout", sessionKey: "agent:main:session:auto-timeout", agentId: "main" },
+    );
+
+    assert.equal(output, undefined);
+    await delay(75);
+
+    assert.equal(patchMetadataCalls, 0, "late recall should not update injection metadata");
+    assert.ok(
+      logs.warn.some((line) => line.includes("auto-recall timed out after 1ms")),
+      "expected timeout warning",
+    );
+    assert.ok(
+      logs.warn.some((line) => line.includes("dropping late auto-recall result after timeout")),
+      "expected late-result drop warning",
+    );
+    assert.equal(
+      logs.info.some((line) => /injecting \d+ memories into context/.test(line)),
+      false,
+      "late recall should not log a context injection",
+    );
+  });
+});

--- a/test/issue606_sdk-migration.test.mjs
+++ b/test/issue606_sdk-migration.test.mjs
@@ -14,9 +14,18 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
+import jitiFactory from "jiti";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH = resolve(__dirname, "..", "index.ts");
+const pluginSdkStubPath = resolve(__dirname, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+const loadIndexModule = () => jiti("../index.ts");
 
 // ---------------------------------------------------------------------------
 // Static analysis smoke tests — verify migration code is present
@@ -273,13 +282,13 @@ describe("loadEmbeddedPiRunner — F1/F2 behavioral integration", () => {
     // We can't easily reset module-level state, so we test the circuit breaker
     // function directly. The actual integration (Layer 1 blocked after N failures)
     // requires a fresh module instance per test which Node test runner doesn't give us.
-    const { isLayer1CircuitOpen } = await import("../index.ts");
+    const { isLayer1CircuitOpen } = loadIndexModule();
     // isLayer1CircuitOpen is internal; if it exists and returns boolean, the mechanism is wired
     assert.strictEqual(typeof isLayer1CircuitOpen, "function", "isLayer1CircuitOpen should be exported for testability");
   });
 
   it("F1: reportLayer1Failure is exported and callable", async () => {
-    const { reportLayer1Failure } = await import("../index.ts");
+    const { reportLayer1Failure } = loadIndexModule();
     assert.strictEqual(typeof reportLayer1Failure, "function", "reportLayer1Failure must be exported");
     // Calling it should not throw
     assert.doesNotThrow(() => reportLayer1Failure(), "reportLayer1Failure() must not throw");


### PR DESCRIPTION
## Summary
- split the auto-recall timeout behavior out of #764 as requested in maintainer triage
- mark auto-recall work as timed out when the startup guard wins the race
- drop late retrieval results before metadata updates, context logging/injection, or pending recall bookkeeping can run
- add a focused regression test for slow auto-recall results arriving after timeout

## Tests
- `node --test test/auto-recall-timeout.test.mjs`
- `node --test test/per-agent-auto-recall.test.mjs`
- `node --test test/auto-recall-query-length.test.mjs`
- `git diff upstream/master --check`

Also checked: `node --test test/recall-text-cleanup.test.mjs` still has existing order-dependent retriever mock failures unrelated to this branch; the specific affected case passes in isolation with `node --test --test-name-pattern "auto-recall only injects confirmed" test/recall-text-cleanup.test.mjs`.