### PR TITLE
add native cosine fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ That's the difference an **AI Memory Assistant** makes — it learns your style,
 
 ## Quick Start
 
-> **CPU Requirement:** Your CPU must support **AVX/AVX2** instructions (Intel Sandy Bridge 2011+ / AMD Bulldozer 2011+). LanceDB's native vector engine requires these — on unsupported CPUs the plugin will crash with `SIGILL` (Illegal Instruction). Check with: `grep -o 'avx[^ ]*' /proc/cpuinfo | head -1` (no output = not supported). See [#419](https://github.com/CortexReach/memory-lancedb-pro/issues/419) for details.
+> **CPU Requirement:** Your CPU must support **AVX** instructions. LanceDB native vector search may require **AVX2** on some Linux x64 builds and can crash AVX-only CPUs with `SIGILL`; set `retrieval.disableNativeCosine: true` or `MEMORY_LANCEDB_DISABLE_NATIVE_COSINE=1` to use a scoped row scan plus JavaScript cosine ranking. Check CPU flags with: `grep -o 'avx[^ ]*' /proc/cpuinfo | head -1` (no output = not supported). See [#419](https://github.com/CortexReach/memory-lancedb-pro/issues/419) and [#644](https://github.com/CortexReach/memory-lancedb-pro/issues/644) for details.
 
 ### Option A: One-Click Install Script (Recommended)
 
@@ -478,6 +478,7 @@ Query → BM25 FTS ─────┘
     "recencyHalfLifeDays": 14,
     "recencyWeight": 0.1,
     "filterNoise": true,
+    "disableNativeCosine": false,
     "lengthNormAnchor": 500,
     "hardMinScore": 0.35,
     "timeDecayHalfLifeDays": 60,
@@ -583,6 +584,23 @@ Notes for `llm.auth: "oauth"`:
 - You can set `llm.oauthPath` if you want to store that file somewhere else.
 - `auth login` snapshots the previous api-key `llm` config next to the OAuth file, and `auth logout` restores that snapshot when available.
 - Switching from `api-key` to `oauth` does not automatically carry over `llm.baseURL`. Set it manually in OAuth mode only when you intentionally want a custom ChatGPT/Codex-compatible backend.
+
+</details>
+
+<details>
+<summary><strong>Legacy CPU Fallback</strong></summary>
+
+If an AVX-only Linux x64 host crashes inside LanceDB native vector search with `SIGILL`, disable native cosine and let memory-lancedb-pro scan scoped rows and rank them in JavaScript:
+
+```json
+{
+  "retrieval": {
+    "disableNativeCosine": true
+  }
+}
+```
+
+You can also set `MEMORY_LANCEDB_DISABLE_NATIVE_COSINE=1` for the same behavior.
 
 </details>
 

--- a/index.ts
+++ b/index.ts
@@ -169,6 +169,8 @@ interface PluginConfig {
     timeDecayHalfLifeDays?: number;
     reinforcementFactor?: number;
     maxHalfLifeMultiplier?: number;
+    /** Disable LanceDB native vector search and rank scanned rows with JS cosine. */
+    disableNativeCosine?: boolean;
   };
   decay?: {
     recencyHalfLifeDays?: number;
@@ -2012,6 +2014,7 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
   const store = new MemoryStore({
     dbPath: resolvedDbPath,
     vectorDim,
+    disableNativeCosine: config.retrieval?.disableNativeCosine === true,
     onStoragePathWarning: (message) => api.logger.warn(message),
   });
   const embedder = createEmbedder({

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -503,6 +503,11 @@
             "default": true,
             "description": "Filter out noise memories (agent denials, meta-questions, boilerplate)"
           },
+          "disableNativeCosine": {
+            "type": "boolean",
+            "default": false,
+            "description": "Disable LanceDB native vector search and rank scoped rows with JavaScript cosine. Enable on AVX-only Linux x64 CPUs that crash with SIGILL in LanceDB native vector search."
+          },
           "lengthNormAnchor": {
             "type": "integer",
             "minimum": 0,
@@ -1695,6 +1700,11 @@
     "retrieval.candidatePoolSize": {
       "label": "Candidate Pool Size",
       "help": "Number of candidates to fetch before fusion and reranking",
+      "advanced": true
+    },
+    "retrieval.disableNativeCosine": {
+      "label": "Disable Native Cosine",
+      "help": "Use a scoped row scan plus JS cosine ranking instead of LanceDB native vector search. Enable on AVX-only Linux x64 CPUs that crash with SIGILL.",
       "advanced": true
     },
     "retrieval.lengthNormAnchor": {

--- a/src/store.ts
+++ b/src/store.ts
@@ -50,6 +50,8 @@ export interface MemorySearchResult {
 export interface StoreConfig {
   dbPath: string;
   vectorDim: number;
+  /** Disable LanceDB native vector search and rank scanned rows with JS cosine. */
+  disableNativeCosine?: boolean;
   onStoragePathWarning?: (message: string) => void;
 }
 
@@ -232,6 +234,42 @@ function scoreLexicalHit(query: string, candidates: Array<{ text: string; weight
   }
 
   return score;
+}
+
+function parseBooleanEnvFlag(value: string | undefined): boolean {
+  return /^(1|true|yes|on)$/i.test((value ?? "").trim());
+}
+
+function toNumberVector(value: unknown): number[] {
+  if (!value || typeof value !== "object") return [];
+
+  const maybeArrayLike = value as ArrayLike<unknown>;
+  if (typeof maybeArrayLike.length !== "number" || maybeArrayLike.length < 0) {
+    return [];
+  }
+
+  const vector = Array.from(maybeArrayLike, (item) => Number(item));
+  return vector.every(Number.isFinite) ? vector : [];
+}
+
+function cosineSimilarity(left: number[], right: number[]): number {
+  if (!Array.isArray(left) || left.length === 0 || right.length !== left.length) return 0;
+
+  let dot = 0;
+  let leftNorm = 0;
+  let rightNorm = 0;
+  for (let index = 0; index < left.length; index++) {
+    const l = Number(left[index]);
+    const r = Number(right[index]);
+    if (!Number.isFinite(l) || !Number.isFinite(r)) return 0;
+    dot += l * r;
+    leftNorm += l * l;
+    rightNorm += r * r;
+  }
+
+  const denominator = Math.sqrt(leftNorm) * Math.sqrt(rightNorm);
+  if (denominator <= 0) return 0;
+  return Math.max(-1, Math.min(1, dot / denominator));
 }
 
 // ============================================================================
@@ -419,6 +457,7 @@ export class MemoryStore {
   private initPromise: Promise<void> | null = null;
   private ftsIndexCreated = false;
   private updateQueue: Promise<void> = Promise.resolve();
+  private nativeCosineFallbackLogged = false;
 
   // Cross-call batch accumulator（Issue #690）
   // 多個 concurrent bulkStore() 會先累積在這裡，每 100ms flush 一次，
@@ -448,12 +487,15 @@ export class MemoryStore {
   private static readonly MAX_PENDING_BATCH_SIZE = 1000;
 
   private readonly config: StoreConfig;
+  private readonly disableNativeCosine: boolean;
 
   constructor(config: StoreConfig) {
+    const envDisablesNativeCosine = parseBooleanEnvFlag(process.env.MEMORY_LANCEDB_DISABLE_NATIVE_COSINE);
     this.config = {
       ...config,
       dbPath: normalizeStoragePath(config.dbPath),
     };
+    this.disableNativeCosine = config.disableNativeCosine === true || envDisablesNativeCosine;
   }
 
   private async runWithFileLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -1346,7 +1388,24 @@ export class MemoryStore {
     const overFetchMultiplier = inactiveFilter ? 20 : 10;
     const fetchLimit = Math.min(safeLimit * overFetchMultiplier, 200);
 
-    let query = this.table!.vectorSearch(vector).distanceType('cosine').limit(fetchLimit);
+    if (this.disableNativeCosine && !this.nativeCosineFallbackLogged) {
+      console.warn(
+        "memory-lancedb-pro: LanceDB native vector cosine disabled; scanning candidates and using JS cosine rerank fallback",
+      );
+      this.nativeCosineFallbackLogged = true;
+    }
+    let query = this.disableNativeCosine
+      ? this.table!.query().select([
+        "id",
+        "text",
+        "vector",
+        "category",
+        "scope",
+        "importance",
+        "timestamp",
+        "metadata",
+      ])
+      : this.table!.vectorSearch(vector).distanceType("cosine").limit(fetchLimit);
 
     // Apply scope filter if provided
     if (scopeFilter && scopeFilter.length > 0) {
@@ -1360,7 +1419,11 @@ export class MemoryStore {
     const mapped: MemorySearchResult[] = [];
 
     for (const row of results) {
-      const distance = Number(row._distance ?? 0);
+      const rowVector = toNumberVector(row.vector);
+      if (rowVector.length !== vector.length) continue;
+      const distance = this.disableNativeCosine
+        ? 1 - cosineSimilarity(vector, rowVector)
+        : Number(row._distance ?? 0);
       const score = 1 / (1 + distance);
 
       if (score < minScore) continue;
@@ -1379,7 +1442,7 @@ export class MemoryStore {
       const entry: MemoryEntry = {
         id: row.id as string,
         text: row.text as string,
-        vector: row.vector as number[],
+        vector: rowVector,
         category: row.category as MemoryEntry["category"],
         scope: rowScope,
         importance: Number(row.importance),
@@ -1394,10 +1457,14 @@ export class MemoryStore {
 
       mapped.push({ entry, score });
 
-      if (mapped.length >= safeLimit) break;
+      if (!this.disableNativeCosine && mapped.length >= safeLimit) break;
     }
 
-    return mapped;
+    if (this.disableNativeCosine) {
+      mapped.sort((a, b) => b.score - a.score);
+    }
+
+    return mapped.slice(0, safeLimit);
   }
 
   async bm25Search(

--- a/test/vector-search-cosine.test.mjs
+++ b/test/vector-search-cosine.test.mjs
@@ -82,6 +82,69 @@ try {
     assert.ok(l2Score < 0.3, `L2 score ${l2Score.toFixed(4)} should be below minScore=0.3`);
     console.log(`  ✅ L2 score = ${l2Score.toFixed(4)} (would drop all results, confirming cosine is needed)`);
 
+    // Test 5: Legacy CPU fallback skips native vector search and reranks with JS cosine.
+    console.log("Test 5: Native cosine fallback reranks candidates in JavaScript...");
+    const fallbackStore = new MemoryStore({
+        dbPath: path.join(workDir, "unused-fallback-db"),
+        vectorDim: 2,
+        disableNativeCosine: true,
+    });
+    const calls = [];
+    const fakeRows = [
+        {
+            id: "orthogonal",
+            text: "orthogonal fallback memory",
+            vector: { 0: 0, 1: 1, length: 2 },
+            category: "fact",
+            scope: "test",
+            importance: 0.5,
+            timestamp: Date.now(),
+            metadata: "{}",
+            _distance: 0,
+        },
+        {
+            id: "similar",
+            text: "similar fallback memory",
+            vector: { 0: 1, 1: 0, length: 2 },
+            category: "fact",
+            scope: "test",
+            importance: 0.5,
+            timestamp: Date.now(),
+            metadata: "{}",
+            _distance: 999,
+        },
+    ];
+    const fakeScanQuery = {
+        select(columns) {
+            calls.push(`select:${columns.join(",")}`);
+            return this;
+        },
+        where(value) {
+            calls.push(`where:${value}`);
+            return this;
+        },
+        async toArray() {
+            return fakeRows;
+        },
+    };
+    fallbackStore.table = {
+        vectorSearch() {
+            calls.push("vectorSearch");
+            throw new Error("native vector search should not be called");
+        },
+        query() {
+            calls.push("query");
+            return fakeScanQuery;
+        },
+    };
+
+    const fallbackResults = await fallbackStore.vectorSearch([1, 0], 2, 0, ["test"]);
+    assert.equal(calls.includes("vectorSearch"), false, "fallback must not call LanceDB native vector search");
+    assert.equal(fallbackResults[0].entry.id, "similar", "JS cosine rerank should move the similar row first");
+    assert.deepEqual(fallbackResults[0].entry.vector, [1, 0], "fallback should normalize LanceDB vector-like values");
+    assert.ok(fallbackResults[0].score > fallbackResults[1].score, "similar row should score above orthogonal row");
+    console.log("  ✅ Native cosine fallback skipped vectorSearch and reranked by JS cosine");
+
     console.log("\n=== All vector-search-cosine tests passed! ===");
 
 } finally {


### PR DESCRIPTION
## Summary
- add retrieval.disableNativeCosine and MEMORY_LANCEDB_DISABLE_NATIVE_COSINE as escape hatches for AVX-only hosts
- skip LanceDB distanceType("cosine") when disabled, then score and sort vector candidates with JavaScript cosine
- document the AVX-only SIGILL fallback and expose it in the plugin manifest
- extend the vector-search cosine regression to prove the fallback avoids native cosine and reranks correctly

Closes #644.

## Validation
- node test/vector-search-cosine.test.mjs
- npx tsc --noEmit
- node scripts/verify-ci-test-manifest.mjs
- git diff --check