### PR TITLE
skip fallback reflection learning entries

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1355,16 +1355,7 @@ function buildReflectionFallbackText(): string {
     "- (none captured)",
     "",
     "## Learning governance candidates (.learnings / promotion / skill extraction)",
-    "### Entry 1",
-    "**Priority**: medium",
-    "**Status**: triage",
-    "**Area**: config",
-    "### Summary",
-    "Investigate last failed tool execution and decide whether it belongs in .learnings/ERRORS.md.",
-    "### Details",
-    "The reflection pipeline fell back; confirm the failure is reproducible before treating it as a durable error record.",
-    "### Suggested Action",
-    "Reproduce the latest failed tool execution, classify it as triage or error, and then log it with the appropriate tool/file path evidence.",
+    "- (none captured)",
     "",
     "## Open loops / next actions",
     "- Investigate why embedded reflection generation failed.",
@@ -4266,7 +4257,9 @@ const memoryLanceDBProPlugin = {
             throw new Error(`Failed to allocate unique reflection file for ${dateStr} ${timeCompact}`);
           }
 
-          const reflectionGovernanceCandidates = extractReflectionLearningGovernanceCandidates(reflectionText);
+          const reflectionGovernanceCandidates = reflectionGenerated.usedFallback
+            ? []
+            : extractReflectionLearningGovernanceCandidates(reflectionText);
           if (config.selfImprovement?.enabled !== false && reflectionGovernanceCandidates.length > 0) {
             for (const candidate of reflectionGovernanceCandidates) {
               const appendResult = await appendSelfImprovementEntry({

--- a/test/reflection-bypass-hook.test.mjs
+++ b/test/reflection-bypass-hook.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -242,5 +242,82 @@ describe("reflection hooks tolerate bypass scope filters", () => {
       harness.logs.some(([, msg]) => msg.includes("derived injection suppressed after command:new")),
       "expected derived suppression to be logged",
     );
+  });
+
+  it("does not append learning governance entries when reflection generation falls back", async () => {
+    const pluginConfig = {
+      ...makePluginConfig(workDir),
+      selfImprovement: { enabled: true, beforeResetNote: false, ensureLearningFiles: false },
+      memoryReflection: {
+        storeToLanceDB: false,
+        writeLegacyCombined: false,
+        timeoutMs: 1,
+      },
+    };
+
+    const harness = createPluginApiHarness({
+      resolveRoot: workDir,
+      pluginConfig,
+    });
+    harness.api.runtime = {
+      agent: {
+        async runEmbeddedPiAgent() {
+          throw new Error("forced embedded fallback");
+        },
+      },
+    };
+
+    memoryLanceDBProPlugin.register(harness.api);
+
+    const sessionFile = path.join(workDir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "message", message: { role: "user", content: "Please remember this fallback test." } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "I will reflect on it." } }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const originalCliBin = process.env.OPENCLAW_CLI_BIN;
+    process.env.OPENCLAW_CLI_BIN = "/usr/bin/false";
+    try {
+      const commandHooks = harness.eventHandlers.get("command:new") || [];
+      const reflectionCommandHook = commandHooks.find((hook) =>
+        hook.meta?.name === "memory-lancedb-pro.memory-reflection.command-new"
+      );
+      assert.ok(reflectionCommandHook, "expected memory reflection command:new hook");
+
+      await reflectionCommandHook.handler({
+        sessionKey: "agent:main:fallback-learning-noise",
+        timestamp: 1_800_000_000_000,
+        action: "command:new",
+        context: {
+          cfg: pluginConfig,
+          workspaceDir: workDir,
+          sessionEntry: {
+            sessionId: "fallback-session",
+            sessionFile,
+          },
+        },
+      }, { sessionKey: "agent:main:fallback-learning-noise", agentId: "main" });
+    } finally {
+      if (originalCliBin === undefined) delete process.env.OPENCLAW_CLI_BIN;
+      else process.env.OPENCLAW_CLI_BIN = originalCliBin;
+    }
+
+    const learningsPath = path.join(workDir, ".learnings", "LEARNINGS.md");
+    assert.equal(existsSync(learningsPath), false, "fallback reflection should not append .learnings entries");
+
+    const reflectionPath = path.join(
+      workDir,
+      "memory",
+      "reflections",
+      "2027-01-15",
+      "080000000-main-fallback-session.md",
+    );
+    const reflectionBody = readFileSync(reflectionPath, "utf-8");
+    assert.match(reflectionBody, /## Learning governance candidates \(\.learnings \/ promotion \/ skill extraction\)\n- \(none captured\)/);
+    assert.doesNotMatch(reflectionBody, /Investigate last failed tool execution/);
   });
 });


### PR DESCRIPTION
## Summary
- mark fallback reflection learning-governance candidates as empty
- skip learning-governance extraction when reflection generation used the static fallback
- add a command:new fallback regression that verifies no .learnings entry is appended

Closes #814.

## Validation
- node --test test/reflection-bypass-hook.test.mjs
- npx tsc --noEmit
- node scripts/verify-ci-test-manifest.mjs
- git diff --check