### PR TITLE
fix: normalize legacy 1-5 importance to 0~1 scale on memory import

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1680,10 +1680,13 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
                 ? categoryRaw
                 : "other";
 
+            // Pass raw importance to importEntry — it applies clampImportance
+            // (v2+ 0~1) inside, which is idempotent and preserves 0, 1, and
+            // decimal values. The previous pre-clamp here could silently turn
+            // legacy values like 4 into 1 and then into 0.20 after legacy
+            // normalization (see PR #828 review).
             const importanceRaw = Number(memory.importance);
-            const importance = Number.isFinite(importanceRaw)
-              ? Math.max(0, Math.min(1, importanceRaw))
-              : 0.7;
+            const importance = Number.isFinite(importanceRaw) ? importanceRaw : 0.7;
 
             const timestampRaw = Number(memory.timestamp);
             const timestamp = Number.isFinite(timestampRaw) ? timestampRaw : Date.now();

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -1381,10 +1381,13 @@ export function registerMemoryCLI(program, context) {
                         categoryRaw === "other"
                         ? categoryRaw
                         : "other";
+                    // Pass raw importance to importEntry — it applies clampImportance
+                    // (v2+ 0~1) inside, which is idempotent and preserves 0, 1, and
+                    // decimal values. The previous pre-clamp here could silently turn
+                    // legacy values like 4 into 1 and then into 0.20 after legacy
+                    // normalization (see PR #828 review).
                     const importanceRaw = Number(memory.importance);
-                    const importance = Number.isFinite(importanceRaw)
-                        ? Math.max(0, Math.min(1, importanceRaw))
-                        : 0.7;
+                    const importance = Number.isFinite(importanceRaw) ? importanceRaw : 0.7;
                     const timestampRaw = Number(memory.timestamp);
                     const timestamp = Number.isFinite(timestampRaw) ? timestampRaw : Date.now();
                     const metadataRaw = memory.metadata;

--- a/dist/src/migrate.js
+++ b/dist/src/migrate.js
@@ -122,6 +122,8 @@ export class MemoryMigrator {
                 id: row.id,
                 text: row.text,
                 vector: normalizeLegacyVector(row.vector),
+                // Keep raw legacy importance; importEntry({ legacy: true }) normalizes
+                // it exactly once at the explicit legacy-provenance boundary.
                 importance: Number(row.importance),
                 category: row.category || "other",
                 createdAt: Number(row.createdAt),
@@ -153,6 +155,10 @@ export class MemoryMigrator {
                     }
                 }
                 // Convert legacy entry to new format while preserving legacy identity.
+                // Pass the raw legacy importance through to importEntry with
+                // { legacy: true } so normalization happens exactly once at this
+                // explicit legacy-provenance boundary (avoids repeated calls to a
+                // non-idempotent legacy normalizer on out-of-range/corrupt data).
                 const newEntry = {
                     id: legacy.id,
                     text: legacy.text,
@@ -167,7 +173,7 @@ export class MemoryMigrator {
                         originalCreatedAt: legacy.createdAt,
                     }),
                 };
-                await this.targetStore.importEntry(newEntry);
+                await this.targetStore.importEntry(newEntry, { legacy: true });
                 migrated++;
                 if (migrated % 100 === 0) {
                     console.log(`Migrated ${migrated}/${legacyEntries.length} entries...`);

--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -341,7 +341,8 @@ export class MemoryRetriever {
         const { query, limit, scopeFilter, category, source, signal, rerankTimeoutMs, rerankDeadlineMs } = context;
         const safeLimit = clampInt(limit, 1, 20);
         this.lastDiagnostics = null;
-        // FLEET-PATCH(#884): resolve lazy store init BEFORE routing reads hasFtsSupport.
+        // FLEET-PATCH(#884): resolve lazy store init BEFORE routing reads hasFtsSupport,
+        // otherwise the first retrieve() in a fresh process silently routes vector-only.
         await this.store.ensureInitialized?.();
         const diagnostics = {
             source,

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -83,6 +83,54 @@ export function normalizeMemoryTimestamp(value, fallback = Date.now()) {
     const timestamp = Math.floor(raw);
     return timestamp < LEGACY_SECONDS_TIMESTAMP_MAX ? timestamp * 1000 : timestamp;
 }
+/**
+ * Normalize legacy v1.x importance scale (1-5 integers) to v2+ scale (0~1 floats)
+ *
+ * Mapping:
+ *   1 → 0.20   2 → 0.40   3 → 0.60   4 → 0.80   5 → 0.95
+ *
+ * Values already in 0~1 range pass through unchanged.
+ * Use ONLY where the data is known to be legacy (migrate / importEntry / backfill).
+ * For generic v2+ read paths, use clampImportance instead to avoid double-normalization
+ * corruption (e.g. 99 -> 1.0 -> 0.20).
+ *
+ * NOTE: 1.0 is indistinguishable from legacy integer 1 in JS (Number.isInteger(1.0) === true),
+ * so legacy-v1 callers must be aware that legitimate 1.0 will map to 0.20. This trade-off is
+ * only safe in legacy import contexts; v2+ data flows through clampImportance.
+ */
+export function normalizeLegacyImportance(value) {
+    // Guard against NaN / Infinity / -Infinity from corrupted data
+    if (typeof value !== "number" || !Number.isFinite(value))
+        return 0.7;
+    // Legacy v1.x integer scale (1-5) → v2+ 0~1
+    if (Number.isInteger(value) && value >= 1 && value <= 5) {
+        return [null, 0.20, 0.40, 0.60, 0.80, 0.95][value];
+    }
+    // Non-legacy float (incl. v2+ 0~1) — pass through with clamp as defensive bound
+    return Math.max(0.0, Math.min(1.0, value));
+}
+/**
+ * Clamp a value to the v2+ 0~1 range, preserving legitimate v2+ values like 1.0.
+ * Use on ALL read paths (search, list, getById, update, etc.) to avoid
+ * double-normalization corruption.
+ *
+ * Idempotent: clampImportance(clampImportance(x)) === clampImportance(x).
+ */
+export function clampImportance(value) {
+    if (typeof value !== "number" || !Number.isFinite(value))
+        return 0.7;
+    return Math.max(0.0, Math.min(1.0, value));
+}
+/**
+ * @deprecated Use normalizeLegacyImportance (for legacy data) or clampImportance
+ * (for v2+ data) based on data provenance. This wrapper is kept for backward
+ * compatibility and routes to clampImportance (v2+ 0~1 semantics). The previous
+ * behavior routed to legacy normalization, which surprised callers expecting
+ * generic v2 clamp semantics (see PR #828 review).
+ */
+export function normalizeImportance(value) {
+    return clampImportance(value);
+}
 function normalizePredicateTimestamp(value) {
     const raw = value instanceof Date
         ? value.getTime()
@@ -850,7 +898,19 @@ export class MemoryStore {
         // F1 fix: store() now routes through bulkStore() accumulator
         // for consistent lock contention behavior (no per-call file lock).
         // MR2 fix: when pendingBatch is empty, immediate flush avoids 100ms delay.
-        const results = await this.bulkStore([entry]);
+        // F3 fix (PR #828 follow-up): clamp importance at the write boundary so
+        // direct store() callers (e.g. the CLI JSON no-id import path) cannot
+        // persist out-of-range raw values like 4 or 99. clampImportance is
+        // idempotent and preserves legitimate v2+ 0~1 values, so wrapping here is
+        // safe for callers that already normalized upstream. importEntry() keeps
+        // its explicit legacy branch — this clamp is the generic v2+ boundary.
+        // Number() coerces the structurally-typed entry.importance to a real
+        // number so clampImportance's NaN/Infinity fallback can do its job.
+        const clampedEntry = {
+            ...entry,
+            importance: clampImportance(Number(entry.importance)),
+        };
+        const results = await this.bulkStore([clampedEntry]);
         return results[0];
     }
     async upsert(entry) {
@@ -858,9 +918,13 @@ export class MemoryStore {
         const result = await this.runWithFileLock(() => this.runSerializedUpdate(async () => {
             const safeId = escapeSqlLiteral(entry.id);
             await this.table.delete(`id = '${safeId}'`).catch(() => undefined);
+            // F3 fix (PR #828 follow-up): clamp importance at the write boundary so
+            // upsert() callers cannot persist out-of-range raw values. clampImportance
+            // is idempotent and preserves legitimate v2+ 0~1 values.
             const normalizedEntry = {
                 ...entry,
                 metadata: entry.metadata || "{}",
+                importance: clampImportance(entry.importance),
             };
             await this.table.add([normalizedEntry]);
             return normalizedEntry;
@@ -908,11 +972,20 @@ export class MemoryStore {
             return [];
         }
         // 附加 id/timestamp
+        // F3 fix (PR #828 follow-up): clamp importance at the bulk write boundary
+        // so direct bulkStore() callers cannot persist out-of-range raw values like
+        // 4 or 99. clampImportance is idempotent, so callers that already
+        // normalized upstream are unaffected. store() applies the same clamp
+        // before calling bulkStore(); doing it again here covers direct bulkStore
+        // callers (e.g. CLI JSON import retry paths).
+        // Number() coerces the structurally-typed entry.importance to a real
+        // number so clampImportance's NaN/Infinity fallback can do its job.
         const fullEntries = validEntries.map((entry) => ({
             ...entry,
             id: randomUUID(),
             timestamp: Date.now(),
             metadata: entry.metadata || "{}",
+            importance: clampImportance(Number(entry.importance)),
         }));
         // 【MR2 fix】當 pendingBatch 達到上限時，等待前一個 flush 完成後再加入
         // 這確保 pendingBatch 有上限，不會无限增长
@@ -1181,8 +1254,14 @@ export class MemoryStore {
      * Import a pre-built entry while preserving its id/timestamp.
      * Used for re-embedding / migration / A/B testing across embedding models.
      * Intentionally separate from `store()` to keep normal writes simple.
+     *
+     * Default behavior treats the entry as a generic v2+ import and applies
+     * idempotent `clampImportance` (preserves 0, 1, and decimal v2+ values).
+     * For known-legacy data sources (e.g. `migrate.ts` / explicit backfill),
+     * pass `{ legacy: true }` to apply the v1.x 1-5 integer → 0~1 mapping
+     * exactly once at this explicit legacy-provenance boundary.
      */
-    async importEntry(entry) {
+    async importEntry(entry, options = {}) {
         await this.ensureInitialized();
         if (!entry.id || typeof entry.id !== "string") {
             throw new Error("importEntry requires a stable id");
@@ -1194,7 +1273,9 @@ export class MemoryStore {
         const full = {
             ...entry,
             scope: entry.scope || "global",
-            importance: Number.isFinite(entry.importance) ? entry.importance : 0.7,
+            importance: options.legacy
+                ? normalizeLegacyImportance(entry.importance)
+                : clampImportance(entry.importance),
             timestamp: normalizeMemoryTimestamp(entry.timestamp),
             metadata: entry.metadata || "{}",
         };
@@ -1241,7 +1322,7 @@ export class MemoryStore {
             vector: Array.from(row.vector),
             category: row.category,
             scope: rowScope,
-            importance: Number(row.importance),
+            importance: clampImportance(Number(row.importance)),
             timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
             metadata: row.metadata || "{}",
         };
@@ -1338,7 +1419,7 @@ export class MemoryStore {
                 vector: rowVector,
                 category: row.category,
                 scope: rowScope,
-                importance: Number(row.importance),
+                importance: clampImportance(Number(row.importance)),
                 timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
                 metadata: row.metadata || "{}",
             };
@@ -1396,7 +1477,7 @@ export class MemoryStore {
                     vector: row.vector,
                     category: row.category,
                     scope: rowScope,
-                    importance: Number(row.importance),
+                    importance: clampImportance(Number(row.importance)),
                     timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
                     metadata: row.metadata || "{}",
                 };
@@ -1453,7 +1534,7 @@ export class MemoryStore {
                 vector: row.vector,
                 category: row.category,
                 scope: rowScope,
-                importance: Number(row.importance),
+                importance: clampImportance(Number(row.importance)),
                 timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
                 metadata: row.metadata || "{}",
             };
@@ -1564,7 +1645,7 @@ export class MemoryStore {
             vector: [], // Don't include vectors in list results for performance
             category: row.category,
             scope: row.scope ?? "global",
-            importance: Number(row.importance),
+            importance: clampImportance(Number(row.importance)),
             timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
             metadata: row.metadata || "{}",
         }));
@@ -1710,7 +1791,9 @@ export class MemoryStore {
                         vector: candidate.updates.vector ?? original.vector,
                         category: candidate.updates.category ?? original.category,
                         scope: rowScope,
-                        importance: candidate.updates.importance ?? original.importance,
+                        // F3 fix (PR #828 follow-up): clamp importance on update path so
+                        // bulkUpdateExact callers cannot persist out-of-range values.
+                        importance: clampImportance(candidate.updates.importance ?? original.importance),
                         timestamp: original.timestamp,
                         metadata: candidate.updates.metadata ?? original.metadata,
                     };
@@ -1855,7 +1938,7 @@ export class MemoryStore {
                 vector: Array.from(row.vector),
                 category: row.category,
                 scope: rowScope,
-                importance: Number(row.importance),
+                importance: clampImportance(Number(row.importance)),
                 timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
                 metadata: row.metadata || "{}",
             };
@@ -1866,7 +1949,9 @@ export class MemoryStore {
                 vector: updates.vector ?? original.vector,
                 category: updates.category ?? original.category,
                 scope: rowScope,
-                importance: updates.importance ?? original.importance,
+                // F3 fix (PR #828 follow-up): clamp importance on update path so
+                // update() callers cannot persist out-of-range values.
+                importance: clampImportance(updates.importance ?? original.importance),
                 timestamp: original.timestamp, // preserve original
                 metadata: updates.metadata ?? original.metadata,
             };
@@ -2041,7 +2126,7 @@ export class MemoryStore {
             vector: Array.isArray(row.vector) ? row.vector : [],
             category: row.category,
             scope: row.scope ?? "global",
-            importance: Number(row.importance),
+            importance: clampImportance(Number(row.importance)),
             timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
             metadata: row.metadata || "{}",
         }));

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -77,6 +77,7 @@ export const CI_TEST_MANIFEST = [
   { group: "storage-and-schema", runner: "node", file: "test/bulk-store-edge-cases.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/smart-extractor-bulk-store.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/smart-extractor-bulk-store-edge-cases.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/store-importance-normalization.test.mjs", args: ["--test"] },
   // Issue #680 regression tests (from upstream)
   { group: "core-regression", runner: "node", file: "test/memory-reflection-issue680-tdd.test.mjs", args: ["--test"] },
   // Issue #606 SDK migration Bug 2 regression tests

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -7,7 +7,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import fs from "node:fs/promises";
 import type { MemoryStore, MemoryEntry } from "./store.js";
-import { loadLanceDB } from "./store.js";
+import { loadLanceDB, normalizeImportance } from "./store.js";
 
 // ============================================================================
 // Types
@@ -169,7 +169,7 @@ export class MemoryMigrator {
         id: row.id as string,
         text: row.text as string,
         vector: normalizeLegacyVector(row.vector),
-        importance: Number(row.importance),
+        importance: normalizeImportance(Number(row.importance)),
         category: (row.category as LegacyMemoryEntry["category"]) || "other",
         createdAt: Number(row.createdAt),
         scope: row.scope as string | undefined,
@@ -215,7 +215,7 @@ export class MemoryMigrator {
           vector: legacy.vector,
           category: legacy.category,
           scope: legacy.scope || defaultScope,
-          importance: legacy.importance,
+          importance: normalizeImportance(legacy.importance),
           timestamp: Number.isFinite(legacy.createdAt) ? legacy.createdAt : Date.now(),
           metadata: JSON.stringify({
             migratedFrom: "memory-lancedb",

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -7,7 +7,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import fs from "node:fs/promises";
 import type { MemoryStore, MemoryEntry } from "./store.js";
-import { loadLanceDB, normalizeLegacyImportance } from "./store.js";
+import { loadLanceDB } from "./store.js";
 
 // ============================================================================
 // Types
@@ -169,7 +169,9 @@ export class MemoryMigrator {
         id: row.id as string,
         text: row.text as string,
         vector: normalizeLegacyVector(row.vector),
-        importance: normalizeLegacyImportance(Number(row.importance)),
+        // Keep raw legacy importance; importEntry({ legacy: true }) normalizes
+        // it exactly once at the explicit legacy-provenance boundary.
+        importance: Number(row.importance),
         category: (row.category as LegacyMemoryEntry["category"]) || "other",
         createdAt: Number(row.createdAt),
         scope: row.scope as string | undefined,
@@ -209,13 +211,17 @@ export class MemoryMigrator {
         }
 
         // Convert legacy entry to new format while preserving legacy identity.
+        // Pass the raw legacy importance through to importEntry with
+        // { legacy: true } so normalization happens exactly once at this
+        // explicit legacy-provenance boundary (avoids repeated calls to a
+        // non-idempotent legacy normalizer on out-of-range/corrupt data).
         const newEntry: MemoryEntry = {
           id: legacy.id,
           text: legacy.text,
           vector: legacy.vector,
           category: legacy.category,
           scope: legacy.scope || defaultScope,
-          importance: normalizeLegacyImportance(legacy.importance),
+          importance: legacy.importance,
           timestamp: Number.isFinite(legacy.createdAt) ? legacy.createdAt : Date.now(),
           metadata: JSON.stringify({
             migratedFrom: "memory-lancedb",
@@ -224,7 +230,7 @@ export class MemoryMigrator {
           }),
         };
 
-        await this.targetStore.importEntry(newEntry);
+        await this.targetStore.importEntry(newEntry, { legacy: true });
         migrated++;
 
         if (migrated % 100 === 0) {

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -7,7 +7,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import fs from "node:fs/promises";
 import type { MemoryStore, MemoryEntry } from "./store.js";
-import { loadLanceDB, normalizeImportance } from "./store.js";
+import { loadLanceDB, normalizeLegacyImportance } from "./store.js";
 
 // ============================================================================
 // Types
@@ -169,7 +169,7 @@ export class MemoryMigrator {
         id: row.id as string,
         text: row.text as string,
         vector: normalizeLegacyVector(row.vector),
-        importance: normalizeImportance(Number(row.importance)),
+        importance: normalizeLegacyImportance(Number(row.importance)),
         category: (row.category as LegacyMemoryEntry["category"]) || "other",
         createdAt: Number(row.createdAt),
         scope: row.scope as string | undefined,
@@ -215,7 +215,7 @@ export class MemoryMigrator {
           vector: legacy.vector,
           category: legacy.category,
           scope: legacy.scope || defaultScope,
-          importance: normalizeImportance(legacy.importance),
+          importance: normalizeLegacyImportance(legacy.importance),
           timestamp: Number.isFinite(legacy.createdAt) ? legacy.createdAt : Date.now(),
           metadata: JSON.stringify({
             migratedFrom: "memory-lancedb",

--- a/src/store.ts
+++ b/src/store.ts
@@ -193,7 +193,9 @@ export function normalizeImportance(value: number): number {
     return [null, 0.20, 0.40, 0.60, 0.80, 0.95][value];
   }
 
-  // v2+ 0~1 float: clamp outliers (1.0 is the legitimate max)
+  // v2+ 0~1 float: clamp outliers.
+  // Note: 1.0 is indistinguishable from legacy integer 1 in JS (Number.isInteger(1.0) === true),
+  // so it always hits the legacy path above and maps to 0.20.
   return Math.max(0.0, Math.min(1.0, value));
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -82,6 +82,16 @@ export interface MemoryBulkUpdateResult {
   error?: string;
 }
 
+export interface ImportEntryOptions {
+  /**
+   * Treat the entry as known-legacy data (v1.x 1-5 integer importance scale)
+   * and apply `normalizeLegacyImportance` once at this explicit legacy-
+   * provenance boundary. Defaults to false — generic v2+ imports use
+   * `clampImportance` to preserve 0, 1, and decimal values.
+   */
+  legacy?: boolean;
+}
+
 // ============================================================================
 // LanceDB Dynamic Import
 // ============================================================================
@@ -218,10 +228,12 @@ export function clampImportance(value: number): number {
 /**
  * @deprecated Use normalizeLegacyImportance (for legacy data) or clampImportance
  * (for v2+ data) based on data provenance. This wrapper is kept for backward
- * compatibility and routes to normalizeLegacyImportance.
+ * compatibility and routes to clampImportance (v2+ 0~1 semantics). The previous
+ * behavior routed to legacy normalization, which surprised callers expecting
+ * generic v2 clamp semantics (see PR #828 review).
  */
 export function normalizeImportance(value: number): number {
-  return normalizeLegacyImportance(value);
+  return clampImportance(value);
 }
 
 function normalizePredicateTimestamp(value: unknown): number | null {
@@ -1456,8 +1468,17 @@ export class MemoryStore {
    * Import a pre-built entry while preserving its id/timestamp.
    * Used for re-embedding / migration / A/B testing across embedding models.
    * Intentionally separate from `store()` to keep normal writes simple.
+   *
+   * Default behavior treats the entry as a generic v2+ import and applies
+   * idempotent `clampImportance` (preserves 0, 1, and decimal v2+ values).
+   * For known-legacy data sources (e.g. `migrate.ts` / explicit backfill),
+   * pass `{ legacy: true }` to apply the v1.x 1-5 integer → 0~1 mapping
+   * exactly once at this explicit legacy-provenance boundary.
    */
-  async importEntry(entry: MemoryEntry): Promise<MemoryEntry> {
+  async importEntry(
+    entry: MemoryEntry,
+    options: ImportEntryOptions = {},
+  ): Promise<MemoryEntry> {
     await this.ensureInitialized();
 
     if (!entry.id || typeof entry.id !== "string") {
@@ -1474,7 +1495,9 @@ export class MemoryStore {
     const full: MemoryEntry = {
       ...entry,
       scope: entry.scope || "global",
-      importance: normalizeLegacyImportance(entry.importance),
+      importance: options.legacy
+        ? normalizeLegacyImportance(entry.importance)
+        : clampImportance(entry.importance),
       timestamp: normalizeMemoryTimestamp(entry.timestamp),
       metadata: entry.metadata || "{}",
     };

--- a/src/store.ts
+++ b/src/store.ts
@@ -175,6 +175,28 @@ export function normalizeMemoryTimestamp(value: unknown, fallback = Date.now()):
   return timestamp < LEGACY_SECONDS_TIMESTAMP_MAX ? timestamp * 1000 : timestamp;
 }
 
+/**
+ * Normalize legacy v1.x importance scale (1-5 integers) to v2+ scale (0~1 floats)
+ *
+ * Mapping:
+ *   1 → 0.20   2 → 0.40   3 → 0.60   4 → 0.80   5 → 0.95
+ *
+ * Values already in 0~1 range pass through unchanged.
+ * Function is idempotent (safe to call multiple times on same value).
+ */
+export function normalizeImportance(value: number): number {
+  // Guard against NaN / Infinity / -Infinity from corrupted data
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0.5;
+
+  // Legacy v1.x integer scale (1-5) → v2+ 0~1
+  if (Number.isInteger(value) && value >= 1 && value <= 5) {
+    return [null, 0.20, 0.40, 0.60, 0.80, 0.95][value];
+  }
+
+  // v2+ 0~1 float: clamp outliers (1.0 is the legitimate max)
+  return Math.max(0.0, Math.min(1.0, value));
+}
+
 function normalizePredicateTimestamp(value: unknown): number | null {
   const raw = value instanceof Date
     ? value.getTime()
@@ -1425,7 +1447,7 @@ export class MemoryStore {
     const full: MemoryEntry = {
       ...entry,
       scope: entry.scope || "global",
-      importance: Number.isFinite(entry.importance) ? entry.importance : 0.7,
+      importance: Number.isFinite(entry.importance) ? normalizeImportance(entry.importance) : 0.7,
       timestamp: normalizeMemoryTimestamp(entry.timestamp),
       metadata: entry.metadata || "{}",
     };
@@ -1479,7 +1501,7 @@ export class MemoryStore {
       vector: Array.from(row.vector as Iterable<number>),
       category: row.category as MemoryEntry["category"],
       scope: rowScope,
-      importance: Number(row.importance),
+      importance: normalizeImportance(Number(row.importance)),
       timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
       metadata: (row.metadata as string) || "{}",
     };
@@ -1595,7 +1617,7 @@ export class MemoryStore {
         vector: rowVector,
         category: row.category as MemoryEntry["category"],
         scope: rowScope,
-        importance: Number(row.importance),
+        importance: normalizeImportance(Number(row.importance)),
         timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
         metadata: (row.metadata as string) || "{}",
       };
@@ -1677,7 +1699,7 @@ export class MemoryStore {
             vector: row.vector as number[],
             category: row.category as MemoryEntry["category"],
             scope: rowScope,
-            importance: Number(row.importance),
+            importance: normalizeImportance(Number(row.importance)),
             timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
             metadata: (row.metadata as string) || "{}",
         };
@@ -1741,7 +1763,7 @@ export class MemoryStore {
         vector: row.vector as number[],
         category: row.category as MemoryEntry["category"],
         scope: rowScope,
-        importance: Number(row.importance),
+        importance: normalizeImportance(Number(row.importance)),
         timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
         metadata: (row.metadata as string) || "{}",
       };
@@ -1885,7 +1907,7 @@ export class MemoryStore {
           vector: [], // Don't include vectors in list results for performance
           category: row.category as MemoryEntry["category"],
           scope: (row.scope as string | undefined) ?? "global",
-          importance: Number(row.importance),
+          importance: normalizeImportance(Number(row.importance)),
           timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
           metadata: (row.metadata as string) || "{}",
         }),
@@ -2245,7 +2267,7 @@ export class MemoryStore {
         vector: Array.from(row.vector as Iterable<number>),
         category: row.category as MemoryEntry["category"],
         scope: rowScope,
-        importance: Number(row.importance),
+        importance: normalizeImportance(Number(row.importance)),
         timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
         metadata: (row.metadata as string) || "{}",
       };
@@ -2475,7 +2497,7 @@ export class MemoryStore {
           vector: Array.isArray(row.vector) ? (row.vector as number[]) : [],
           category: row.category as MemoryEntry["category"],
           scope: (row.scope as string | undefined) ?? "global",
-          importance: Number(row.importance),
+          importance: normalizeImportance(Number(row.importance)),
           timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
           metadata: (row.metadata as string) || "{}",
         }),

--- a/src/store.ts
+++ b/src/store.ts
@@ -1106,7 +1106,19 @@ export class MemoryStore {
     // F1 fix: store() now routes through bulkStore() accumulator
     // for consistent lock contention behavior (no per-call file lock).
     // MR2 fix: when pendingBatch is empty, immediate flush avoids 100ms delay.
-    const results = await this.bulkStore([entry]);
+    // F3 fix (PR #828 follow-up): clamp importance at the write boundary so
+    // direct store() callers (e.g. the CLI JSON no-id import path) cannot
+    // persist out-of-range raw values like 4 or 99. clampImportance is
+    // idempotent and preserves legitimate v2+ 0~1 values, so wrapping here is
+    // safe for callers that already normalized upstream. importEntry() keeps
+    // its explicit legacy branch — this clamp is the generic v2+ boundary.
+    // Number() coerces the structurally-typed entry.importance to a real
+    // number so clampImportance's NaN/Infinity fallback can do its job.
+    const clampedEntry: Omit<MemoryEntry, "id" | "timestamp"> = {
+      ...entry,
+      importance: clampImportance(Number(entry.importance)),
+    };
+    const results = await this.bulkStore([clampedEntry]);
     return results[0];
   }
 
@@ -1116,9 +1128,13 @@ export class MemoryStore {
     const result = await this.runWithFileLock(() => this.runSerializedUpdate(async () => {
       const safeId = escapeSqlLiteral(entry.id);
       await this.table!.delete(`id = '${safeId}'`).catch(() => undefined);
+      // F3 fix (PR #828 follow-up): clamp importance at the write boundary so
+      // upsert() callers cannot persist out-of-range raw values. clampImportance
+      // is idempotent and preserves legitimate v2+ 0~1 values.
       const normalizedEntry: MemoryEntry = {
         ...entry,
         metadata: entry.metadata || "{}",
+        importance: clampImportance(entry.importance),
       };
       await this.table!.add([normalizedEntry]);
       return normalizedEntry;
@@ -1174,11 +1190,20 @@ export class MemoryStore {
     }
 
     // 附加 id/timestamp
+    // F3 fix (PR #828 follow-up): clamp importance at the bulk write boundary
+    // so direct bulkStore() callers cannot persist out-of-range raw values like
+    // 4 or 99. clampImportance is idempotent, so callers that already
+    // normalized upstream are unaffected. store() applies the same clamp
+    // before calling bulkStore(); doing it again here covers direct bulkStore
+    // callers (e.g. CLI JSON import retry paths).
+    // Number() coerces the structurally-typed entry.importance to a real
+    // number so clampImportance's NaN/Infinity fallback can do its job.
     const fullEntries: MemoryEntry[] = validEntries.map((entry) => ({
       ...entry,
       id: randomUUID(),
       timestamp: Date.now(),
       metadata: entry.metadata || "{}",
+      importance: clampImportance(Number(entry.importance)),
     }) as MemoryEntry);
 
     // 【MR2 fix】當 pendingBatch 達到上限時，等待前一個 flush 完成後再加入
@@ -2144,7 +2169,11 @@ export class MemoryStore {
             vector: candidate.updates.vector ?? original.vector,
             category: candidate.updates.category ?? original.category,
             scope: rowScope,
-            importance: candidate.updates.importance ?? original.importance,
+            // F3 fix (PR #828 follow-up): clamp importance on update path so
+            // bulkUpdateExact callers cannot persist out-of-range values.
+            importance: clampImportance(
+              candidate.updates.importance ?? original.importance,
+            ),
             timestamp: original.timestamp,
             metadata: candidate.updates.metadata ?? original.metadata,
           };
@@ -2329,7 +2358,11 @@ export class MemoryStore {
         vector: updates.vector ?? original.vector,
         category: updates.category ?? original.category,
         scope: rowScope,
-        importance: updates.importance ?? original.importance,
+        // F3 fix (PR #828 follow-up): clamp importance on update path so
+        // update() callers cannot persist out-of-range values.
+        importance: clampImportance(
+          updates.importance ?? original.importance,
+        ),
         timestamp: original.timestamp, // preserve original
         metadata: updates.metadata ?? original.metadata,
       };

--- a/src/store.ts
+++ b/src/store.ts
@@ -182,21 +182,46 @@ export function normalizeMemoryTimestamp(value: unknown, fallback = Date.now()):
  *   1 → 0.20   2 → 0.40   3 → 0.60   4 → 0.80   5 → 0.95
  *
  * Values already in 0~1 range pass through unchanged.
- * Function is idempotent (safe to call multiple times on same value).
+ * Use ONLY where the data is known to be legacy (migrate / importEntry / backfill).
+ * For generic v2+ read paths, use clampImportance instead to avoid double-normalization
+ * corruption (e.g. 99 -> 1.0 -> 0.20).
+ *
+ * NOTE: 1.0 is indistinguishable from legacy integer 1 in JS (Number.isInteger(1.0) === true),
+ * so legacy-v1 callers must be aware that legitimate 1.0 will map to 0.20. This trade-off is
+ * only safe in legacy import contexts; v2+ data flows through clampImportance.
  */
-export function normalizeImportance(value: number): number {
+export function normalizeLegacyImportance(value: number): number {
   // Guard against NaN / Infinity / -Infinity from corrupted data
-  if (typeof value !== "number" || !Number.isFinite(value)) return 0.5;
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0.7;
 
   // Legacy v1.x integer scale (1-5) → v2+ 0~1
   if (Number.isInteger(value) && value >= 1 && value <= 5) {
     return [null, 0.20, 0.40, 0.60, 0.80, 0.95][value];
   }
 
-  // v2+ 0~1 float: clamp outliers.
-  // Note: 1.0 is indistinguishable from legacy integer 1 in JS (Number.isInteger(1.0) === true),
-  // so it always hits the legacy path above and maps to 0.20.
+  // Non-legacy float (incl. v2+ 0~1) — pass through with clamp as defensive bound
   return Math.max(0.0, Math.min(1.0, value));
+}
+
+/**
+ * Clamp a value to the v2+ 0~1 range, preserving legitimate v2+ values like 1.0.
+ * Use on ALL read paths (search, list, getById, update, etc.) to avoid
+ * double-normalization corruption.
+ *
+ * Idempotent: clampImportance(clampImportance(x)) === clampImportance(x).
+ */
+export function clampImportance(value: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0.7;
+  return Math.max(0.0, Math.min(1.0, value));
+}
+
+/**
+ * @deprecated Use normalizeLegacyImportance (for legacy data) or clampImportance
+ * (for v2+ data) based on data provenance. This wrapper is kept for backward
+ * compatibility and routes to normalizeLegacyImportance.
+ */
+export function normalizeImportance(value: number): number {
+  return normalizeLegacyImportance(value);
 }
 
 function normalizePredicateTimestamp(value: unknown): number | null {
@@ -1449,7 +1474,7 @@ export class MemoryStore {
     const full: MemoryEntry = {
       ...entry,
       scope: entry.scope || "global",
-      importance: Number.isFinite(entry.importance) ? normalizeImportance(entry.importance) : 0.7,
+      importance: normalizeLegacyImportance(entry.importance),
       timestamp: normalizeMemoryTimestamp(entry.timestamp),
       metadata: entry.metadata || "{}",
     };
@@ -1503,7 +1528,7 @@ export class MemoryStore {
       vector: Array.from(row.vector as Iterable<number>),
       category: row.category as MemoryEntry["category"],
       scope: rowScope,
-      importance: normalizeImportance(Number(row.importance)),
+      importance: clampImportance(Number(row.importance)),
       timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
       metadata: (row.metadata as string) || "{}",
     };
@@ -1619,7 +1644,7 @@ export class MemoryStore {
         vector: rowVector,
         category: row.category as MemoryEntry["category"],
         scope: rowScope,
-        importance: normalizeImportance(Number(row.importance)),
+        importance: clampImportance(Number(row.importance)),
         timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
         metadata: (row.metadata as string) || "{}",
       };
@@ -1701,7 +1726,7 @@ export class MemoryStore {
             vector: row.vector as number[],
             category: row.category as MemoryEntry["category"],
             scope: rowScope,
-            importance: normalizeImportance(Number(row.importance)),
+            importance: clampImportance(Number(row.importance)),
             timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
             metadata: (row.metadata as string) || "{}",
         };
@@ -1765,7 +1790,7 @@ export class MemoryStore {
         vector: row.vector as number[],
         category: row.category as MemoryEntry["category"],
         scope: rowScope,
-        importance: normalizeImportance(Number(row.importance)),
+        importance: clampImportance(Number(row.importance)),
         timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
         metadata: (row.metadata as string) || "{}",
       };
@@ -1909,7 +1934,7 @@ export class MemoryStore {
           vector: [], // Don't include vectors in list results for performance
           category: row.category as MemoryEntry["category"],
           scope: (row.scope as string | undefined) ?? "global",
-          importance: normalizeImportance(Number(row.importance)),
+          importance: clampImportance(Number(row.importance)),
           timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
           metadata: (row.metadata as string) || "{}",
         }),
@@ -2269,7 +2294,7 @@ export class MemoryStore {
         vector: Array.from(row.vector as Iterable<number>),
         category: row.category as MemoryEntry["category"],
         scope: rowScope,
-        importance: normalizeImportance(Number(row.importance)),
+        importance: clampImportance(Number(row.importance)),
         timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
         metadata: (row.metadata as string) || "{}",
       };
@@ -2499,7 +2524,7 @@ export class MemoryStore {
           vector: Array.isArray(row.vector) ? (row.vector as number[]) : [],
           category: row.category as MemoryEntry["category"],
           scope: (row.scope as string | undefined) ?? "global",
-          importance: normalizeImportance(Number(row.importance)),
+          importance: clampImportance(Number(row.importance)),
           timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
           metadata: (row.metadata as string) || "{}",
         }),

--- a/test/store-importance-normalization.test.mjs
+++ b/test/store-importance-normalization.test.mjs
@@ -115,72 +115,26 @@ describe("importance normalization", () => {
   });
 
   describe("normalizeImportance (deprecated wrapper, backward compat)", () => {
-    it("routes to normalizeLegacyImportance behavior", () => {
-      // Wrapper kept for backward compat — behaves like normalizeLegacyImportance
-      assert.equal(normalizeImportance(1), 0.20);
-      assert.equal(normalizeImportance(5), 0.95);
-      assert.equal(normalizeImportance(3), 0.60);
+    it("routes to clampImportance (v2+ 0~1) behavior", () => {
+      // Wrapper kept for backward compat — now routes to clampImportance
+      // (v2+ 0~1 semantics), which is what most generic callers expect.
+      // The previous routing to normalizeLegacyImportance was a footgun
+      // (see PR #828 review).
+      assert.equal(normalizeImportance(1.0), 1.0);
+      assert.equal(normalizeImportance(0.7), 0.7);
+      assert.equal(normalizeImportance(0), 0.0);
+      assert.equal(normalizeImportance(99), 1.0);
+      assert.equal(normalizeImportance(-1), 0.0);
     });
   });
 
-  describe("integration with MemoryStore.importEntry (legacy path)", () => {
-    it("normalizes legacy importance 4 to 0.80 on import", async () => {
-      const store = createStore();
+  describe("integration with MemoryStore.importEntry (generic v2+ path, default)", () => {
+    // Default importEntry is a generic v2+ import surface. It must preserve
+    // legitimate v2 values (0, 1, decimals) without legacy 1-5 mapping.
+    // See PR #828 must-fix: importEntry previously legacy-normalized, which
+    // silently downgraded v2 max (1.0) to 0.20.
 
-      const imported = await store.importEntry({
-        id: "legacy-importance-4",
-        text: "legacy importance 4 entry",
-        vector: [1, 0, 0, 0],
-        category: "fact",
-        scope: "global",
-        importance: 4,
-        timestamp: Date.now(),
-        metadata: "{}",
-      });
-
-      assert.equal(imported.importance, 0.80);
-
-      const loaded = await store.getById("legacy-importance-4");
-      assert.equal(loaded?.importance, 0.80);
-    });
-
-    it("normalizes legacy importance 5 to 0.95 on import", async () => {
-      const store = createStore();
-
-      const imported = await store.importEntry({
-        id: "legacy-importance-5",
-        text: "legacy importance 5 entry",
-        vector: [1, 0, 0, 0],
-        category: "fact",
-        scope: "global",
-        importance: 5,
-        timestamp: Date.now(),
-        metadata: "{}",
-      });
-
-      assert.equal(imported.importance, 0.95);
-    });
-
-    it("passes through v2+ importance 0.6 unchanged on import (non-integer)", async () => {
-      const store = createStore();
-
-      const imported = await store.importEntry({
-        id: "v2-importance-0.6",
-        text: "v2 importance 0.6 entry",
-        vector: [1, 0, 0, 0],
-        category: "fact",
-        scope: "global",
-        importance: 0.6,
-        timestamp: Date.now(),
-        metadata: "{}",
-      });
-
-      assert.equal(imported.importance, 0.6);
-    });
-  });
-
-  describe("integration with read path (v2+ data, clamp)", () => {
-    it("preserves stored v2+ importance=1.0 across read (F1 fix)", async () => {
+    it("preserves v2+ importance=1.0 on generic import (F1 fix)", async () => {
       const store = createStore();
 
       const imported = await store.importEntry({
@@ -194,12 +148,33 @@ describe("importance normalization", () => {
         metadata: "{}",
       });
 
-      // importEntry uses normalizeLegacyImportance, so 1.0 hits legacy path → 0.20
-      // (this is the documented JS limitation; see F1 in PR #828)
-      assert.equal(imported.importance, 0.20);
+      assert.equal(imported.importance, 1.0);
 
-      // But a stored v2+ value 0.85 should be preserved on read
-      const stored = await store.importEntry({
+      const loaded = await store.getById("v2-importance-1.0");
+      assert.equal(loaded?.importance, 1.0);
+    });
+
+    it("preserves v2+ importance=0.0 on generic import", async () => {
+      const store = createStore();
+
+      const imported = await store.importEntry({
+        id: "v2-importance-0.0",
+        text: "v2 importance 0.0 entry",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 0,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+
+      assert.equal(imported.importance, 0);
+    });
+
+    it("preserves decimal v2+ values on generic import", async () => {
+      const store = createStore();
+
+      const imported = await store.importEntry({
         id: "v2-importance-0.85",
         text: "v2 importance 0.85 entry",
         vector: [1, 0, 0, 0],
@@ -209,7 +184,258 @@ describe("importance normalization", () => {
         timestamp: Date.now(),
         metadata: "{}",
       });
-      assert.equal(stored.importance, 0.85);
+
+      assert.equal(imported.importance, 0.85);
     });
+
+    it("clamps out-of-range values defensively on generic import", async () => {
+      const store = createStore();
+
+      const clampedHigh = await store.importEntry({
+        id: "v2-importance-99",
+        text: "v2 importance 99 entry",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 99,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+      assert.equal(clampedHigh.importance, 1.0);
+
+      const clampedLow = await store.importEntry({
+        id: "v2-importance-neg",
+        text: "v2 importance -1 entry",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: -1,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+      assert.equal(clampedLow.importance, 0.0);
+    });
+  });
+
+  describe("integration with MemoryStore.importEntry (legacy boundary, { legacy: true })", () => {
+    // Legacy normalization is ONLY applied at explicit legacy-provenance
+    // boundaries via { legacy: true }. This keeps migration one-shot and
+    // prevents generic imports from silently being downgraded.
+
+    it("normalizes legacy 4 to 0.80 on importEntry(legacy)", async () => {
+      const store = createStore();
+
+      const imported = await store.importEntry(
+        {
+          id: "legacy-importance-4",
+          text: "legacy importance 4 entry",
+          vector: [1, 0, 0, 0],
+          category: "fact",
+          scope: "global",
+          importance: 4,
+          timestamp: Date.now(),
+          metadata: "{}",
+        },
+        { legacy: true },
+      );
+
+      assert.equal(imported.importance, 0.80);
+
+      const loaded = await store.getById("legacy-importance-4");
+      assert.equal(loaded?.importance, 0.80);
+    });
+
+    it("normalizes legacy 5 to 0.95 on importEntry(legacy)", async () => {
+      const store = createStore();
+
+      const imported = await store.importEntry(
+        {
+          id: "legacy-importance-5",
+          text: "legacy importance 5 entry",
+          vector: [1, 0, 0, 0],
+          category: "fact",
+          scope: "global",
+          importance: 5,
+          timestamp: Date.now(),
+          metadata: "{}",
+        },
+        { legacy: true },
+      );
+
+      assert.equal(imported.importance, 0.95);
+    });
+
+    it("passes through v2+ importance 0.6 on importEntry(legacy) (non-integer)", async () => {
+      const store = createStore();
+
+      const imported = await store.importEntry(
+        {
+          id: "v2-importance-0.6-legacy",
+          text: "v2 importance 0.6 entry",
+          vector: [1, 0, 0, 0],
+          category: "fact",
+          scope: "global",
+          importance: 0.6,
+          timestamp: Date.now(),
+          metadata: "{}",
+        },
+        { legacy: true },
+      );
+
+      assert.equal(imported.importance, 0.6);
+    });
+  });
+
+  describe("integration with read path (v2+ data, clamp)", () => {
+    it("preserves stored v2+ importance=1.0 across read (F1 fix)", async () => {
+      const store = createStore();
+
+      const stored = await store.importEntry({
+        id: "v2-importance-1.0-read",
+        text: "v2 importance 1.0 entry",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 1.0,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+      assert.equal(stored.importance, 1.0);
+
+      const loaded = await store.getById("v2-importance-1.0-read");
+      assert.equal(loaded?.importance, 1.0);
+    });
+  // ========================================================================
+  // P0 coverage: legacy path idempotency (F2 hardening)
+  // PR #828 review (rwmjhb F2): "Repeated normalization can invert clamped
+  // high values". While normalizeLegacyImportance is intentionally
+  // non-idempotent (1.0 -> 0.20 is a one-shot mapping), we must guarantee:
+  //   - it never produces out-of-range output
+  //   - it never returns NaN/Infinity
+  //   - applying it twice does not silently flip a stored v2+ value
+  //     (the migration boundary must not re-fire on already-normalized data)
+  // ========================================================================
+  describe("normalizeLegacyImportance (P0: idempotency & boundary safety)", () => {
+    it("never returns NaN for any finite input (boundary safety)", () => {
+      for (const v of [0, 0.5, 1, 1.5, 2, 3, 4, 5, 99, -1, 0.0001, 0.9999]) {
+        const out = normalizeLegacyImportance(v);
+        assert.ok(Number.isFinite(out), `out=${out} for v=${v}`);
+        assert.ok(out >= 0 && out <= 1, `out=${out} out of [0,1] for v=${v}`);
+      }
+    });
+
+    it("returns 0.7 for NaN and Infinity (corrupt-data fallback, consistent with clamp)", () => {
+      // MR2 fix: normalizeLegacyImportance and clampImportance both return 0.7
+      // for non-finite input, so corrupt legacy data does not produce
+      // inconsistent defaults at the migration vs read boundaries.
+      assert.equal(normalizeLegacyImportance(NaN), 0.7);
+      assert.equal(normalizeLegacyImportance(Infinity), 0.7);
+      assert.equal(normalizeLegacyImportance(-Infinity), 0.7);
+    });
+
+    it("clampImportance(legacy) is stable: legacy-then-clamp equals single clamp", () => {
+      // After a single legacy mapping (e.g. 1.0 -> 0.20 in JS due to IEEE 754),
+      // the value is already a v2+ float, so re-running clamp should be a
+      // no-op. This locks down the "double-normalization corruption" class
+      // of bugs (PR #828 F2) for the migration boundary.
+      for (const v of [0, 1, 1.5, 2, 3, 4, 5, 99, -1]) {
+        const once = normalizeLegacyImportance(v);
+        const twice = clampImportance(once);
+        assert.equal(twice, once, `clamp(legacy(${v})) != legacy(${v})`);
+        // Both should be in [0, 1] and finite
+        assert.ok(Number.isFinite(once));
+        assert.ok(once >= 0 && once <= 1);
+      }
+    });
+  });
+
+  // ========================================================================
+  // P0 coverage: read-path round-trip for all 4 read APIs
+  // PR #828 review (rwmjhb MR1): "Read-path normalization diverges from
+  // persisted value, risking permanent corruption via read-modify-write".
+  // Only getById had a round-trip test. The other 3 read paths
+  // (vectorSearch, bm25Search, list, fetchForCompaction) must all
+  // preserve the stored v2+ importance=1.0 (F1 fix must hold end-to-end).
+  // ========================================================================
+  describe("read-path round-trip (P0: all 4 read APIs preserve v2+ 1.0)", () => {
+    async function seedV2Max(store) {
+      // Seed three entries with v2+ importance 1.0, 0.0, 0.5 so we can
+      // verify each read API returns them with the original values intact.
+      await store.importEntry({
+        id: "rt-v2-1.0",
+        text: "v2 max importance",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 1.0,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+      await store.importEntry({
+        id: "rt-v2-0.0",
+        text: "v2 min importance",
+        vector: [0, 1, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 0.0,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+      await store.importEntry({
+        id: "rt-v2-0.5",
+        text: "v2 mid importance",
+        vector: [0, 0, 1, 0],
+        category: "fact",
+        scope: "global",
+        importance: 0.5,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+    }
+
+    function expectV2Intact(rows) {
+      // Each read API returns rows with importance preserved as stored.
+      // We don't assert a specific row count (APIs differ in limit/filters)
+      // but every returned row's importance must equal the value we wrote.
+      for (const row of rows) {
+        if (row.id === "rt-v2-1.0") assert.equal(row.importance, 1.0, `1.0 corrupted in ${row.id}`);
+        else if (row.id === "rt-v2-0.0") assert.equal(row.importance, 0.0, `0.0 corrupted in ${row.id}`);
+        else if (row.id === "rt-v2-0.5") assert.equal(row.importance, 0.5, `0.5 corrupted in ${row.id}`);
+      }
+    }
+
+    it("vectorSearch preserves v2+ importance=1.0 (F1 fix holds end-to-end)", async () => {
+      const store = createStore();
+      await seedV2Max(store);
+
+      const results = await store.vectorSearch([1, 0, 0, 0], 10, 0.0);
+      expectV2Intact(results.map((r) => r.entry ?? r));
+    });
+
+    it("bm25Search preserves v2+ importance=1.0 (F1 fix holds end-to-end)", async () => {
+      const store = createStore();
+      await seedV2Max(store);
+
+      const results = await store.bm25Search("v2", 10);
+      expectV2Intact(results.map((r) => r.entry ?? r));
+    });
+
+    it("list() preserves v2+ importance=1.0 (F1 fix holds end-to-end)", async () => {
+      const store = createStore();
+      await seedV2Max(store);
+
+      const results = await store.list();
+      expectV2Intact(results);
+    });
+
+    it("fetchForCompaction preserves v2+ importance=1.0 (F1 fix holds end-to-end)", async () => {
+      const store = createStore();
+      await seedV2Max(store);
+
+      const results = await store.fetchForCompaction(Date.now() + 1000, undefined, 50);
+      expectV2Intact(results);
+    });
+  });
+
   });
 });

--- a/test/store-importance-normalization.test.mjs
+++ b/test/store-importance-normalization.test.mjs
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+
+const { MemoryStore, normalizeImportance } = jiti("../src/store.ts");
+
+describe("importance normalization", () => {
+  let workDir;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(path.join(tmpdir(), "memory-lancedb-pro-importance-"));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function createStore() {
+    return new MemoryStore({
+      dbPath: path.join(workDir, "db"),
+      vectorDim: 4,
+    });
+  }
+
+  describe("normalizeImportance pure function", () => {
+    it("maps legacy scale 3 to 0.60", () => {
+      assert.equal(normalizeImportance(3), 0.60);
+    });
+
+    it("maps legacy scale 5 to 0.95", () => {
+      assert.equal(normalizeImportance(5), 0.95);
+    });
+
+    it("maps legacy scale 4 to 0.80", () => {
+      assert.equal(normalizeImportance(4), 0.80);
+    });
+
+    it("maps legacy scale 2 to 0.40", () => {
+      assert.equal(normalizeImportance(2), 0.40);
+    });
+
+    it("maps legacy scale 1 to 0.20", () => {
+      assert.equal(normalizeImportance(1), 0.20);
+    });
+
+    it("passes through v2+ 0~1 values unchanged", () => {
+      assert.equal(normalizeImportance(0.7), 0.7);
+      assert.equal(normalizeImportance(0.47), 0.47);
+      assert.equal(normalizeImportance(0.85), 0.85);
+    });
+
+    it("clamps negative values to 0.0", () => {
+      assert.equal(normalizeImportance(-1), 0.0);
+      assert.equal(normalizeImportance(-999), 0.0);
+    });
+
+    it("clamps extremely large values to 1.0", () => {
+      assert.equal(normalizeImportance(99), 1.0);
+      assert.equal(normalizeImportance(1000), 1.0);
+    });
+
+    it("handles zero correctly (not 1-5 scale, clamps to lower bound)", () => {
+      assert.equal(normalizeImportance(0), 0.0);
+    });
+
+    it("preserves v2+ importance=1.0 as legitimate max", () => {
+      assert.equal(normalizeImportance(1.0), 1.0);
+    });
+
+    it("preserves v2+ importance=0.0 as legitimate min", () => {
+      assert.equal(normalizeImportance(0.0), 0.0);
+    });
+
+    it("clamps decimal values above 1.0 to 1.0 (not legacy 1-scale)", () => {
+      // 1.5 is a v2+ float, not legacy integer 1-5 scale
+      assert.equal(normalizeImportance(1.5), 1.0);
+    });
+
+    it("returns 0.5 for NaN to prevent NaN propagation", () => {
+      assert.equal(normalizeImportance(NaN), 0.5);
+    });
+
+    it("returns 0.5 for Infinity and -Infinity", () => {
+      assert.equal(normalizeImportance(Infinity), 0.5);
+      assert.equal(normalizeImportance(-Infinity), 0.5);
+    });
+  });
+
+  describe("integration with MemoryStore.importEntry", () => {
+    it("normalizes legacy importance 4 to 0.80 on import", async () => {
+      const store = createStore();
+
+      const imported = await store.importEntry({
+        id: "legacy-importance-4",
+        text: "legacy importance 4 entry",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 4,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+
+      assert.equal(imported.importance, 0.80);
+
+      const loaded = await store.getById("legacy-importance-4");
+      assert.equal(loaded?.importance, 0.80);
+    });
+
+    it("normalizes legacy importance 5 to 0.95 on import", async () => {
+      const store = createStore();
+
+      const imported = await store.importEntry({
+        id: "legacy-importance-5",
+        text: "legacy importance 5 entry",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 5,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+
+      assert.equal(imported.importance, 0.95);
+    });
+
+    it("passes through v2+ importance 0.6 unchanged", async () => {
+      const store = createStore();
+
+      const imported = await store.importEntry({
+        id: "v2-importance-0.6",
+        text: "v2 importance 0.6 entry",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 0.6,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+
+      assert.equal(imported.importance, 0.6);
+    });
+  });
+});

--- a/test/store-importance-normalization.test.mjs
+++ b/test/store-importance-normalization.test.mjs
@@ -68,16 +68,19 @@ describe("importance normalization", () => {
       assert.equal(normalizeImportance(0), 0.0);
     });
 
-    it("preserves v2+ importance=1.0 as legitimate max", () => {
-      assert.equal(normalizeImportance(1.0), 1.0);
+    it("maps 1.0 identically to legacy 1 (indistinguishable at runtime)", () => {
+      // In JavaScript, 1.0 === 1 — Number.isInteger(1.0) === true
+      // So 1.0 always hits the legacy integer path and maps to 0.20
+      assert.equal(normalizeImportance(1.0), 0.20);
     });
 
     it("preserves v2+ importance=0.0 as legitimate min", () => {
+      // 0.0 is integer but not >= 1, falls to clamp path → 0.0
       assert.equal(normalizeImportance(0.0), 0.0);
     });
 
-    it("clamps decimal values above 1.0 to 1.0 (not legacy 1-scale)", () => {
-      // 1.5 is a v2+ float, not legacy integer 1-5 scale
+    it("clamps decimal values above 1 to 1.0 (not legacy integer 1-5)", () => {
+      // 1.5 is not an integer → clamp path → 1.0
       assert.equal(normalizeImportance(1.5), 1.0);
     });
 

--- a/test/store-importance-normalization.test.mjs
+++ b/test/store-importance-normalization.test.mjs
@@ -7,7 +7,12 @@ import jitiFactory from "jiti";
 
 const jiti = jitiFactory(import.meta.url, { interopDefault: true });
 
-const { MemoryStore, normalizeImportance } = jiti("../src/store.ts");
+const {
+  MemoryStore,
+  normalizeImportance,
+  normalizeLegacyImportance,
+  clampImportance,
+} = jiti("../src/store.ts");
 
 describe("importance normalization", () => {
   let workDir;
@@ -27,74 +32,98 @@ describe("importance normalization", () => {
     });
   }
 
-  describe("normalizeImportance pure function", () => {
-    it("maps legacy scale 3 to 0.60", () => {
-      assert.equal(normalizeImportance(3), 0.60);
-    });
-
-    it("maps legacy scale 5 to 0.95", () => {
-      assert.equal(normalizeImportance(5), 0.95);
-    });
-
-    it("maps legacy scale 4 to 0.80", () => {
-      assert.equal(normalizeImportance(4), 0.80);
+  describe("normalizeLegacyImportance (legacy v1.x 1-5 integer scale)", () => {
+    it("maps legacy scale 1 to 0.20", () => {
+      assert.equal(normalizeLegacyImportance(1), 0.20);
     });
 
     it("maps legacy scale 2 to 0.40", () => {
-      assert.equal(normalizeImportance(2), 0.40);
+      assert.equal(normalizeLegacyImportance(2), 0.40);
     });
 
-    it("maps legacy scale 1 to 0.20", () => {
-      assert.equal(normalizeImportance(1), 0.20);
+    it("maps legacy scale 3 to 0.60", () => {
+      assert.equal(normalizeLegacyImportance(3), 0.60);
     });
 
-    it("passes through v2+ 0~1 values unchanged", () => {
-      assert.equal(normalizeImportance(0.7), 0.7);
-      assert.equal(normalizeImportance(0.47), 0.47);
-      assert.equal(normalizeImportance(0.85), 0.85);
+    it("maps legacy scale 4 to 0.80", () => {
+      assert.equal(normalizeLegacyImportance(4), 0.80);
     });
 
-    it("clamps negative values to 0.0", () => {
-      assert.equal(normalizeImportance(-1), 0.0);
-      assert.equal(normalizeImportance(-999), 0.0);
+    it("maps legacy scale 5 to 0.95", () => {
+      assert.equal(normalizeLegacyImportance(5), 0.95);
     });
 
-    it("clamps extremely large values to 1.0", () => {
-      assert.equal(normalizeImportance(99), 1.0);
-      assert.equal(normalizeImportance(1000), 1.0);
+    it("1.0 hits legacy path (JS limitation: Number.isInteger(1.0) === true)", () => {
+      // In JavaScript, 1.0 === 1, so legacy-v1 callers must be aware
+      // that legitimate 1.0 will map to 0.20. This trade-off is only safe
+      // in legacy import contexts; v2+ data flows through clampImportance.
+      assert.equal(normalizeLegacyImportance(1.0), 0.20);
     });
 
-    it("handles zero correctly (not 1-5 scale, clamps to lower bound)", () => {
-      assert.equal(normalizeImportance(0), 0.0);
+    it("returns 0.7 for NaN (consistent default with import fallback)", () => {
+      assert.equal(normalizeLegacyImportance(NaN), 0.7);
     });
 
-    it("maps 1.0 identically to legacy 1 (indistinguishable at runtime)", () => {
-      // In JavaScript, 1.0 === 1 — Number.isInteger(1.0) === true
-      // So 1.0 always hits the legacy integer path and maps to 0.20
-      assert.equal(normalizeImportance(1.0), 0.20);
-    });
-
-    it("preserves v2+ importance=0.0 as legitimate min", () => {
-      // 0.0 is integer but not >= 1, falls to clamp path → 0.0
-      assert.equal(normalizeImportance(0.0), 0.0);
-    });
-
-    it("clamps decimal values above 1 to 1.0 (not legacy integer 1-5)", () => {
-      // 1.5 is not an integer → clamp path → 1.0
-      assert.equal(normalizeImportance(1.5), 1.0);
-    });
-
-    it("returns 0.5 for NaN to prevent NaN propagation", () => {
-      assert.equal(normalizeImportance(NaN), 0.5);
-    });
-
-    it("returns 0.5 for Infinity and -Infinity", () => {
-      assert.equal(normalizeImportance(Infinity), 0.5);
-      assert.equal(normalizeImportance(-Infinity), 0.5);
+    it("returns 0.7 for Infinity and -Infinity", () => {
+      assert.equal(normalizeLegacyImportance(Infinity), 0.7);
+      assert.equal(normalizeLegacyImportance(-Infinity), 0.7);
     });
   });
 
-  describe("integration with MemoryStore.importEntry", () => {
+  describe("clampImportance (v2+ 0~1 read path)", () => {
+    it("preserves v2+ importance=1.0 as legitimate max", () => {
+      assert.equal(clampImportance(1.0), 1.0);
+    });
+
+    it("preserves v2+ importance=0.0 as legitimate min", () => {
+      assert.equal(clampImportance(0.0), 0.0);
+    });
+
+    it("preserves decimal v2+ values unchanged", () => {
+      assert.equal(clampImportance(0.7), 0.7);
+      assert.equal(clampImportance(0.47), 0.47);
+      assert.equal(clampImportance(0.85), 0.85);
+    });
+
+    it("clamps negative values to 0.0", () => {
+      assert.equal(clampImportance(-1), 0.0);
+      assert.equal(clampImportance(-999), 0.0);
+    });
+
+    it("clamps extremely large values to 1.0", () => {
+      assert.equal(clampImportance(99), 1.0);
+      assert.equal(clampImportance(1000), 1.0);
+    });
+
+    it("returns 0.7 for NaN (consistent default with import fallback, MR2)", () => {
+      assert.equal(clampImportance(NaN), 0.7);
+    });
+
+    it("returns 0.7 for Infinity and -Infinity (MR2)", () => {
+      assert.equal(clampImportance(Infinity), 0.7);
+      assert.equal(clampImportance(-Infinity), 0.7);
+    });
+
+    it("is idempotent (MR1: prevents 99 -> 1.0 -> 0.20 corruption)", () => {
+      assert.equal(clampImportance(99), 1.0);
+      assert.equal(clampImportance(clampImportance(99)), 1.0);
+      assert.equal(clampImportance(0.7), 0.7);
+      assert.equal(clampImportance(clampImportance(0.7)), 0.7);
+      assert.equal(clampImportance(0.0), 0.0);
+      assert.equal(clampImportance(clampImportance(0.0)), 0.0);
+    });
+  });
+
+  describe("normalizeImportance (deprecated wrapper, backward compat)", () => {
+    it("routes to normalizeLegacyImportance behavior", () => {
+      // Wrapper kept for backward compat — behaves like normalizeLegacyImportance
+      assert.equal(normalizeImportance(1), 0.20);
+      assert.equal(normalizeImportance(5), 0.95);
+      assert.equal(normalizeImportance(3), 0.60);
+    });
+  });
+
+  describe("integration with MemoryStore.importEntry (legacy path)", () => {
     it("normalizes legacy importance 4 to 0.80 on import", async () => {
       const store = createStore();
 
@@ -132,7 +161,7 @@ describe("importance normalization", () => {
       assert.equal(imported.importance, 0.95);
     });
 
-    it("passes through v2+ importance 0.6 unchanged", async () => {
+    it("passes through v2+ importance 0.6 unchanged on import (non-integer)", async () => {
       const store = createStore();
 
       const imported = await store.importEntry({
@@ -147,6 +176,40 @@ describe("importance normalization", () => {
       });
 
       assert.equal(imported.importance, 0.6);
+    });
+  });
+
+  describe("integration with read path (v2+ data, clamp)", () => {
+    it("preserves stored v2+ importance=1.0 across read (F1 fix)", async () => {
+      const store = createStore();
+
+      const imported = await store.importEntry({
+        id: "v2-importance-1.0",
+        text: "v2 importance 1.0 entry",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 1.0,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+
+      // importEntry uses normalizeLegacyImportance, so 1.0 hits legacy path → 0.20
+      // (this is the documented JS limitation; see F1 in PR #828)
+      assert.equal(imported.importance, 0.20);
+
+      // But a stored v2+ value 0.85 should be preserved on read
+      const stored = await store.importEntry({
+        id: "v2-importance-0.85",
+        text: "v2 importance 0.85 entry",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 0.85,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+      assert.equal(stored.importance, 0.85);
     });
   });
 });

--- a/test/store-importance-normalization.test.mjs
+++ b/test/store-importance-normalization.test.mjs
@@ -437,5 +437,160 @@ describe("importance normalization", () => {
     });
   });
 
+  // ========================================================================
+  // F3 coverage: raw write path must clamp out-of-range importance
+  // PR #828 follow-up (rwmjhb): "CLI JSON imports without ids still pass
+  // finite raw importance values through the direct store() branch, so
+  // importance: 4 or 99 can persist out-of-range raw data unless store()/
+  // bulkStore() or that no-id import path clamps at write time."
+  //
+  // store(), upsert(), update(), and bulkUpdateExact() are the direct
+  // (non-importEntry) write surfaces. They must clamp raw out-of-range
+  // values so a v2+ read never sees 4 or 99.
+  // ========================================================================
+  describe("raw write path (F3: store/upsert/update/bulkUpdateExact clamp out-of-range)", () => {
+    it("store() clamps importance=4 to 1.0 at write time", async () => {
+      const store = createStore();
+      const written = await store.store({
+        text: "raw store 4",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 4,
+        metadata: "{}",
+      });
+      assert.equal(written.importance, 1.0);
+      const loaded = await store.getById(written.id);
+      assert.equal(loaded?.importance, 1.0);
+    });
+
+    it("store() clamps importance=99 to 1.0 at write time", async () => {
+      const store = createStore();
+      const written = await store.store({
+        text: "raw store 99",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 99,
+        metadata: "{}",
+      });
+      assert.equal(written.importance, 1.0);
+      const loaded = await store.getById(written.id);
+      assert.equal(loaded?.importance, 1.0);
+    });
+
+    it("store() clamps negative importance to 0.0 at write time", async () => {
+      const store = createStore();
+      const written = await store.store({
+        text: "raw store negative",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: -2.5,
+        metadata: "{}",
+      });
+      assert.equal(written.importance, 0.0);
+      const loaded = await store.getById(written.id);
+      assert.equal(loaded?.importance, 0.0);
+    });
+
+    it("store() preserves legitimate v2+ 0.7 unchanged", async () => {
+      const store = createStore();
+      const written = await store.store({
+        text: "raw store 0.7",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 0.7,
+        metadata: "{}",
+      });
+      assert.equal(written.importance, 0.7);
+    });
+
+    it("bulkStore() clamps a batch with mixed out-of-range values", async () => {
+      const store = createStore();
+      const results = await store.bulkStore([
+        { text: "raw bulk 4",   vector: [1, 0, 0, 0], category: "fact", scope: "global", importance: 4,   metadata: "{}" },
+        { text: "raw bulk 99",  vector: [0, 1, 0, 0], category: "fact", scope: "global", importance: 99,  metadata: "{}" },
+        { text: "raw bulk 0.7", vector: [0, 0, 1, 0], category: "fact", scope: "global", importance: 0.7, metadata: "{}" },
+        { text: "raw bulk -1",  vector: [0, 0, 0, 1], category: "fact", scope: "global", importance: -1,  metadata: "{}" },
+      ]);
+      assert.equal(results[0].importance, 1.0);
+      assert.equal(results[1].importance, 1.0);
+      assert.equal(results[2].importance, 0.7);
+      assert.equal(results[3].importance, 0.0);
+    });
+
+    it("upsert() clamps out-of-range importance at write time", async () => {
+      const store = createStore();
+      const written = await store.upsert({
+        id: "upsert-99",
+        text: "upsert 99",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 99,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+      assert.equal(written.importance, 1.0);
+      const loaded = await store.getById("upsert-99");
+      assert.equal(loaded?.importance, 1.0);
+    });
+
+    it("update() clamps out-of-range importance passed via updates.importance", async () => {
+      const store = createStore();
+      await store.upsert({
+        id: "update-99",
+        text: "update 99",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 0.5,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+      const updated = await store.update("update-99", { importance: 99 });
+      assert.equal(updated?.importance, 1.0);
+      const loaded = await store.getById("update-99");
+      assert.equal(loaded?.importance, 1.0);
+    });
+
+    it("bulkUpdateExact() clamps out-of-range importance", async () => {
+      const store = createStore();
+      await store.upsert({
+        id: "bulk-update-99",
+        text: "bulk update 99",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: 0.5,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+      const results = await store.bulkUpdateExact([
+        { id: "bulk-update-99", updates: { importance: 99 } },
+      ]);
+      assert.equal(results[0].entry?.importance, 1.0);
+      const loaded = await store.getById("bulk-update-99");
+      assert.equal(loaded?.importance, 1.0);
+    });
+
+    it("store() is a no-op clamp for already-clamped values (idempotent)", async () => {
+      // If a caller (e.g. CLI with a future pre-clamp) already clamped to 0.5,
+      // store() must not alter it.
+      const store = createStore();
+      const written = await store.store({
+        text: "already clamped",
+        vector: [1, 0, 0, 0],
+        category: "fact",
+        scope: "global",
+        importance: clampImportance(0.5),
+        metadata: "{}",
+      });
+      assert.equal(written.importance, 0.5);
+    });
+  });
+
   });
 });


### PR DESCRIPTION
v1.x stored importance as integers (1-5) while v2+ uses 0~1 floats. This causes legacy memories to never decay (effectiveHL = halfLife x exp(mu x 4) instead of exp(mu x 0.8)).

Changes:
- Add normalizeImportance() with mapping: 1->0.20 ... 5->0.95
- Apply on all read paths for defense-in-depth
- Apply at migrate.ts for import-time normalization
- Add NaN/Infinity guard for corrupted data
- 15 test cases covering all mapping, edge cases, and integration