### PR TITLE
fix Windows LanceDB file URL paths

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -20,7 +20,7 @@ import { spawn } from "node:child_process";
 const isCliMode = () => process.env.OPENCLAW_CLI === "1";
 
 // Import core components
-import { MemoryStore, validateStoragePath } from "./src/store.js";
+import { MemoryStore, normalizeStoragePath, validateStoragePath } from "./src/store.js";
 import {
   createEmbedder,
   getEffectiveVectorDimensions,
@@ -1978,10 +1978,10 @@ let _singletonState: PluginSingletonState | null = null;
 
 function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
   const config = parsePluginConfig(api.pluginConfig);
-  const resolvedDbPath = api.resolvePath(config.dbPath || getDefaultDbPath());
+  let resolvedDbPath = normalizeStoragePath(api.resolvePath(config.dbPath || getDefaultDbPath()));
 
   try {
-    validateStoragePath(resolvedDbPath);
+    resolvedDbPath = validateStoragePath(resolvedDbPath);
   } catch (err) {
     api.logger.warn(
       `memory-lancedb-pro: storage path issue — ${String(err)}\n` +

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -15,6 +15,7 @@ export const CI_TEST_MANIFEST = [
   { group: "storage-and-schema", runner: "node", file: "test/reflection-bypass-hook.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/smart-extractor-scope-filter.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/store-empty-scope-filter.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/storage-path-normalization.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/recall-text-cleanup.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/update-consistency-lancedb.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/strip-envelope-metadata.test.mjs", args: ["--test"] },

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,6 +16,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
 
 // ============================================================================
@@ -134,13 +135,45 @@ function scoreLexicalHit(query: string, candidates: Array<{ text: string; weight
 // Storage Path Validation
 // ============================================================================
 
+function fileUrlToWindowsPath(url: URL): string {
+  const host = url.hostname && url.hostname !== "localhost" ? url.hostname : "";
+  const pathname = decodeURIComponent(url.pathname);
+
+  if (host) {
+    return `\\\\${host}${pathname.replace(/\//g, "\\")}`;
+  }
+
+  const withoutDriveSlash = /^\/[a-zA-Z]:/.test(pathname)
+    ? pathname.slice(1)
+    : pathname;
+  return withoutDriveSlash.replace(/\//g, "\\");
+}
+
+export function normalizeStoragePath(
+  dbPath: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const trimmed = dbPath.trim();
+  if (!trimmed.startsWith("file://")) return dbPath;
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "file:") return dbPath;
+    return platform === "win32"
+      ? fileUrlToWindowsPath(url)
+      : fileURLToPath(url);
+  } catch {
+    return dbPath;
+  }
+}
+
 /**
  * Validate and prepare the storage directory before LanceDB connection.
  * Resolves symlinks, creates missing directories, and checks write permissions.
  * Returns the resolved absolute path on success, or throws a descriptive error.
  */
 export function validateStoragePath(dbPath: string): string {
-  let resolvedPath = dbPath;
+  let resolvedPath = normalizeStoragePath(dbPath);
 
   // Resolve symlinks (including dangling symlinks)
   try {
@@ -239,7 +272,14 @@ export class MemoryStore {
   // 當 pending callers 超過此值時，block 並同步 flush，確保 pendingBatch 不會無限膨胀。
   private static readonly MAX_PENDING_BATCH_SIZE = 1000;
 
-  constructor(private readonly config: StoreConfig) { }
+  private readonly config: StoreConfig;
+
+  constructor(config: StoreConfig) {
+    this.config = {
+      ...config,
+      dbPath: normalizeStoragePath(config.dbPath),
+    };
+  }
 
   private async runWithFileLock<T>(fn: () => Promise<T>): Promise<T> {
     const lockfile = await loadLockfile();

--- a/test/storage-path-normalization.test.mjs
+++ b/test/storage-path-normalization.test.mjs
@@ -1,0 +1,52 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const { MemoryStore, normalizeStoragePath, validateStoragePath } = jiti("../src/store.ts");
+
+describe("storage path normalization", () => {
+  it("converts Windows drive-letter file URLs to native paths", () => {
+    assert.equal(
+      normalizeStoragePath("file:///C:/openclaw-memory", "win32"),
+      "C:\\openclaw-memory",
+    );
+  });
+
+  it("converts Windows UNC file URLs to native UNC paths", () => {
+    assert.equal(
+      normalizeStoragePath("file://server/share/openclaw-memory", "win32"),
+      "\\\\server\\share\\openclaw-memory",
+    );
+  });
+
+  it("keeps native Windows paths unchanged", () => {
+    assert.equal(
+      normalizeStoragePath("C:/openclaw-memory", "win32"),
+      "C:/openclaw-memory",
+    );
+  });
+
+  it("normalizes constructor dbPath before LanceDB and lock use", () => {
+    const input = "file:///tmp/openclaw-memory";
+    const store = new MemoryStore({
+      dbPath: input,
+      vectorDim: 3,
+    });
+
+    assert.equal(store.dbPath, normalizeStoragePath(input));
+  });
+
+  it("validates local file URLs using native filesystem paths", () => {
+    const dir = mkdtempSync(join(tmpdir(), "memory-lancedb-pro-file-url-"));
+    try {
+      assert.equal(validateStoragePath(pathToFileURL(dir).href), dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- normalize `file://` storage paths before validation, locking, and LanceDB connect
- convert Windows drive-letter and UNC file URLs back to native Windows paths
- add storage path normalization coverage to the storage-and-schema CI group

Closes #800.

## Validation
- `/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test test/storage-path-normalization.test.mjs`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH /Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/run-ci-tests.mjs --group storage-and-schema`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH /Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/verify-ci-test-manifest.mjs`

Note: local Homebrew Node is currently missing `libsimdjson.31.dylib`, so validation used the bundled Codex Node runtime.

If this PR is squashed or reworked, please preserve author attribution or include: Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>