### PR TITLE
refresh FTS support before retrieval

### DIFF
--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -572,6 +572,16 @@ export class MemoryRetriever {
     return this._statsCollector;
   }
 
+  private async resolveFtsSupport(): Promise<boolean> {
+    const storeWithRefresh = this.store as MemoryStore & {
+      refreshFtsSupport?: () => Promise<boolean>;
+    };
+    if (typeof storeWithRefresh.refreshFtsSupport === "function") {
+      return await storeWithRefresh.refreshFtsSupport();
+    }
+    return this.store.hasFtsSupport;
+  }
+
   async retrieve(context: RetrievalContext): Promise<RetrievalResult[]> {
     const { query, limit, scopeFilter, category, source } = context;
     const safeLimit = clampInt(limit, 1, 20);
@@ -607,6 +617,9 @@ export class MemoryRetriever {
     try {
       // Create trace only when stats collector is active (zero overhead otherwise)
       const trace = this._statsCollector ? new TraceCollector() : undefined;
+      const hasFtsSupport = this.config.mode === "vector"
+        ? this.store.hasFtsSupport
+        : await this.resolveFtsSupport();
 
       // Check if query contains tag prefixes -> use BM25-only + mustContain
       const tagTokens = this.extractTagTokens(query);
@@ -621,7 +634,7 @@ export class MemoryRetriever {
           trace,
           diagnostics,
         );
-      } else if (this.config.mode === "vector" || !this.store.hasFtsSupport) {
+      } else if (this.config.mode === "vector" || !hasFtsSupport) {
         results = await this.vectorOnlyRetrieval(
           query,
           safeLimit,
@@ -649,7 +662,7 @@ export class MemoryRetriever {
       if (trace && this._statsCollector) {
         const mode = tagTokens.length > 0
           ? "bm25"
-          : (this.config.mode === "vector" || !this.store.hasFtsSupport)
+          : (this.config.mode === "vector" || !hasFtsSupport)
             ? "vector"
             : "hybrid";
         const finalTrace = trace.finalize(query, mode);
@@ -685,12 +698,15 @@ export class MemoryRetriever {
 
     const tagTokens = this.extractTagTokens(query);
     let results: RetrievalResult[];
+    const hasFtsSupport = this.config.mode === "vector"
+      ? this.store.hasFtsSupport
+      : await this.resolveFtsSupport();
 
     if (tagTokens.length > 0) {
       results = await this.bm25OnlyRetrieval(
         query, tagTokens, safeLimit, scopeFilter, category, trace,
       );
-    } else if (this.config.mode === "vector" || !this.store.hasFtsSupport) {
+    } else if (this.config.mode === "vector" || !hasFtsSupport) {
       results = await this.vectorOnlyRetrieval(
         query, safeLimit, scopeFilter, category, trace,
       );
@@ -701,7 +717,7 @@ export class MemoryRetriever {
     }
 
     const mode = tagTokens.length > 0 ? "bm25"
-      : (this.config.mode === "vector" || !this.store.hasFtsSupport) ? "vector" : "hybrid";
+      : (this.config.mode === "vector" || !hasFtsSupport) ? "vector" : "hybrid";
     const finalTrace = trace.finalize(query, mode);
 
     if (this._statsCollector) {
@@ -1786,13 +1802,13 @@ export class MemoryRetriever {
       return {
         success: true,
         mode: this.config.mode,
-        hasFtsSupport: this.store.hasFtsSupport,
+        hasFtsSupport: await this.resolveFtsSupport(),
       };
     } catch (error) {
       return {
         success: false,
         mode: this.config.mode,
-        hasFtsSupport: this.store.hasFtsSupport,
+        hasFtsSupport: await this.resolveFtsSupport(),
         error: error instanceof Error ? error.message : String(error),
       };
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -218,6 +218,13 @@ function isExplicitDenyAllScopeFilter(scopeFilter?: string[]): boolean {
   return Array.isArray(scopeFilter) && scopeFilter.length === 0;
 }
 
+function hasFtsIndex(indices: unknown): boolean {
+  return Array.isArray(indices) && indices.some((idx: any) =>
+    idx?.indexType === "FTS" ||
+    (Array.isArray(idx?.columns) && idx.columns.includes("text")),
+  );
+}
+
 function scoreLexicalHit(query: string, candidates: Array<{ text: string; weight: number }>): number {
   const normalizedQuery = normalizeSearchText(query);
   if (!normalizedQuery) return 0;
@@ -418,6 +425,7 @@ export class MemoryStore {
   private table: LanceDB.Table | null = null;
   private initPromise: Promise<void> | null = null;
   private ftsIndexCreated = false;
+  private _lastFtsError: string | null = null;
   private updateQueue: Promise<void> = Promise.resolve();
 
   // Cross-call batch accumulator（Issue #690）
@@ -705,12 +713,14 @@ export class MemoryStore {
     try {
       await this.createFtsIndex(table);
       this.ftsIndexCreated = true;
+      this._lastFtsError = null;
     } catch (err) {
       console.warn(
         "Failed to create FTS index, falling back to vector-only search:",
         err,
       );
       this.ftsIndexCreated = false;
+      this._lastFtsError = err instanceof Error ? err.message : String(err);
     }
 
     this.db = db;
@@ -832,11 +842,8 @@ export class MemoryStore {
     try {
       // Check if FTS index already exists
       const indices = await table.listIndices();
-      const hasFtsIndex = indices?.some(
-        (idx: any) => idx.indexType === "FTS" || idx.columns?.includes("text"),
-      );
 
-      if (!hasFtsIndex) {
+      if (!hasFtsIndex(indices)) {
         // LanceDB @lancedb/lancedb >=0.26: use Index.fts() config
         const lancedb = await loadLanceDB();
         await table.createIndex("text", {
@@ -1415,7 +1422,7 @@ export class MemoryStore {
     // Over-fetch when filtering inactive records to avoid crowding
     const fetchLimit = inactiveFilter ? Math.min(safeLimit * 20, 200) : safeLimit;
 
-    if (!this.ftsIndexCreated) {
+    if (!this.ftsIndexCreated && !(await this.refreshFtsSupportFromTable())) {
       return this.lexicalFallbackSearch(query, safeLimit, scopeFilter, options);
     }
 
@@ -1693,6 +1700,7 @@ export class MemoryStore {
     categoryCounts: Record<string, number>;
   }> {
     await this.ensureInitialized();
+    await this.refreshFtsSupportFromTable();
 
     if (isExplicitDenyAllScopeFilter(scopeFilter)) {
       return {
@@ -1945,11 +1953,29 @@ export class MemoryStore {
     return this.ftsIndexCreated;
   }
 
-  /** Last FTS error for diagnostics */
-  private _lastFtsError: string | null = null;
-
   get lastFtsError(): string | null {
     return this._lastFtsError;
+  }
+
+  private async refreshFtsSupportFromTable(): Promise<boolean> {
+    if (!this.table) return this.ftsIndexCreated;
+
+    try {
+      const indices = await this.table.listIndices();
+      const available = hasFtsIndex(indices);
+      this.ftsIndexCreated = available;
+      if (available) this._lastFtsError = null;
+      return available;
+    } catch (err) {
+      this.ftsIndexCreated = false;
+      this._lastFtsError = err instanceof Error ? err.message : String(err);
+      return false;
+    }
+  }
+
+  async refreshFtsSupport(): Promise<boolean> {
+    await this.ensureInitialized();
+    return this.refreshFtsSupportFromTable();
   }
 
   /** Get FTS index health status */

--- a/test/retriever-graceful-degradation.test.mjs
+++ b/test/retriever-graceful-degradation.test.mjs
@@ -17,7 +17,7 @@ function buildResult(id = "memory-1", text = "test result") {
       category: "other",
       scope: "global",
       importance: 0.7,
-      timestamp: 1700000000000,
+      timestamp: Date.now(),
       metadata: "{}",
     },
     score: 0.9,
@@ -100,6 +100,39 @@ describe("Retriever Graceful Degradation (Promise.allSettled)", () => {
       retriever.getLastDiagnostics()?.bm25ResultCount,
       0,
     );
+  });
+
+  it("refreshes FTS support before choosing the retrieval mode", async () => {
+    let refreshCalls = 0;
+    const { retriever, bm25Queries } = createRetrieverHarness(
+      { rerank: "none", hardMinScore: 0, filterNoise: false },
+      {
+        hasFtsSupport: false,
+        async refreshFtsSupport() {
+          refreshCalls += 1;
+          return true;
+        },
+        async vectorSearch() {
+          return [];
+        },
+        async bm25Search(query) {
+          bm25Queries.push(query);
+          return [buildResult("memory-fts", "literal token recovered through BM25")];
+        },
+      },
+    );
+
+    const results = await retriever.retrieve({
+      query: "literal token",
+      limit: 1,
+      source: "manual",
+    });
+
+    assert.equal(refreshCalls, 1);
+    assert.equal(bm25Queries.length, 1);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].entry.id, "memory-fts");
+    assert.equal(results[0].sources.bm25?.rank, 1);
   });
 
   it("uses vector-only results when BM25 fails", async () => {

--- a/test/store-list-stats-projection-fallback.test.mjs
+++ b/test/store-list-stats-projection-fallback.test.mjs
@@ -5,11 +5,14 @@ import jitiFactory from "jiti";
 const jiti = jitiFactory(import.meta.url, { interopDefault: true });
 const { MemoryStore } = jiti("../src/store.ts");
 
-function makeProjectionEmptyTable(rows) {
+function makeProjectionEmptyTable(rows, getIndices = () => []) {
   const calls = { projected: 0, unprojected: 0 };
 
   return {
     calls,
+    async listIndices() {
+      return getIndices();
+    },
     query() {
       const builder = {
         where() {
@@ -71,5 +74,24 @@ describe("MemoryStore list/stats projection fallback", () => {
 
     assert.equal(fakeTable.calls.projected, 2);
     assert.equal(fakeTable.calls.unprojected, 2);
+  });
+
+  it("refreshes cached FTS support during stats", async () => {
+    let indices = [];
+    const fakeTable = makeProjectionEmptyTable([], () => indices);
+    const store = new MemoryStore({ dbPath: "/unused", vectorDim: 3 });
+    store.table = fakeTable;
+    store.ftsIndexCreated = false;
+
+    assert.equal(store.hasFtsSupport, false);
+
+    indices = [{ indexType: "FTS", columns: ["text"] }];
+
+    assert.deepEqual(await store.stats(), {
+      totalCount: 0,
+      scopeCounts: {},
+      categoryCounts: {},
+    });
+    assert.equal(store.hasFtsSupport, true);
   });
 });


### PR DESCRIPTION
## Summary
- add an explicit MemoryStore FTS support refresh path while keeping the sync getter contract
- refresh FTS support before retrieval mode selection, BM25 fallback, and stats reporting
- add regressions for recall recovering after cached false and stats updating from live listIndices()

Closes #816.

## Validation
- node --test test/retriever-graceful-degradation.test.mjs
- node --test test/store-list-stats-projection-fallback.test.mjs
- npx tsc --noEmit
- node scripts/verify-ci-test-manifest.mjs
- git diff --check