### PR TITLE
fallback list and stats when LanceDB metadata projection is empty

### DIFF
--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -16,6 +16,7 @@ export const CI_TEST_MANIFEST = [
   { group: "storage-and-schema", runner: "node", file: "test/smart-extractor-scope-filter.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/store-empty-scope-filter.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/storage-path-normalization.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/store-list-stats-projection-fallback.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/recall-text-cleanup.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/update-consistency-lancedb.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/strip-envelope-metadata.test.mjs", args: ["--test"] },

--- a/src/store.ts
+++ b/src/store.ts
@@ -1273,8 +1273,6 @@ export class MemoryStore {
 
     if (isExplicitDenyAllScopeFilter(scopeFilter)) return [];
 
-    let query = this.table!.query();
-
     // Build where conditions
     const conditions: string[] = [];
 
@@ -1289,13 +1287,13 @@ export class MemoryStore {
       conditions.push(`category = '${escapeSqlLiteral(category)}'`);
     }
 
-    if (conditions.length > 0) {
-      query = query.where(conditions.join(" AND "));
-    }
+    const applyConditions = (query: any) =>
+      conditions.length > 0 ? query.where(conditions.join(" AND ")) : query;
 
     // Fetch all matching rows (no pre-limit) so app-layer sort is correct across full dataset
-    const results = await query
-      .select([
+    const results = await this.queryRowsWithProjectionFallback(
+      applyConditions,
+      [
         "id",
         "text",
         "category",
@@ -1303,8 +1301,8 @@ export class MemoryStore {
         "importance",
         "timestamp",
         "metadata",
-      ])
-      .toArray();
+      ],
+    );
 
     return results
       .map(
@@ -1323,6 +1321,24 @@ export class MemoryStore {
       .slice(offset, offset + limit);
   }
 
+  private async queryRowsWithProjectionFallback(
+    applyFilters: (query: any) => any,
+    columns: string[],
+  ): Promise<any[]> {
+    const projectedRows = await applyFilters(this.table!.query())
+      .select(columns)
+      .toArray();
+
+    if (projectedRows.length > 0) {
+      return projectedRows;
+    }
+
+    // Some LanceDB upgrades have returned empty projected metadata reads while
+    // the underlying table still has rows. Retry the identical query without
+    // projection so list/stats stay aligned with recall/vector reads.
+    return await applyFilters(this.table!.query()).toArray();
+  }
+
   async stats(scopeFilter?: string[]): Promise<{
     totalCount: number;
     scopeCounts: Record<string, number>;
@@ -1338,16 +1354,21 @@ export class MemoryStore {
       };
     }
 
-    let query = this.table!.query();
-
+    const conditions: string[] = [];
     if (scopeFilter && scopeFilter.length > 0) {
       const scopeConditions = scopeFilter
         .map((scope) => `scope = '${escapeSqlLiteral(scope)}'`)
         .join(" OR ");
-      query = query.where(`((${scopeConditions}) OR scope IS NULL)`);
+      conditions.push(`((${scopeConditions}) OR scope IS NULL)`);
     }
 
-    const results = await query.select(["scope", "category"]).toArray();
+    const applyConditions = (query: any) =>
+      conditions.length > 0 ? query.where(conditions.join(" AND ")) : query;
+
+    const results = await this.queryRowsWithProjectionFallback(
+      applyConditions,
+      ["scope", "category"],
+    );
 
     const scopeCounts: Record<string, number> = {};
     const categoryCounts: Record<string, number> = {};

--- a/test/store-list-stats-projection-fallback.test.mjs
+++ b/test/store-list-stats-projection-fallback.test.mjs
@@ -1,0 +1,75 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const { MemoryStore } = jiti("../src/store.ts");
+
+function makeProjectionEmptyTable(rows) {
+  const calls = { projected: 0, unprojected: 0 };
+
+  return {
+    calls,
+    query() {
+      const builder = {
+        where() {
+          return builder;
+        },
+        select() {
+          return {
+            async toArray() {
+              calls.projected += 1;
+              return [];
+            },
+          };
+        },
+        async toArray() {
+          calls.unprojected += 1;
+          return rows;
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+describe("MemoryStore list/stats projection fallback", () => {
+  it("falls back to unprojected LanceDB rows when projected metadata reads are empty", async () => {
+    const timestamp = Date.now();
+    const row = {
+      id: "memory-1",
+      text: "remember projection fallback",
+      vector: [0.1, 0.2, 0.3],
+      category: "fact",
+      scope: "global",
+      importance: 0.8,
+      timestamp,
+      metadata: "{}",
+    };
+    const fakeTable = makeProjectionEmptyTable([row]);
+    const store = new MemoryStore({ dbPath: "/unused", vectorDim: 3 });
+    store.table = fakeTable;
+
+    assert.deepEqual(await store.list(undefined, undefined, 10, 0), [
+      {
+        id: "memory-1",
+        text: "remember projection fallback",
+        vector: [],
+        category: "fact",
+        scope: "global",
+        importance: 0.8,
+        timestamp,
+        metadata: "{}",
+      },
+    ]);
+
+    assert.deepEqual(await store.stats(), {
+      totalCount: 1,
+      scopeCounts: { global: 1 },
+      categoryCounts: { fact: 1 },
+    });
+
+    assert.equal(fakeTable.calls.projected, 2);
+    assert.equal(fakeTable.calls.unprojected, 2);
+  });
+});


### PR DESCRIPTION
## Summary

- retry `MemoryStore.list()` and `MemoryStore.stats()` without projection when a projected LanceDB metadata read returns zero rows
- keep the same scope/category filters on the fallback query
- add a regression test for the projection-empty/list-stats mismatch

Closes #607.

## Validation

- `node --test test/store-list-stats-projection-fallback.test.mjs`
- `node scripts/verify-ci-test-manifest.mjs`
- `npm run test:storage-and-schema`
- `npx tsc --noEmit`
- `git diff --check`

If maintainers squash/rework this PR, please preserve author attribution or include:

`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`