### PR TITLE
disable reasoning traces for JSON LLM calls

### DIFF
--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -39,6 +39,8 @@ export interface LlmClient {
  * or contain surrounding text.
  */
 function extractJsonFromResponse(text: string): string | null {
+  text = stripReasoningTrace(text);
+
   const fenceMatch = text.match(/```(?:json)?\s*\n?([\s\S]*?)```/);
   if (fenceMatch) {
     return fenceMatch[1].trim();
@@ -62,6 +64,16 @@ function extractJsonFromResponse(text: string): string | null {
 
   if (lastBrace === -1) return null;
   return text.substring(firstBrace, lastBrace + 1);
+}
+
+function stripReasoningTrace(text: string): string {
+  const closingThinkTag = text.toLowerCase().lastIndexOf("</think>");
+  if (closingThinkTag === -1) return text;
+  return text.slice(closingThinkTag + "</think>".length).trim();
+}
+
+function shouldDisableReasoningForJson(model: string): boolean {
+  return /qwen3|deepseek.*r1|qwq/i.test(model);
 }
 
 function previewText(value: string, maxLen = 200): string {
@@ -190,7 +202,7 @@ function createApiKeyClient(config: LlmClientConfig, log: (msg: string) => void,
     async completeJson<T>(prompt: string, label = "generic"): Promise<T | null> {
       lastError = null;
       try {
-        const response = await client.chat.completions.create({
+        const request = {
           model: config.model,
           messages: [
             {
@@ -201,7 +213,12 @@ function createApiKeyClient(config: LlmClientConfig, log: (msg: string) => void,
             { role: "user", content: prompt },
           ],
           temperature: 0.1,
-        });
+          ...(shouldDisableReasoningForJson(config.model)
+            ? { chat_template_kwargs: { enable_thinking: false } }
+            : {}),
+        };
+
+        const response = await client.chat.completions.create(request as any);
 
         const raw = response.choices?.[0]?.message?.content;
         if (!raw) {
@@ -421,4 +438,4 @@ export function createLlmClient(config: LlmClientConfig): LlmClient {
   return createApiKeyClient(config, log, warnLog);
 }
 
-export { extractJsonFromResponse, repairCommonJson };
+export { extractJsonFromResponse, repairCommonJson, shouldDisableReasoningForJson, stripReasoningTrace };

--- a/test/llm-api-key-client.test.mjs
+++ b/test/llm-api-key-client.test.mjs
@@ -4,7 +4,7 @@ import { afterEach, describe, it } from "node:test";
 import jitiFactory from "jiti";
 
 const jiti = jitiFactory(import.meta.url, { interopDefault: true });
-const { createLlmClient } = jiti("../src/llm-client.ts");
+const { createLlmClient, shouldDisableReasoningForJson, stripReasoningTrace } = jiti("../src/llm-client.ts");
 
 describe("LLM api-key client", () => {
   let server;
@@ -64,5 +64,48 @@ describe("LLM api-key client", () => {
       },
     ]);
     assert.equal(requestBody.temperature, 0.1);
+    assert.equal(requestBody.chat_template_kwargs, undefined);
+  });
+
+  it("disables thinking for reasoning models and strips reasoning traces before JSON parse", async () => {
+    let requestBody;
+
+    server = http.createServer(async (req, res) => {
+      let body = "";
+      for await (const chunk of req) body += chunk;
+      requestBody = JSON.parse(body);
+
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        choices: [
+          {
+            message: {
+              content: "<think>plan first</think>{\"memories\":[{\"text\":\"clean json\"}]}",
+            },
+          },
+        ],
+      }));
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = server.address().port;
+
+    const llm = createLlmClient({
+      auth: "api-key",
+      apiKey: "test-api-key",
+      model: "Qwen3.5-27B-FP8",
+      baseURL: `http://127.0.0.1:${port}/v1`,
+    });
+
+    const result = await llm.completeJson("extract", "reasoning-probe");
+    assert.deepEqual(result, { memories: [{ text: "clean json" }] });
+    assert.deepEqual(requestBody.chat_template_kwargs, { enable_thinking: false });
+  });
+
+  it("detects known reasoning model names", () => {
+    assert.equal(shouldDisableReasoningForJson("qwen3.5-27b-fp8"), true);
+    assert.equal(shouldDisableReasoningForJson("DeepSeek-R1-Distill-Qwen-32B"), true);
+    assert.equal(shouldDisableReasoningForJson("QwQ-32B"), true);
+    assert.equal(shouldDisableReasoningForJson("gpt-4o-mini"), false);
+    assert.equal(stripReasoningTrace("<think>{\"bad\":true}</think>{\"ok\":true}"), "{\"ok\":true}");
   });
 });


### PR DESCRIPTION
## Summary
- disable vLLM thinking mode for Qwen3, DeepSeek-R1, and QwQ JSON calls in API-key mode
- strip completed </think> reasoning traces before extracting JSON as a fallback
- extend API-key client coverage for non-reasoning and reasoning model request bodies

Refs #573

## Tests
- PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/andy/.codex/tmp/arg0/codex-arg0AI2Yx5:/Users/andy/.antigravity/antigravity/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/Users/andy/.cargo/bin:/Users/andy/.cache/lm-studio/bin:/Applications/Codex.app/Contents/Resources /Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test test/llm-api-key-client.test.mjs
- PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/andy/.codex/tmp/arg0/codex-arg0AI2Yx5:/Users/andy/.antigravity/antigravity/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/Users/andy/.cargo/bin:/Users/andy/.cache/lm-studio/bin:/Applications/Codex.app/Contents/Resources /Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/run-ci-tests.mjs --group llm-clients-and-auth
- PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/andy/.codex/tmp/arg0/codex-arg0AI2Yx5:/Users/andy/.antigravity/antigravity/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/Users/andy/.cargo/bin:/Users/andy/.cache/lm-studio/bin:/Applications/Codex.app/Contents/Resources /Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/verify-ci-test-manifest.mjs

If this PR is squashed or reworked, please preserve author attribution or include:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>