### PR TITLE
inject self-improvement reset reminder silently

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -475,7 +475,15 @@ const DEFAULT_SELF_IMPROVEMENT_REMINDER = [
   "Keep entries simple: date, title, what happened, what to do differently.",
 ].join("\n");
 
-const SELF_IMPROVEMENT_NOTE_PREFIX = "/note self-improvement (before reset):";
+const SELF_IMPROVEMENT_RESET_REMINDER_CONTEXT = [
+  "<self-improvement-reminder>",
+  "If anything was learned/corrected in the previous session, log it now:",
+  "- .learnings/LEARNINGS.md (corrections/best practices)",
+  "- .learnings/ERRORS.md (failures/root causes)",
+  "- Distill reusable rules to AGENTS.md / SOUL.md / TOOLS.md.",
+  "- If reusable across tasks, extract a new skill from the learning.",
+  "</self-improvement-reminder>",
+].join("\n");
 const DEFAULT_REFLECTION_MESSAGE_COUNT = 120;
 const DEFAULT_REFLECTION_MAX_INPUT_CHARS = 24_000;
 const DEFAULT_REFLECTION_TIMEOUT_MS = 20_000;
@@ -3675,6 +3683,23 @@ const memoryLanceDBProPlugin = {
     // ========================================================================
 
     if (config.selfImprovement?.enabled !== false) {
+      const pendingSelfImprovementResetReminderBySession = new Set<string>();
+      const getSelfImprovementSessionKey = (event: any, ctx?: any): string => {
+        const candidates = [
+          event?.sessionKey,
+          ctx?.sessionKey,
+          event?.context?.sessionKey,
+          event?.context?.sessionId,
+          ctx?.sessionId,
+        ];
+        for (const candidate of candidates) {
+          if (typeof candidate === "string" && candidate.trim().length > 0) {
+            return candidate.trim();
+          }
+        }
+        return "";
+      };
+
       api.registerHook("agent:bootstrap", async (event) => {
         const context = (event.context || {}) as Record<string, unknown>;
         const sessionKey = typeof event.sessionKey === "string" ? event.sessionKey : "";
@@ -3716,25 +3741,24 @@ const memoryLanceDBProPlugin = {
       });
 
       if (config.selfImprovement?.beforeResetNote !== false) {
-        const appendSelfImprovementNote = async (event: any) => {
-          // Basic validation BEFORE dedup — skip events that will legitimately return anyway
-          if (!Array.isArray(event.messages)) {
-            api.logger.warn(`self-improvement: command:${String(event?.action || "unknown")} missing event.messages array; skip note inject`);
+        const markSelfImprovementResetReminder = async (event: any) => {
+          const action = String(event?.action || "unknown");
+          const sessionKey = getSelfImprovementSessionKey(event);
+          if (!sessionKey) {
+            api.logger.warn(`self-improvement: command:${action} missing sessionKey; skip reminder mark`);
             return;
           }
 
           if (_dedupHookEvent("selfImprovement", event)) return;
 
           try {
-            const action = String(event?.action || "unknown");
-            const sessionKeyForLog = typeof event?.sessionKey === "string" ? event.sessionKey : "";
             const contextForLog = (event?.context && typeof event.context === "object")
               ? (event.context as Record<string, unknown>)
               : {};
             const commandSource = typeof contextForLog.commandSource === "string" ? contextForLog.commandSource : "";
             const contextKeys = Object.keys(contextForLog).slice(0, 8).join(",");
             api.logger.info(
-              `self-improvement: command:${action} hook start; sessionKey=${sessionKeyForLog || "(none)"}; source=${commandSource || "(unknown)"}; hasMessages=${Array.isArray(event?.messages)}; contextKeys=${contextKeys || "(none)"}`
+              `self-improvement: command:${action} hook start; sessionKey=${sessionKey}; source=${commandSource || "(unknown)"}; contextKeys=${contextKeys || "(none)"}`
             );
 
             // Skip self-improvement note on Discord channel (non-thread) resets
@@ -3753,38 +3777,39 @@ const memoryLanceDBProPlugin = {
               return;
             }
 
-            const exists = event.messages.some((m: unknown) => typeof m === "string" && m.includes(SELF_IMPROVEMENT_NOTE_PREFIX));
-            if (exists) {
-              api.logger.info(`self-improvement: command:${action} note already present; skip duplicate inject`);
-              return;
-            }
-
-            event.messages.push(
-              [
-                SELF_IMPROVEMENT_NOTE_PREFIX,
-                "- If anything was learned/corrected, log it now:",
-                "  - .learnings/LEARNINGS.md (corrections/best practices)",
-                "  - .learnings/ERRORS.md (failures/root causes)",
-                "- Distill reusable rules to AGENTS.md / SOUL.md / TOOLS.md.",
-                "- If reusable across tasks, extract a new skill from the learning.",
-                "- Then proceed with the new session.",
-              ].join("\n")
-            );
-            api.logger.info(
-              `self-improvement: command:${action} injected note; messages=${event.messages.length}`
-            );
+            pendingSelfImprovementResetReminderBySession.add(sessionKey);
+            api.logger.info(`self-improvement: command:${action} queued silent reminder for next prompt`);
           } catch (err) {
-            api.logger.warn(`self-improvement: note inject failed: ${String(err)}`);
+            api.logger.warn(`self-improvement: reminder mark failed: ${String(err)}`);
           }
         };
 
-        api.registerHook("command:new", appendSelfImprovementNote, {
-          name: "memory-lancedb-pro.self-improvement.command-new",
-          description: "Append self-improvement note before /new",
+        api.on("before_prompt_build", async (event: any, ctx: any) => {
+          const sessionKey = getSelfImprovementSessionKey(event, ctx);
+          if (!sessionKey || !pendingSelfImprovementResetReminderBySession.delete(sessionKey)) {
+            return;
+          }
+          return {
+            prependContext: SELF_IMPROVEMENT_RESET_REMINDER_CONTEXT,
+            ephemeral: true,
+          };
+        }, {
+          name: "memory-lancedb-pro.self-improvement.before-prompt-build",
+          description: "Inject self-improvement reminder silently after /new or /reset",
         });
-        api.registerHook("command:reset", appendSelfImprovementNote, {
+
+        api.on("session_end", (_event: any, ctx: any) => {
+          const sessionKey = getSelfImprovementSessionKey(_event, ctx);
+          if (sessionKey) pendingSelfImprovementResetReminderBySession.delete(sessionKey);
+        }, { priority: 20 });
+
+        api.registerHook("command:new", markSelfImprovementResetReminder, {
+          name: "memory-lancedb-pro.self-improvement.command-new",
+          description: "Queue self-improvement reminder before /new",
+        });
+        api.registerHook("command:reset", markSelfImprovementResetReminder, {
           name: "memory-lancedb-pro.self-improvement.command-reset",
-          description: "Append self-improvement note before /reset",
+          description: "Queue self-improvement reminder before /reset",
         });
       }
 

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -30,6 +30,7 @@ export const CI_TEST_MANIFEST = [
   { group: "core-regression", runner: "node", file: "test/smart-extractor-batch-embed.test.mjs" },
   { group: "packaging-and-workflow", runner: "node", file: "test/plugin-manifest-regression.mjs" },
   { group: "core-regression", runner: "node", file: "test/session-summary-before-reset.test.mjs", args: ["--test"] },
+  { group: "core-regression", runner: "node", file: "test/self-improvement-reset-note.test.mjs", args: ["--test"] },
   { group: "packaging-and-workflow", runner: "node", file: "test/sync-plugin-version.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/smart-metadata-v2.mjs" },
   { group: "storage-and-schema", runner: "node", file: "test/vector-search-cosine.test.mjs" },

--- a/test/self-improvement-reset-note.test.mjs
+++ b/test/self-improvement-reset-note.test.mjs
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginSdkStubPath = path.resolve(testDir, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+
+const pluginModule = jiti("../index.ts");
+const memoryLanceDBProPlugin = pluginModule.default || pluginModule;
+const resetRegistration = pluginModule.resetRegistration ?? (() => {});
+
+function createPluginApiHarness({ pluginConfig, resolveRoot }) {
+  const eventHandlers = new Map();
+  const logs = [];
+
+  const api = {
+    pluginConfig,
+    resolvePath(target) {
+      if (typeof target !== "string") return target;
+      if (path.isAbsolute(target)) return target;
+      return path.join(resolveRoot, target);
+    },
+    logger: {
+      info(message) {
+        logs.push(["info", String(message)]);
+      },
+      warn(message) {
+        logs.push(["warn", String(message)]);
+      },
+      debug(message) {
+        logs.push(["debug", String(message)]);
+      },
+      error(message) {
+        logs.push(["error", String(message)]);
+      },
+    },
+    registerTool() {},
+    registerCli() {},
+    registerService() {},
+    on(eventName, handler, meta) {
+      const list = eventHandlers.get(eventName) || [];
+      list.push({ handler, meta });
+      eventHandlers.set(eventName, list);
+    },
+    registerHook(eventName, handler, opts) {
+      const list = eventHandlers.get(eventName) || [];
+      list.push({ handler, meta: opts });
+      eventHandlers.set(eventName, list);
+    },
+  };
+
+  return { api, eventHandlers, logs };
+}
+
+function makePluginConfig(workDir) {
+  return {
+    dbPath: path.join(workDir, "db"),
+    autoCapture: false,
+    autoRecall: false,
+    smartExtraction: false,
+    sessionStrategy: "none",
+    selfImprovement: {
+      enabled: true,
+      beforeResetNote: true,
+      ensureLearningFiles: false,
+    },
+    embedding: {
+      provider: "openai-compatible",
+      apiKey: "test-api-key",
+      model: "text-embedding-3-small",
+      baseURL: "http://127.0.0.1:9/v1",
+      dimensions: 4,
+    },
+  };
+}
+
+describe("self-improvement reset reminder", () => {
+  let workDir;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(path.join(tmpdir(), "self-improvement-reset-"));
+    resetRegistration();
+  });
+
+  afterEach(() => {
+    resetRegistration();
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("queues a silent reminder after /new without appending a visible note message", async () => {
+    const harness = createPluginApiHarness({
+      resolveRoot: workDir,
+      pluginConfig: makePluginConfig(workDir),
+    });
+    memoryLanceDBProPlugin.register(harness.api);
+
+    const commandHook = harness.eventHandlers
+      .get("command:new")
+      ?.find((hook) => hook.meta?.name === "memory-lancedb-pro.self-improvement.command-new");
+    assert.ok(commandHook, "expected self-improvement command:new hook");
+
+    const promptHook = harness.eventHandlers
+      .get("before_prompt_build")
+      ?.find((hook) => hook.meta?.name === "memory-lancedb-pro.self-improvement.before-prompt-build");
+    assert.ok(promptHook, "expected self-improvement before_prompt_build hook");
+
+    const messages = ["user content remains user-visible content only"];
+    await commandHook.handler({
+      action: "command:new",
+      sessionKey: "agent:main:test-session",
+      timestamp: 1,
+      messages,
+      context: {},
+    });
+
+    assert.deepEqual(messages, ["user content remains user-visible content only"]);
+
+    const result = await promptHook.handler(
+      { sessionKey: "agent:main:test-session" },
+      { sessionKey: "agent:main:test-session" },
+    );
+    assert.match(result?.prependContext, /<self-improvement-reminder>/);
+    assert.doesNotMatch(result?.prependContext ?? "", /\/note self-improvement/);
+    assert.equal(result?.ephemeral, true);
+
+    const secondResult = await promptHook.handler(
+      { sessionKey: "agent:main:test-session" },
+      { sessionKey: "agent:main:test-session" },
+    );
+    assert.equal(secondResult, undefined, "reminder should be consumed after one prompt");
+  });
+});


### PR DESCRIPTION
## Summary
- stop appending the self-improvement reset reminder to user-visible command messages
- queue a one-shot silent reminder for the next before_prompt_build context instead
- add regression coverage that command:new leaves event.messages unchanged and consumes the silent reminder once

Closes #615

## Tests
- PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/andy/.codex/tmp/arg0/codex-arg0qrQEad:/Users/andy/.antigravity/antigravity/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/Users/andy/.cargo/bin:/Users/andy/.cache/lm-studio/bin:/Applications/Codex.app/Contents/Resources /Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test test/self-improvement-reset-note.test.mjs test/plugin-manifest-regression.mjs test/session-summary-before-reset.test.mjs
- PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/andy/.codex/tmp/arg0/codex-arg0qrQEad:/Users/andy/.antigravity/antigravity/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/Users/andy/.cargo/bin:/Users/andy/.cache/lm-studio/bin:/Applications/Codex.app/Contents/Resources /Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/verify-ci-test-manifest.mjs

Note: I also tried the full core-regression group. It currently stops in test/recall-text-cleanup.test.mjs before reaching this new test due recall fixture leakage unrelated to this change.

If this PR is squashed or reworked, please preserve author attribution or include:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>