### PR TITLE
cap self-improvement learning entries

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -214,6 +214,7 @@ interface PluginConfig {
     beforeResetNote?: boolean;
     skipSubagentBootstrap?: boolean;
     ensureLearningFiles?: boolean;
+    maxEntries?: number;
   };
   memoryReflection?: {
     enabled?: boolean;
@@ -2592,6 +2593,7 @@ const memoryLanceDBProPlugin = {
         workspaceDir: getDefaultWorkspaceDir(),
         mdMirror,
         workspaceBoundary: config.workspaceBoundary,
+        selfImprovementMaxEntries: config.selfImprovement?.maxEntries,
       },
       {
         enableManagementTools: config.enableManagementTools,
@@ -4247,7 +4249,7 @@ const memoryLanceDBProPlugin = {
           const reflectionGovernanceCandidates = extractReflectionLearningGovernanceCandidates(reflectionText);
           if (config.selfImprovement?.enabled !== false && reflectionGovernanceCandidates.length > 0) {
             for (const candidate of reflectionGovernanceCandidates) {
-              await appendSelfImprovementEntry({
+              const appendResult = await appendSelfImprovementEntry({
                 baseDir: workspaceDir,
                 type: "learning",
                 summary: candidate.summary,
@@ -4258,7 +4260,13 @@ const memoryLanceDBProPlugin = {
                 priority: candidate.priority || "medium",
                 status: candidate.status || "pending",
                 source: `memory-lancedb-pro/reflection:${relPath}`,
+                maxEntries: config.selfImprovement?.maxEntries,
               });
+              if (appendResult.skipped) {
+                api.logger.warn(
+                  `self-improvement: skipped reflection learning candidate because .learnings limit was reached (${appendResult.entryCount}/${appendResult.maxEntries})`,
+                );
+              }
             }
           }
 
@@ -4901,12 +4909,14 @@ export function parsePluginConfig(value: unknown): PluginConfig {
         beforeResetNote: (cfg.selfImprovement as Record<string, unknown>).beforeResetNote !== false,
         skipSubagentBootstrap: (cfg.selfImprovement as Record<string, unknown>).skipSubagentBootstrap !== false,
         ensureLearningFiles: (cfg.selfImprovement as Record<string, unknown>).ensureLearningFiles !== false,
+        maxEntries: parsePositiveInt((cfg.selfImprovement as Record<string, unknown>).maxEntries) ?? 500,
       }
       : {
         enabled: true,
         beforeResetNote: true,
         skipSubagentBootstrap: true,
         ensureLearningFiles: true,
+        maxEntries: 500,
       },
     memoryReflection: memoryReflectionRaw
       ? {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -703,6 +703,12 @@
           "ensureLearningFiles": {
             "type": "boolean",
             "default": true
+          },
+          "maxEntries": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 500,
+            "description": "Maximum number of entries to retain per .learnings file before new appends are skipped."
           }
         }
       },
@@ -1353,6 +1359,11 @@
     "selfImprovement.ensureLearningFiles": {
       "label": "Ensure Learning Files",
       "help": "Auto-create .learnings files when missing",
+      "advanced": true
+    },
+    "selfImprovement.maxEntries": {
+      "label": "Max Learning Entries",
+      "help": "Maximum entries per .learnings file before new appends are skipped",
       "advanced": true
     },
     "memoryReflection.storeToLanceDB": {

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -31,6 +31,7 @@ export const CI_TEST_MANIFEST = [
   { group: "packaging-and-workflow", runner: "node", file: "test/plugin-manifest-regression.mjs" },
   { group: "core-regression", runner: "node", file: "test/session-summary-before-reset.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/self-improvement-reset-note.test.mjs", args: ["--test"] },
+  { group: "core-regression", runner: "node", file: "test/self-improvement.test.mjs", args: ["--test"] },
   { group: "packaging-and-workflow", runner: "node", file: "test/sync-plugin-version.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/smart-metadata-v2.mjs" },
   { group: "storage-and-schema", runner: "node", file: "test/vector-search-cosine.test.mjs" },

--- a/src/self-improvement-files.ts
+++ b/src/self-improvement-files.ts
@@ -14,6 +14,7 @@ Append structured entries:
 - Include symptom, context, probable cause, and prevention`;
 
 const fileWriteQueues = new Map<string, Promise<void>>();
+export const DEFAULT_SELF_IMPROVEMENT_MAX_ENTRIES = 500;
 
 async function withFileWriteQueue<T>(filePath: string, action: () => Promise<T>): Promise<T> {
   const previous = fileWriteQueues.get(filePath) ?? Promise.resolve();
@@ -39,17 +40,25 @@ function todayYmd(): string {
   return new Date().toISOString().slice(0, 10).replace(/-/g, "");
 }
 
-async function nextLearningId(filePath: string, prefix: "LRN" | "ERR"): Promise<string> {
-  const date = todayYmd();
-  let count = 0;
-  try {
-    const content = await readFile(filePath, "utf-8");
-    const matches = content.match(new RegExp(`\\[${prefix}-${date}-\\d{3}\\]`, "g"));
-    count = matches?.length ?? 0;
-  } catch {
-    // ignore
-  }
+function nextLearningIdFromContent(content: string, prefix: "LRN" | "ERR", date = todayYmd()): string {
+  const matches = content.match(new RegExp(`\\[${prefix}-${date}-\\d{3}\\]`, "g"));
+  const count = matches?.length ?? 0;
   return `${prefix}-${date}-${String(count + 1).padStart(3, "0")}`;
+}
+
+export function countSelfImprovementEntries(content: string, prefix?: "LRN" | "ERR"): number {
+  const pattern = prefix
+    ? new RegExp(`^## \\[${prefix}-\\d{8}-\\d{3}\\]`, "gm")
+    : /^## \[(?:LRN|ERR)-\d{8}-\d{3}\]/gm;
+  return (content.match(pattern) || []).length;
+}
+
+function normalizeMaxEntries(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_SELF_IMPROVEMENT_MAX_ENTRIES;
+  }
+  return Math.floor(parsed);
 }
 
 export async function ensureSelfImprovementLearningFiles(baseDir: string): Promise<void> {
@@ -81,11 +90,15 @@ export interface AppendSelfImprovementEntryParams {
   priority?: string;
   status?: string;
   source?: string;
+  maxEntries?: number;
 }
 
 export async function appendSelfImprovementEntry(params: AppendSelfImprovementEntryParams): Promise<{
   id: string;
   filePath: string;
+  skipped: boolean;
+  entryCount: number;
+  maxEntries: number;
 }> {
   const {
     baseDir,
@@ -98,6 +111,7 @@ export async function appendSelfImprovementEntry(params: AppendSelfImprovementEn
     priority = "medium",
     status = "pending",
     source = "memory-lancedb-pro/self_improvement_log",
+    maxEntries,
   } = params;
 
   await ensureSelfImprovementLearningFiles(baseDir);
@@ -105,9 +119,20 @@ export async function appendSelfImprovementEntry(params: AppendSelfImprovementEn
   const fileName = type === "learning" ? "LEARNINGS.md" : "ERRORS.md";
   const filePath = join(learningsDir, fileName);
   const idPrefix = type === "learning" ? "LRN" : "ERR";
+  const effectiveMaxEntries = normalizeMaxEntries(maxEntries);
 
-  const id = await withFileWriteQueue(filePath, async () => {
-    const entryId = await nextLearningId(filePath, idPrefix);
+  const result = await withFileWriteQueue(filePath, async () => {
+    const prev = await readFile(filePath, "utf-8").catch(() => "");
+    const entryCount = countSelfImprovementEntries(prev, idPrefix);
+    if (entryCount >= effectiveMaxEntries) {
+      return {
+        id: "",
+        skipped: true,
+        entryCount,
+      };
+    }
+
+    const entryId = nextLearningIdFromContent(prev, idPrefix);
     const nowIso = new Date().toISOString();
     const titleSuffix = type === "learning" ? ` ${category}` : "";
     const entry = [
@@ -132,11 +157,14 @@ export async function appendSelfImprovementEntry(params: AppendSelfImprovementEn
       "---",
       "",
     ].join("\n");
-    const prev = await readFile(filePath, "utf-8").catch(() => "");
     const separator = prev.trimEnd().length > 0 ? "\n\n" : "";
     await appendFile(filePath, `${separator}${entry}`, "utf-8");
-    return entryId;
+    return {
+      id: entryId,
+      skipped: false,
+      entryCount: entryCount + 1,
+    };
   });
 
-  return { id, filePath };
+  return { ...result, filePath, maxEntries: effectiveMaxEntries };
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -23,7 +23,12 @@ import {
 } from "./smart-metadata.js";
 import { classifyTemporal, inferExpiry } from "./temporal-classifier.js";
 import { TEMPORAL_VERSIONED_CATEGORIES } from "./memory-categories.js";
-import { appendSelfImprovementEntry, ensureSelfImprovementLearningFiles } from "./self-improvement-files.js";
+import {
+  appendSelfImprovementEntry,
+  countSelfImprovementEntries,
+  DEFAULT_SELF_IMPROVEMENT_MAX_ENTRIES,
+  ensureSelfImprovementLearningFiles,
+} from "./self-improvement-files.js";
 import { getDisplayCategoryTag } from "./reflection-metadata.js";
 import type { RetrievalTrace } from "./retrieval-trace.js";
 import {
@@ -65,6 +70,7 @@ interface ToolContext {
   workspaceDir?: string;
   mdMirror?: MdMirrorWriter | null;
   workspaceBoundary?: WorkspaceBoundaryConfig;
+  selfImprovementMaxEntries?: number;
 }
 
 function resolveAgentId(runtimeAgentId: unknown, fallback?: string): string | undefined {
@@ -292,7 +298,7 @@ export function registerSelfImprovementLogTool(api: OpenClawPluginApi, context: 
         };
         try {
           const workspaceDir = resolveWorkspaceDir(toolCtx, context.workspaceDir);
-          const { id: entryId, filePath } = await appendSelfImprovementEntry({
+          const result = await appendSelfImprovementEntry({
             baseDir: workspaceDir,
             type,
             summary,
@@ -302,12 +308,37 @@ export function registerSelfImprovementLogTool(api: OpenClawPluginApi, context: 
             area,
             priority,
             source: "memory-lancedb-pro/self_improvement_log",
+            maxEntries: context.selfImprovementMaxEntries,
           });
           const fileName = type === "learning" ? "LEARNINGS.md" : "ERRORS.md";
+          if (result.skipped) {
+            return {
+              content: [{
+                type: "text",
+                text:
+                  `Skipped ${type} entry: .learnings/${fileName} already has ` +
+                  `${result.entryCount}/${result.maxEntries} entries. Review, archive, or raise selfImprovement.maxEntries.`,
+              }],
+              details: {
+                action: "skipped_limit",
+                type,
+                filePath: result.filePath,
+                entryCount: result.entryCount,
+                maxEntries: result.maxEntries,
+              },
+            };
+          }
 
           return {
-            content: [{ type: "text", text: `Logged ${type} entry ${entryId} to .learnings/${fileName}` }],
-            details: { action: "logged", type, id: entryId, filePath },
+            content: [{ type: "text", text: `Logged ${type} entry ${result.id} to .learnings/${fileName}` }],
+            details: {
+              action: "logged",
+              type,
+              id: result.id,
+              filePath: result.filePath,
+              entryCount: result.entryCount,
+              maxEntries: result.maxEntries,
+            },
           };
         } catch (error) {
           return {
@@ -453,11 +484,24 @@ export function registerSelfImprovementReviewTool(api: OpenClawPluginApi, contex
           await ensureSelfImprovementLearningFiles(workspaceDir);
           const learningsDir = join(workspaceDir, ".learnings");
           const files = ["LEARNINGS.md", "ERRORS.md"] as const;
-          const stats = { pending: 0, high: 0, promoted: 0, total: 0 };
+          const maxEntries = context.selfImprovementMaxEntries ?? DEFAULT_SELF_IMPROVEMENT_MAX_ENTRIES;
+          const stats = {
+            pending: 0,
+            high: 0,
+            promoted: 0,
+            total: 0,
+            files: {} as Record<string, { entries: number; maxEntries: number; atLimit: boolean }>,
+          };
 
           for (const f of files) {
             const content = await readFile(join(learningsDir, f), "utf-8").catch(() => "");
-            stats.total += (content.match(/^## \[/gm) || []).length;
+            const entries = countSelfImprovementEntries(content);
+            stats.files[f] = {
+              entries,
+              maxEntries,
+              atLimit: entries >= maxEntries,
+            };
+            stats.total += entries;
             stats.pending += (content.match(/\*\*Status\*\*:\s*pending/gi) || []).length;
             stats.high += (content.match(/\*\*Priority\*\*:\s*(high|critical)/gi) || []).length;
             stats.promoted += (content.match(/\*\*Status\*\*:\s*promoted(_to_skill)?/gi) || []).length;
@@ -469,6 +513,8 @@ export function registerSelfImprovementReviewTool(api: OpenClawPluginApi, contex
             `- Pending: ${stats.pending}`,
             `- High/Critical: ${stats.high}`,
             `- Promoted: ${stats.promoted}`,
+            `- LEARNINGS.md: ${stats.files["LEARNINGS.md"].entries}/${maxEntries}`,
+            `- ERRORS.md: ${stats.files["ERRORS.md"].entries}/${maxEntries}`,
             "",
             "Recommended loop:",
             "1) Resolve high-priority pending entries",

--- a/test/self-improvement.test.mjs
+++ b/test/self-improvement.test.mjs
@@ -17,8 +17,9 @@ const jiti = jitiFactory(import.meta.url, {
 const {
   registerSelfImprovementLogTool,
   registerSelfImprovementExtractSkillTool,
+  registerSelfImprovementReviewTool,
 } = jiti("../src/tools.ts");
-const { appendSelfImprovementEntry } = jiti("../src/self-improvement-files.ts");
+const { appendSelfImprovementEntry, countSelfImprovementEntries } = jiti("../src/self-improvement-files.ts");
 const {
   extractReflectionLearningGovernanceCandidates,
   extractInjectableReflectionMappedMemories,
@@ -26,7 +27,7 @@ const {
   extractReflectionMappedMemories,
 } = jiti("../src/reflection-slices.ts");
 
-function createToolHarness(workspaceDir) {
+function createToolHarness(workspaceDir, overrides = {}) {
   const factories = new Map();
   const api = {
     registerTool(factory, meta) {
@@ -41,10 +42,12 @@ function createToolHarness(workspaceDir) {
     scopeManager: {},
     embedder: {},
     mdMirror: null,
+    ...overrides,
   };
 
   registerSelfImprovementLogTool(api, context);
   registerSelfImprovementExtractSkillTool(api, context);
+  registerSelfImprovementReviewTool(api, context);
 
   return {
     tool(name, toolCtx = {}) {
@@ -228,6 +231,61 @@ describe("self-improvement", () => {
       assert.match(learningsBody, /Document the triage-first rule after it repeats/);
       assert.match(learningsBody, /\*\*Status\*\*: pending/);
       assert.match(learningsBody, /Source: memory-lancedb-pro\/reflection:test/);
+    });
+
+    it("skips new entries when the configured per-file limit is reached", async () => {
+      const first = await appendSelfImprovementEntry({
+        baseDir: workspaceDir,
+        type: "learning",
+        summary: "Keep the active backlog bounded.",
+        maxEntries: 1,
+      });
+      const second = await appendSelfImprovementEntry({
+        baseDir: workspaceDir,
+        type: "learning",
+        summary: "This entry should not be appended.",
+        maxEntries: 1,
+      });
+
+      assert.equal(first.skipped, false);
+      assert.equal(first.entryCount, 1);
+      assert.equal(second.skipped, true);
+      assert.equal(second.entryCount, 1);
+      assert.equal(second.maxEntries, 1);
+
+      const learningsPath = path.join(workspaceDir, ".learnings", "LEARNINGS.md");
+      const learningsBody = readFileSync(learningsPath, "utf-8");
+      assert.equal(countSelfImprovementEntries(learningsBody), 1);
+      assert.match(learningsBody, /Keep the active backlog bounded/);
+      assert.doesNotMatch(learningsBody, /This entry should not be appended/);
+    });
+
+    it("surfaces the entry limit through log and review tools", async () => {
+      const harness = createToolHarness(workspaceDir, { selfImprovementMaxEntries: 1 });
+      const logTool = harness.tool("self_improvement_log");
+      const reviewTool = harness.tool("self_improvement_review");
+
+      const logged = await logTool.execute("tc-limit-1", {
+        type: "learning",
+        summary: "First entry fits under the limit.",
+      });
+      assert.equal(logged?.details?.action, "logged");
+      assert.equal(logged?.details?.entryCount, 1);
+      assert.equal(logged?.details?.maxEntries, 1);
+
+      const skipped = await logTool.execute("tc-limit-2", {
+        type: "learning",
+        summary: "Second entry should be blocked.",
+      });
+      assert.equal(skipped?.details?.action, "skipped_limit");
+      assert.equal(skipped?.details?.entryCount, 1);
+      assert.equal(skipped?.details?.maxEntries, 1);
+      assert.match(skipped?.content?.[0]?.text ?? "", /already has 1\/1 entries/);
+
+      const review = await reviewTool.execute("tc-limit-3", {});
+      assert.equal(review?.details?.stats?.files?.["LEARNINGS.md"]?.entries, 1);
+      assert.equal(review?.details?.stats?.files?.["LEARNINGS.md"]?.atLimit, true);
+      assert.match(review?.content?.[0]?.text ?? "", /LEARNINGS\.md: 1\/1/);
     });
 
     it("handles learning id validation and writes promoted skill scaffold with sanitized outputDir", async () => {


### PR DESCRIPTION
## Summary
- add selfImprovement.maxEntries with a default cap of 500 entries per .learnings file
- skip new self-improvement appends once a file reaches the cap instead of growing indefinitely
- surface entry counts and limit status through self_improvement_log and self_improvement_review
- add regression coverage for direct append limits and tool-facing limit reporting

Closes #599

## Tests
- PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/andy/.codex/tmp/arg0/codex-arg0qrQEad:/Users/andy/.antigravity/antigravity/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/Users/andy/.cargo/bin:/Users/andy/.cache/lm-studio/bin:/Applications/Codex.app/Contents/Resources /Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test test/self-improvement.test.mjs test/plugin-manifest-regression.mjs
- PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/andy/.codex/tmp/arg0/codex-arg0qrQEad:/Users/andy/.antigravity/antigravity/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/Users/andy/.cargo/bin:/Users/andy/.cache/lm-studio/bin:/Applications/Codex.app/Contents/Resources /Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/verify-ci-test-manifest.mjs
- PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/andy/.codex/tmp/arg0/codex-arg0qrQEad:/Users/andy/.antigravity/antigravity/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/Users/andy/.cargo/bin:/Users/andy/.cache/lm-studio/bin:/Applications/Codex.app/Contents/Resources ./node_modules/.bin/tsc --noEmit
- PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/andy/.codex/tmp/arg0/codex-arg0qrQEad:/Users/andy/.antigravity/antigravity/bin:/Library/Frameworks/Python.framework/Versions/3.12/bin:/Users/andy/.local/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/opt/local/bin:/opt/local/sbin:/Users/andy/.cargo/bin:/Users/andy/.cache/lm-studio/bin:/Applications/Codex.app/Contents/Resources /Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/run-ci-tests.mjs --group packaging-and-workflow

If this PR is squashed or reworked, please preserve author attribution or include:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>