### PR TITLE
record rerank fallback diagnostics

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -529,7 +529,7 @@ export function reportLayer1Failure(): void {
   }
 }
 
-function isLayer1CircuitOpen(): boolean {
+export function isLayer1CircuitOpen(): boolean {
   const now = Date.now();
   const cutoff = now - LAYER1_FAILURE_WINDOW_MS;
   const recentFailures = layer1FailureTimestamps.filter((t) => t >= cutoff);

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -169,6 +169,16 @@ export interface RetrievalDiagnostics {
     | "hybrid.fuseResults"
     | "hybrid.rerank"
     | "hybrid.postProcess";
+  rerankFallback?: {
+    provider: NonNullable<RetrievalConfig["rerankProvider"]>;
+    reason:
+      | "invalid_response"
+      | "http_error"
+      | "timeout"
+      | "request_error"
+      | "cosine_error";
+    message: string;
+  };
   errorMessage?: string;
 }
 
@@ -237,6 +247,10 @@ function extractFailureStage(
   return error instanceof Error
     ? (error as TaggedRetrievalError).retrievalFailureStage
     : undefined;
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
 }
 
 function buildDropSummary(
@@ -1019,7 +1033,7 @@ export class MemoryRetriever {
       failureStage = "hybrid.rerank";
       if (this.config.rerank !== "none") {
         trace?.startStage("rerank", filtered.map((r) => r.entry.id));
-        reranked = await this.rerankResults(query, queryVector, rerankInput);
+        reranked = await this.rerankResults(query, queryVector, rerankInput, diagnostics);
         trace?.endStage(reranked.map((r) => r.entry.id), reranked.map((r) => r.score));
       } else {
         reranked = filtered;
@@ -1229,6 +1243,7 @@ export class MemoryRetriever {
     query: string,
     queryVector: number[],
     results: RetrievalResult[],
+    diagnostics?: RetrievalDiagnostics,
   ): Promise<RetrievalResult[]> {
     if (results.length === 0) {
       return results;
@@ -1237,6 +1252,14 @@ export class MemoryRetriever {
     // Try cross-encoder rerank via configured provider API
     const provider = this.config.rerankProvider || "jina";
     const hasApiKey = !!this.config.rerankApiKey;
+    const recordFallback = (
+      reason: NonNullable<RetrievalDiagnostics["rerankFallback"]>["reason"],
+      message: string,
+    ) => {
+      if (diagnostics) {
+        diagnostics.rerankFallback = { provider, reason, message };
+      }
+    };
 
     if (this.config.rerank === "cross-encoder" && hasApiKey) {
       try {
@@ -1278,6 +1301,7 @@ export class MemoryRetriever {
           const parsed = parseRerankResponse(provider, data);
 
           if (!parsed) {
+            recordFallback("invalid_response", "Rerank API returned an invalid response shape");
             console.warn(
               "Rerank API: invalid response shape, falling back to cosine",
             );
@@ -1322,14 +1346,21 @@ export class MemoryRetriever {
           }
         } else {
           const errText = await response.text().catch(() => "");
+          recordFallback(
+            "http_error",
+            `Rerank API returned ${response.status}: ${errText.slice(0, 200)}`,
+          );
           console.warn(
             `Rerank API returned ${response.status}: ${errText.slice(0, 200)}, falling back to cosine`,
           );
         }
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {
-          console.warn(`Rerank API timed out (${this.config.rerankTimeoutMs ?? 5000}ms), falling back to cosine`);
+          const message = `Rerank API timed out (${this.config.rerankTimeoutMs ?? 5000}ms)`;
+          recordFallback("timeout", message);
+          console.warn(`${message}, falling back to cosine`);
         } else {
+          recordFallback("request_error", formatErrorMessage(error));
           console.warn("Rerank API failed, falling back to cosine:", error);
         }
       }
@@ -1353,6 +1384,7 @@ export class MemoryRetriever {
 
       return reranked.sort((a, b) => b.score - a.score);
     } catch (error) {
+      recordFallback("cosine_error", formatErrorMessage(error));
       console.warn("Reranking failed, returning original results:", error);
       return results;
     }
@@ -1661,6 +1693,9 @@ export class MemoryRetriever {
       dropSummary: this.lastDiagnostics.dropSummary.map((drop) => ({
         ...drop,
       })),
+      rerankFallback: this.lastDiagnostics.rerankFallback
+        ? { ...this.lastDiagnostics.rerankFallback }
+        : undefined,
     };
   }
 

--- a/test/issue606_sdk-migration.test.mjs
+++ b/test/issue606_sdk-migration.test.mjs
@@ -14,9 +14,18 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
+import jitiFactory from "jiti";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INDEX_PATH = resolve(__dirname, "..", "index.ts");
+const pluginSdkStubPath = resolve(__dirname, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+const loadIndexModule = () => jiti("../index.ts");
 
 // ---------------------------------------------------------------------------
 // Static analysis smoke tests — verify migration code is present
@@ -273,13 +282,13 @@ describe("loadEmbeddedPiRunner — F1/F2 behavioral integration", () => {
     // We can't easily reset module-level state, so we test the circuit breaker
     // function directly. The actual integration (Layer 1 blocked after N failures)
     // requires a fresh module instance per test which Node test runner doesn't give us.
-    const { isLayer1CircuitOpen } = await import("../index.ts");
+    const { isLayer1CircuitOpen } = loadIndexModule();
     // isLayer1CircuitOpen is internal; if it exists and returns boolean, the mechanism is wired
     assert.strictEqual(typeof isLayer1CircuitOpen, "function", "isLayer1CircuitOpen should be exported for testability");
   });
 
   it("F1: reportLayer1Failure is exported and callable", async () => {
-    const { reportLayer1Failure } = await import("../index.ts");
+    const { reportLayer1Failure } = loadIndexModule();
     assert.strictEqual(typeof reportLayer1Failure, "function", "reportLayer1Failure must be exported");
     // Calling it should not throw
     assert.doesNotThrow(() => reportLayer1Failure(), "reportLayer1Failure() must not throw");

--- a/test/retriever-rerank-regression.mjs
+++ b/test/retriever-rerank-regression.mjs
@@ -59,7 +59,11 @@ async function runScenario(name, responsePayload) {
   });
 
   try {
-    const retriever = createRetriever(fakeStore, fakeEmbedder, retrieverConfig);
+    const retriever = createRetriever(fakeStore, fakeEmbedder, {
+      ...retrieverConfig,
+      minScore: 0,
+      hardMinScore: 0,
+    });
     const results = await retriever.retrieve({
       query: "TESTMEM-20260306-092541",
       limit: 5,
@@ -127,6 +131,43 @@ async function runTeiScenario() {
 await runTeiScenario();
 
 console.log("OK: rerank regression test passed");
+
+async function runRerankFallbackDiagnosticsScenario() {
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  globalThis.fetch = async () => {
+    throw new Error("reranker offline");
+  };
+  console.warn = () => {};
+
+  try {
+    const retriever = createRetriever(fakeStore, fakeEmbedder, retrieverConfig);
+    const results = await retriever.retrieve({
+      query: "TESTMEM-20260306-092541",
+      limit: 5,
+      scopeFilter: ["global"],
+    });
+
+    assert.ok(Array.isArray(results), "rerank fallback should resolve with a result array");
+
+    const diagnostics = retriever.getLastDiagnostics();
+    assert.equal(diagnostics?.failureStage, undefined, "rerank fallback should not mark the whole retrieval failed");
+    assert.equal(diagnostics?.rerankFallback?.provider, "jina");
+    assert.equal(diagnostics?.rerankFallback?.reason, "request_error");
+    assert.match(
+      diagnostics?.rerankFallback?.message || "",
+      /reranker offline/,
+      "diagnostics should include the rerank failure reason",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
+  }
+}
+
+await runRerankFallbackDiagnosticsScenario();
+
+console.log("OK: rerank fallback diagnostics test passed");
 
 const lexicalEntry = {
   id: "lexical-regression-1",


### PR DESCRIPTION
## Summary
- addresses the outstanding rerank diagnostics item from #574
- records cross-encoder rerank fallback details in `getLastDiagnostics()` when the API response is invalid, returns an error status, times out, or throws
- preserves the existing cosine fallback behavior while exposing provider, reason, and message for debugging retrieval quality
- adds regression coverage for rerank request failure diagnostics

## Tests
- `node test/retriever-rerank-regression.mjs`
- `node --test test/retriever-graceful-degradation.test.mjs`
- `git diff --check`