### PR TITLE
fix: unblock auto-recall metadata patching

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2328,9 +2328,6 @@ const memoryLanceDBProPlugin = {
                         suppressionDurationMs: config.autoRecallSuppressionDurationMs ?? TIER1_DEFAULT_SUPPRESSION_DURATION_MS,
                         minRepeated,
                     };
-                    await Promise.allSettled(selected.map(async (item) => store.patchMetadata(item.id, computeTier1Patch(item.meta, tier1PatchOpts), accessibleScopes)));
-                    if (shouldDropLateAutoRecall("pre-context"))
-                        return;
                     const memoryContext = selected.map((item) => item.line).join("\n");
                     const injectedIds = selected.map((item) => item.id).join(",") || "(none)";
                     api.logger.debug?.(`memory-lancedb-pro: auto-recall stats hits=${results.length}, dedupFiltered=${dedupFilteredCount}, stateFiltered=${stateFilteredCount}, suppressedFiltered=${suppressedFilteredCount}, preBudgetItems=${preBudgetItems}, preBudgetChars=${preBudgetChars}, postBudgetItems=${selected.length}, postBudgetChars=${usedChars}, maxItems=${autoRecallMaxItems}, maxChars=${autoRecallMaxChars}, perItemMaxChars=${autoRecallPerItemMaxChars}, injectedIds=${injectedIds}`);
@@ -2345,6 +2342,14 @@ const memoryLanceDBProPlugin = {
                         recallIds: selected.map((item) => item.id),
                         responseText: "", // Will be populated by agent_end
                         injectedAt: Date.now(),
+                    });
+                    void Promise.allSettled(selected.map(async (item) => store.patchMetadata(item.id, computeTier1Patch(item.meta, tier1PatchOpts), accessibleScopes))).then((settled) => {
+                        const rejected = settled.filter((result) => result.status === "rejected");
+                        if (rejected.length > 0) {
+                            api.logger.warn?.(`memory-lancedb-pro: background auto-recall metadata patch failed for ${rejected.length}/${settled.length} memories`);
+                        }
+                    }).catch((err) => {
+                        api.logger.warn?.(`memory-lancedb-pro: background auto-recall metadata patch crashed: ${String(err)}`);
                     });
                     return {
                         prependContext: `<relevant-memories>\n` +

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -3,7 +3,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
-import { existsSync, accessSync, constants, mkdirSync, realpathSync, lstatSync, statSync, unlinkSync, } from "node:fs";
+import { existsSync, accessSync, constants, mkdirSync, realpathSync, lstatSync, statSync, unlinkSync, rmdirSync, } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
@@ -201,6 +201,7 @@ export class MemoryStore {
     async runWithFileLock(fn) {
         const lockfile = await loadLockfile();
         const lockPath = join(this.config.dbPath, ".memory-write.lock");
+        const lockArtifactPath = `${lockPath}.lock`;
         const ensureLockTargetExists = async () => {
             if (!existsSync(lockPath)) {
                 try {
@@ -222,20 +223,25 @@ export class MemoryStore {
         let compromisedErr = null;
         let fnSucceeded = false;
         let fnError = null;
-        // Proactive cleanup of stale lock artifacts（from PR #626）
-        // 根本避免 >5 分鐘的 lock artifact 導致 ECOMPROMISED
-        if (existsSync(lockPath)) {
+        // Proactive cleanup of stale proper-lockfile artifacts（from PR #626）.
+        // proper-lockfile locks the target by creating `${target}.lock`; the
+        // target file itself is expected to persist and must not be treated stale.
+        if (existsSync(lockArtifactPath)) {
             try {
-                const stat = statSync(lockPath);
+                const stat = statSync(lockArtifactPath);
                 const ageMs = Date.now() - stat.mtimeMs;
                 const staleThresholdMs = 5 * 60 * 1000;
                 if (ageMs > staleThresholdMs) {
                     try {
-                        unlinkSync(lockPath);
+                        if (stat.isDirectory()) {
+                            rmdirSync(lockArtifactPath);
+                        }
+                        else {
+                            unlinkSync(lockArtifactPath);
+                        }
+                        console.warn(`[memory-lancedb-pro] cleared stale lock artifact: ${lockArtifactPath} ageMs=${ageMs}`);
                     }
                     catch { }
-                    console.warn(`[memory-lancedb-pro] cleared stale lock: ${lockPath} ageMs=${ageMs}`);
-                    await ensureLockTargetExists();
                 }
             }
             catch { }

--- a/index.ts
+++ b/index.ts
@@ -3008,17 +3008,6 @@ const memoryLanceDBProPlugin = {
               config.autoRecallSuppressionDurationMs ?? TIER1_DEFAULT_SUPPRESSION_DURATION_MS,
             minRepeated,
           };
-          await Promise.allSettled(
-            selected.map(async (item) =>
-              store.patchMetadata(
-                item.id,
-                computeTier1Patch(item.meta, tier1PatchOpts),
-                accessibleScopes,
-              ),
-            ),
-          );
-
-          if (shouldDropLateAutoRecall("pre-context")) return;
 
           const memoryContext = selected.map((item) => item.line).join("\n");
 
@@ -3042,6 +3031,28 @@ const memoryLanceDBProPlugin = {
             responseText: "", // Will be populated by agent_end
             injectedAt: Date.now(),
           });
+
+          void Promise.allSettled(
+            selected.map(async (item) =>
+              store.patchMetadata(
+                item.id,
+                computeTier1Patch(item.meta, tier1PatchOpts),
+                accessibleScopes,
+              ),
+            ),
+          ).then((settled) => {
+            const rejected = settled.filter((result) => result.status === "rejected");
+            if (rejected.length > 0) {
+              api.logger.warn?.(
+                `memory-lancedb-pro: background auto-recall metadata patch failed for ${rejected.length}/${settled.length} memories`,
+              );
+            }
+          }).catch((err) => {
+            api.logger.warn?.(
+              `memory-lancedb-pro: background auto-recall metadata patch crashed: ${String(err)}`,
+            );
+          });
+
           return {
             prependContext:
               `<relevant-memories>\n` +

--- a/src/store.ts
+++ b/src/store.ts
@@ -14,6 +14,7 @@ import {
   lstatSync,
   statSync,
   unlinkSync,
+  rmdirSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -286,6 +287,7 @@ export class MemoryStore {
   private async runWithFileLock<T>(fn: () => Promise<T>): Promise<T> {
     const lockfile = await loadLockfile();
     const lockPath = join(this.config.dbPath, ".memory-write.lock");
+    const lockArtifactPath = `${lockPath}.lock`;
     const ensureLockTargetExists = async () => {
       if (!existsSync(lockPath)) {
         try { mkdirSync(dirname(lockPath), { recursive: true }); } catch {}
@@ -301,17 +303,23 @@ export class MemoryStore {
     let fnSucceeded = false;
     let fnError: unknown = null;
 
-    // Proactive cleanup of stale lock artifacts（from PR #626）
-    // 根本避免 >5 分鐘的 lock artifact 導致 ECOMPROMISED
-    if (existsSync(lockPath)) {
+    // Proactive cleanup of stale proper-lockfile artifacts（from PR #626）.
+    // proper-lockfile locks the target by creating `${target}.lock`; the
+    // target file itself is expected to persist and must not be treated stale.
+    if (existsSync(lockArtifactPath)) {
       try {
-        const stat = statSync(lockPath);
+        const stat = statSync(lockArtifactPath);
         const ageMs = Date.now() - stat.mtimeMs;
         const staleThresholdMs = 5 * 60 * 1000;
         if (ageMs > staleThresholdMs) {
-          try { unlinkSync(lockPath); } catch {}
-          console.warn(`[memory-lancedb-pro] cleared stale lock: ${lockPath} ageMs=${ageMs}`);
-          await ensureLockTargetExists();
+          try {
+            if (stat.isDirectory()) {
+              rmdirSync(lockArtifactPath);
+            } else {
+              unlinkSync(lockArtifactPath);
+            }
+            console.warn(`[memory-lancedb-pro] cleared stale lock artifact: ${lockArtifactPath} ageMs=${ageMs}`);
+          } catch {}
         }
       } catch {}
     }

--- a/test/auto-recall-timeout.test.mjs
+++ b/test/auto-recall-timeout.test.mjs
@@ -137,6 +137,8 @@ describe("auto-recall timeout", () => {
     workspaceDir = mkdtempSync(path.join(tmpdir(), "auto-recall-timeout-"));
     activeCreateRetriever = origCreateRetriever;
     activeCreateEmbedder = origCreateEmbedder;
+    retrieverModuleForMock.createRetriever = (...args) => activeCreateRetriever(...args);
+    embedderModuleForMock.createEmbedder = (...args) => activeCreateEmbedder(...args);
     MemoryStore.prototype.patchMetadata = origPatchMetadata;
     resetRegistration();
   });
@@ -223,5 +225,86 @@ describe("auto-recall timeout", () => {
       false,
       "late recall should not log a context injection",
     );
+  });
+
+  it("returns context before auto-recall metadata patch settles", async () => {
+    const logs = { info: [], warn: [], debug: [] };
+    const patchResolvers = [];
+    let patchMetadataCalls = 0;
+    let patchMetadataSettled = 0;
+
+    activeCreateRetriever = function mockCreateRetriever() {
+      return {
+        async retrieve() {
+          return makeResults();
+        },
+        getConfig() {
+          return { mode: "hybrid" };
+        },
+        setAccessTracker() {},
+        setStatsCollector() {},
+      };
+    };
+    activeCreateEmbedder = function mockCreateEmbedder() {
+      return {
+        async embedQuery() {
+          return new Float32Array(384).fill(0);
+        },
+        async embedPassage() {
+          return new Float32Array(384).fill(0);
+        },
+      };
+    };
+
+    MemoryStore.prototype.patchMetadata = async () => {
+      patchMetadataCalls++;
+      await new Promise((resolve) => patchResolvers.push(resolve));
+      patchMetadataSettled++;
+      return null;
+    };
+
+    const harness = createPluginApiHarness({
+      resolveRoot: workspaceDir,
+      logs,
+      pluginConfig: {
+        dbPath: path.join(workspaceDir, "db"),
+        embedding: { apiKey: "test-api-key" },
+        smartExtraction: false,
+        autoCapture: false,
+        autoRecall: true,
+        autoRecallMinLength: 1,
+        autoRecallTimeoutMs: 10000,
+        selfImprovement: { enabled: false, beforeResetNote: false, ensureLearningFiles: false },
+      },
+    });
+
+    memoryLanceDBProPlugin.register(harness.api);
+
+    const autoRecallHook = getAutoRecallHook(harness.eventHandlers);
+    const timeoutMarker = Symbol("timeout");
+    const output = await Promise.race([
+      autoRecallHook(
+        { prompt: "Please recall what I mentioned before about this task." },
+        { sessionId: "auto-patch-bg", sessionKey: "agent:main:session:auto-patch-bg", agentId: "main" },
+      ),
+      delay(500).then(() => timeoutMarker),
+    ]);
+
+    assert.notEqual(output, timeoutMarker, "metadata patch must not block context injection");
+    assert.match(
+      output?.prependContext ?? "",
+      /<relevant-memories>/,
+      `expected memory context; logs=${JSON.stringify(logs)}`,
+    );
+    assert.equal(patchMetadataCalls, 2, "background metadata patch should still start");
+    assert.equal(patchMetadataSettled, 0, "hook should return before background patch settles");
+    assert.ok(
+      logs.info.some((line) => /injecting \d+ memories into context/.test(line)),
+      "expected context injection log",
+    );
+
+    patchResolvers.forEach((resolve) => resolve());
+    await delay(0);
+    assert.equal(patchMetadataSettled, 2, "background metadata patch should settle after hook returns");
   });
 });

--- a/test/cross-process-lock.test.mjs
+++ b/test/cross-process-lock.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import jitiFactory from "jiti";
@@ -113,6 +113,33 @@ describe("Cross-process file lock", () => {
       const all = await store.list(undefined, undefined, 20, 0);
       assert.strictEqual(all.length, 2, "should have 2 entries after store+store+delete+store");
     } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat persistent lock target file as stale lock artifact", async () => {
+    const { store, dir } = makeStore();
+    const lockTarget = join(dir, ".memory-write.lock");
+    const oldTime = new Date(Date.now() - 10 * 60 * 1000);
+    const warnings = [];
+    const originalWarn = console.warn;
+
+    try {
+      writeFileSync(lockTarget, "");
+      utimesSync(lockTarget, oldTime, oldTime);
+      console.warn = (...args) => {
+        warnings.push(args.join(" "));
+      };
+
+      await store.store(makeEntry(1));
+
+      assert.ok(existsSync(lockTarget), "persistent lock target file should remain");
+      assert.ok(
+        !warnings.some((message) => message.includes("cleared stale lock")),
+        "old lock target file should not emit stale-lock cleanup warnings",
+      );
+    } finally {
+      console.warn = originalWarn;
       rmSync(dir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary
- clean up stale proper-lockfile artifacts at `.memory-write.lock.lock` instead of deleting the persistent `.memory-write.lock` target file
- move Tier 1 auto-recall metadata patching off the `before_prompt_build` critical path so memory context can return before `patchMetadata` settles
- add focused regression coverage for both behaviors

## Why
This addresses two related runtime issues observed on OpenClaw 2026.5.18:
- repeated stale-lock cleanup warnings caused by treating the persistent lock target file as if it were the proper-lockfile artifact
- auto-recall timing out before prompt context injection when metadata patching stalls after retrieval has already selected memories

Related issues/PRs:
- refs #670
- refs #762
- refs #643
- follows #790 by keeping late-result dropping while avoiding metadata patching on the prompt critical path

## Tests
- `git diff --check`
- `npx tsc --project tsconfig.json`
- `node --test test/auto-recall-timeout.test.mjs`
- `node --test test/cross-process-lock.test.mjs`
- `node --test test/per-agent-auto-recall.test.mjs`
- `node --test test/tier1-counters.test.mjs`
- `node --test test/recall-text-cleanup.test.mjs`
- `node --test test/lock-stress-test.mjs`
- `node --test test/lock-release-on-error.test.mjs`

## Live validation
Tested in a local OpenClaw 2026.5.18 Gateway with `memory-lancedb-pro@1.1.0-beta.11` and a LanceDB store containing 5,562 memories:
- old `.memory-write.lock` stale cleanup warnings stopped
- auto-recall injected memories without the previous `before_prompt_build` 15s timeout
- manual `memory_recall`, `memory-pro stats`, `memory-pro list`, and `memory-pro search` continued to work
