### PR TITLE
fix: build compiled runtime before packaging

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -489,6 +489,86 @@ export async function runImportMarkdown(ctx, workspaceGlob, options) {
         ? Math.max(0, Math.min(1, parseFloat(options.importance ?? "0.7")))
         : 0.7;
     const dedupEnabled = !!options.dedup;
+    const buildMarkdownImportEntry = (pending, vector) => ({
+        text: pending.text,
+        vector,
+        importance: importanceDefault,
+        category: "other",
+        scope: pending.scope,
+        metadata: JSON.stringify({ importedFrom: pending.filePath, sourceScope: pending.sourceScope }),
+    });
+    const importEntriesIndividually = async (entries) => {
+        let importedCount = 0;
+        let skippedCount = 0;
+        for (const entry of entries) {
+            try {
+                await ctx.store.store(entry);
+                importedCount++;
+            }
+            catch (err) {
+                console.warn(`  Failed to import: ${String(entry.text).slice(0, 60)}... — ${err}`);
+                skippedCount++;
+            }
+        }
+        return { imported: importedCount, skipped: skippedCount };
+    };
+    const importPendingEntries = async (pendingEntries) => {
+        if (pendingEntries.length === 0)
+            return { imported: 0, skipped: 0 };
+        let vectors;
+        try {
+            vectors = typeof ctx.embedder.embedBatchPassage === "function"
+                ? await ctx.embedder.embedBatchPassage(pendingEntries.map((entry) => entry.text))
+                : await Promise.all(pendingEntries.map((entry) => ctx.embedder.embedPassage(entry.text)));
+        }
+        catch (err) {
+            console.warn(`  [import-markdown] batch embedding failed (${err}); retrying entries individually`);
+            let importedCount = 0;
+            let skippedCount = 0;
+            for (const pending of pendingEntries) {
+                try {
+                    const vector = await ctx.embedder.embedPassage(pending.text);
+                    const result = await importEntriesIndividually([buildMarkdownImportEntry(pending, vector)]);
+                    importedCount += result.imported;
+                    skippedCount += result.skipped;
+                }
+                catch (entryErr) {
+                    console.warn(`  Failed to import: ${pending.text.slice(0, 60)}... — ${entryErr}`);
+                    skippedCount++;
+                }
+            }
+            return { imported: importedCount, skipped: skippedCount };
+        }
+        if (vectors.length !== pendingEntries.length) {
+            console.warn(`  [import-markdown] batch embedding returned ${vectors.length}/${pendingEntries.length} vector(s); retrying entries individually`);
+            let importedCount = 0;
+            let skippedCount = 0;
+            for (const pending of pendingEntries) {
+                try {
+                    const vector = await ctx.embedder.embedPassage(pending.text);
+                    const result = await importEntriesIndividually([buildMarkdownImportEntry(pending, vector)]);
+                    importedCount += result.imported;
+                    skippedCount += result.skipped;
+                }
+                catch (entryErr) {
+                    console.warn(`  Failed to import: ${pending.text.slice(0, 60)}... — ${entryErr}`);
+                    skippedCount++;
+                }
+            }
+            return { imported: importedCount, skipped: skippedCount };
+        }
+        const entries = pendingEntries.map((pending, index) => buildMarkdownImportEntry(pending, vectors[index]));
+        if (typeof ctx.store.bulkStore === "function") {
+            try {
+                await ctx.store.bulkStore(entries);
+                return { imported: entries.length, skipped: 0 };
+            }
+            catch (err) {
+                console.warn(`  [import-markdown] batch store failed (${err}); retrying entries individually`);
+            }
+        }
+        return importEntriesIndividually(entries);
+    };
     // Parse each file for memory entries (lines starting with "- ")
     for (const { filePath, scope: discoveredScope } of mdFiles) {
         let content;
@@ -508,6 +588,8 @@ export async function runImportMarkdown(ctx, workspaceGlob, options) {
         content = content.replace(/^\uFEFF/, "");
         // Normalize line endings: handle both CRLF (\r\n) and LF (\n)
         const lines = content.split(/\r?\n/);
+        const pendingEntries = [];
+        let fileSkipped = 0;
         for (const line of lines) {
             // Skip non-memory lines
             // Supports: "- text", "* text", "+ text" (standard Markdown bullet formats)
@@ -516,6 +598,7 @@ export async function runImportMarkdown(ctx, workspaceGlob, options) {
             const text = line.slice(2).trim();
             if (text.length < minTextLength) {
                 skipped++;
+                fileSkipped++;
                 continue;
             }
             // Use --scope if provided, otherwise fall back to per-file discovered scope.
@@ -529,6 +612,7 @@ export async function runImportMarkdown(ctx, workspaceGlob, options) {
                     const existing = await ctx.store.bm25Search(text, 5, [effectiveScope]);
                     if (existing.length > 0 && existing[0].entry.text === text) {
                         skipped++;
+                        fileSkipped++;
                         if (!options.dryRun) {
                             console.log(`  [skip] already imported: ${text.slice(0, 60)}${text.length > 60 ? "..." : ""}`);
                         }
@@ -545,21 +629,16 @@ export async function runImportMarkdown(ctx, workspaceGlob, options) {
                 imported++;
                 continue;
             }
-            try {
-                const vector = await ctx.embedder.embedPassage(text);
-                await ctx.store.store({
-                    text,
-                    vector,
-                    importance: importanceDefault,
-                    category: "other",
-                    scope: effectiveScope,
-                    metadata: JSON.stringify({ importedFrom: filePath, sourceScope: discoveredScope }),
-                });
-                imported++;
-            }
-            catch (err) {
-                console.warn(`  Failed to import: ${text.slice(0, 60)}... — ${err}`);
-                skipped++;
+            pendingEntries.push({ text, scope: effectiveScope, sourceScope: discoveredScope, filePath });
+        }
+        if (!options.dryRun) {
+            const result = await importPendingEntries(pendingEntries);
+            imported += result.imported;
+            skipped += result.skipped;
+            fileSkipped += result.skipped;
+            if (pendingEntries.length > 0 || fileSkipped > 0) {
+                console.log(`  [import-markdown] ${path.basename(filePath)}: ` +
+                    `${result.imported} imported, ${fileSkipped} skipped`);
             }
         }
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -16,7 +16,7 @@ import { spawn } from "node:child_process";
 // so we downgrade them to debug level when running in CLI mode.
 const isCliMode = () => process.env.OPENCLAW_CLI === "1";
 // Import core components
-import { MemoryStore, normalizeStoragePath, validateStoragePath } from "./src/store.js";
+import { MemoryStore, normalizeStoragePath } from "./src/store.js";
 import { createEmbedder, getEffectiveVectorDimensions, } from "./src/embedder.js";
 import { createRetriever, DEFAULT_RETRIEVAL_CONFIG } from "./src/retriever.js";
 import { createScopeManager, resolveScopeFilter, isSystemBypassId, parseAgentIdFromSessionKey } from "./src/scopes.js";
@@ -1004,16 +1004,7 @@ function buildReflectionFallbackText() {
         "- (none captured)",
         "",
         "## Learning governance candidates (.learnings / promotion / skill extraction)",
-        "### Entry 1",
-        "**Priority**: medium",
-        "**Status**: triage",
-        "**Area**: config",
-        "### Summary",
-        "Investigate last failed tool execution and decide whether it belongs in .learnings/ERRORS.md.",
-        "### Details",
-        "The reflection pipeline fell back; confirm the failure is reproducible before treating it as a durable error record.",
-        "### Suggested Action",
-        "Reproduce the latest failed tool execution, classify it as triage or error, and then log it with the appropriate tool/file path evidence.",
+        "- (none captured)",
         "",
         "## Open loops / next actions",
         "- Investigate why embedded reflection generation failed.",
@@ -1500,15 +1491,13 @@ let _singletonState = null;
 function _initPluginState(api) {
     const config = parsePluginConfig(api.pluginConfig);
     let resolvedDbPath = normalizeStoragePath(api.resolvePath(config.dbPath || getDefaultDbPath()));
-    try {
-        resolvedDbPath = validateStoragePath(resolvedDbPath);
-    }
-    catch (err) {
-        api.logger.warn(`memory-lancedb-pro: storage path issue — ${String(err)}\n` +
-            `  The plugin will still attempt to start, but writes may fail.`);
-    }
     const vectorDim = getEffectiveVectorDimensions(config.embedding.model || "text-embedding-3-small", config.embedding.dimensions, config.embedding.requestDimensions);
-    const store = new MemoryStore({ dbPath: resolvedDbPath, vectorDim });
+    const store = new MemoryStore({
+        dbPath: resolvedDbPath,
+        vectorDim,
+        disableNativeCosine: config.retrieval?.disableNativeCosine === true,
+        onStoragePathWarning: (message) => api.logger.warn(message),
+    });
     const embedder = createEmbedder({
         provider: "openai-compatible",
         apiKey: config.embedding.apiKey,
@@ -1521,6 +1510,7 @@ function _initPluginState(api) {
         taskPassage: config.embedding.taskPassage,
         normalized: config.embedding.normalized,
         chunking: config.embedding.chunking,
+        clientTimeoutMs: config.embedding.clientTimeoutMs,
     });
     const decayEngine = createDecayEngine({
         ...DEFAULT_DECAY_CONFIG,
@@ -3373,7 +3363,9 @@ const memoryLanceDBProPlugin = {
                     if (!writeOk) {
                         throw new Error(`Failed to allocate unique reflection file for ${dateStr} ${timeCompact}`);
                     }
-                    const reflectionGovernanceCandidates = extractReflectionLearningGovernanceCandidates(reflectionText);
+                    const reflectionGovernanceCandidates = reflectionGenerated.usedFallback
+                        ? []
+                        : extractReflectionLearningGovernanceCandidates(reflectionText);
                     if (config.selfImprovement?.enabled !== false && reflectionGovernanceCandidates.length > 0) {
                         for (const candidate of reflectionGovernanceCandidates) {
                             const appendResult = await appendSelfImprovementEntry({
@@ -3705,7 +3697,7 @@ const memoryLanceDBProPlugin = {
                 const runStartupChecks = async () => {
                     try {
                         // Test components (bounded time)
-                        const embedTest = await withTimeout(embedder.test(), 8_000, "embedder.test()");
+                        const embedTest = await withTimeout(embedder.test({ timeoutMs: 7_500 }), 8_000, "embedder.test()");
                         const retrievalTest = await withTimeout(retriever.test(), 8_000, "retriever.test()");
                         api.logger.info(`memory-lancedb-pro: initialized successfully ` +
                             `(embedding: ${embedTest.success ? "OK" : "FAIL"}, ` +
@@ -3846,6 +3838,7 @@ export function parsePluginConfig(value) {
             chunking: typeof embedding.chunking === "boolean"
                 ? embedding.chunking
                 : undefined,
+            clientTimeoutMs: parsePositiveInt(embedding.clientTimeoutMs),
         },
         dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : undefined,
         autoCapture: cfg.autoCapture !== false,

--- a/dist/src/embedder.js
+++ b/dist/src/embedder.js
@@ -334,6 +334,10 @@ export function formatEmbeddingProviderError(error, opts) {
 const MAX_EMBED_DEPTH = 3;
 /** Global timeout for a single embedding operation (ms). */
 const EMBED_TIMEOUT_MS = 10_000;
+/** Default SDK-level HTTP timeout for embedding requests, including batch calls. */
+const DEFAULT_EMBED_CLIENT_TIMEOUT_MS = 30_000;
+/** Bounded startup health probe timeout; normal embeddings keep the larger client timeout. */
+const EMBED_HEALTH_CHECK_TIMEOUT_MS = 7_500;
 /**
  * Strictly decreasing character limit for forced truncation.
  * Each recursion level MUST reduce input by this factor to guarantee progress.
@@ -389,6 +393,9 @@ export class Embedder {
         this._autoChunk = config.chunking !== false;
         const profile = detectEmbeddingProviderProfile(this._baseURL, this._model);
         this._capabilities = getEmbeddingCapabilities(profile);
+        const clientTimeoutMs = Number.isFinite(config.clientTimeoutMs) && config.clientTimeoutMs > 0
+            ? Math.floor(config.clientTimeoutMs)
+            : DEFAULT_EMBED_CLIENT_TIMEOUT_MS;
         // Warn if configured fields will be silently ignored by this provider profile
         if (config.normalized !== undefined && !this._capabilities.normalized) {
             console.debug(`[memory-lancedb-pro] embedding.normalized is set but provider profile "${profile}" does not support it — value will be ignored`);
@@ -411,6 +418,8 @@ export class Embedder {
             return new OpenAI({
                 apiKey: key,
                 ...(baseURL ? { baseURL } : {}),
+                timeout: clientTimeoutMs,
+                maxRetries: 0,
                 defaultHeaders: Object.keys(defaultHeaders).length > 0 ? defaultHeaders : undefined,
             });
         });
@@ -893,9 +902,14 @@ export class Embedder {
         return this._model;
     }
     // Test connection and validate configuration
-    async test() {
+    async test(options = {}) {
+        const timeoutMs = Number.isFinite(options.timeoutMs) && options.timeoutMs > 0
+            ? Math.floor(options.timeoutMs)
+            : EMBED_HEALTH_CHECK_TIMEOUT_MS;
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
         try {
-            const testEmbedding = await this.embedPassage("test");
+            const testEmbedding = await this.embedPassage("test", controller.signal);
             return {
                 success: true,
                 dimensions: testEmbedding.length,
@@ -906,6 +920,9 @@ export class Embedder {
                 success: false,
                 error: error instanceof Error ? error.message : String(error),
             };
+        }
+        finally {
+            clearTimeout(timeoutId);
         }
     }
     get cacheStats() {

--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -329,6 +329,13 @@ export class MemoryRetriever {
     getStatsCollector() {
         return this._statsCollector;
     }
+    async resolveFtsSupport() {
+        const storeWithRefresh = this.store;
+        if (typeof storeWithRefresh.refreshFtsSupport === "function") {
+            return await storeWithRefresh.refreshFtsSupport();
+        }
+        return this.store.hasFtsSupport;
+    }
     async retrieve(context) {
         const { query, limit, scopeFilter, category, source } = context;
         const safeLimit = clampInt(limit, 1, 20);
@@ -363,13 +370,16 @@ export class MemoryRetriever {
         try {
             // Create trace only when stats collector is active (zero overhead otherwise)
             const trace = this._statsCollector ? new TraceCollector() : undefined;
+            const hasFtsSupport = this.config.mode === "vector"
+                ? this.store.hasFtsSupport
+                : await this.resolveFtsSupport();
             // Check if query contains tag prefixes -> use BM25-only + mustContain
             const tagTokens = this.extractTagTokens(query);
             let results;
             if (tagTokens.length > 0) {
                 results = await this.bm25OnlyRetrieval(query, tagTokens, safeLimit, scopeFilter, category, trace, diagnostics);
             }
-            else if (this.config.mode === "vector" || !this.store.hasFtsSupport) {
+            else if (this.config.mode === "vector" || !hasFtsSupport) {
                 results = await this.vectorOnlyRetrieval(query, safeLimit, scopeFilter, category, trace, diagnostics);
             }
             else {
@@ -381,7 +391,7 @@ export class MemoryRetriever {
             if (trace && this._statsCollector) {
                 const mode = tagTokens.length > 0
                     ? "bm25"
-                    : (this.config.mode === "vector" || !this.store.hasFtsSupport)
+                    : (this.config.mode === "vector" || !hasFtsSupport)
                         ? "vector"
                         : "hybrid";
                 const finalTrace = trace.finalize(query, mode);
@@ -412,17 +422,20 @@ export class MemoryRetriever {
         const trace = new TraceCollector();
         const tagTokens = this.extractTagTokens(query);
         let results;
+        const hasFtsSupport = this.config.mode === "vector"
+            ? this.store.hasFtsSupport
+            : await this.resolveFtsSupport();
         if (tagTokens.length > 0) {
             results = await this.bm25OnlyRetrieval(query, tagTokens, safeLimit, scopeFilter, category, trace);
         }
-        else if (this.config.mode === "vector" || !this.store.hasFtsSupport) {
+        else if (this.config.mode === "vector" || !hasFtsSupport) {
             results = await this.vectorOnlyRetrieval(query, safeLimit, scopeFilter, category, trace);
         }
         else {
             results = await this.hybridRetrieval(query, safeLimit, scopeFilter, category, trace);
         }
         const mode = tagTokens.length > 0 ? "bm25"
-            : (this.config.mode === "vector" || !this.store.hasFtsSupport) ? "vector" : "hybrid";
+            : (this.config.mode === "vector" || !hasFtsSupport) ? "vector" : "hybrid";
         const finalTrace = trace.finalize(query, mode);
         if (this._statsCollector) {
             this._statsCollector.recordQuery(finalTrace, source || "debug");
@@ -1293,14 +1306,14 @@ export class MemoryRetriever {
             return {
                 success: true,
                 mode: this.config.mode,
-                hasFtsSupport: this.store.hasFtsSupport,
+                hasFtsSupport: await this.resolveFtsSupport(),
             };
         }
         catch (error) {
             return {
                 success: false,
                 mode: this.config.mode,
-                hasFtsSupport: this.store.hasFtsSupport,
+                hasFtsSupport: await this.resolveFtsSupport(),
                 error: error instanceof Error ? error.message : String(error),
             };
         }

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -4,6 +4,7 @@
 import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
 import { existsSync, accessSync, constants, mkdirSync, realpathSync, lstatSync, statSync, unlinkSync, rmdirSync, writeFileSync, } from "node:fs";
+import { access as accessAsync, lstat as lstatAsync, mkdir as mkdirAsync, realpath as realpathAsync, } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
@@ -138,6 +139,10 @@ function normalizeSearchText(value) {
 function isExplicitDenyAllScopeFilter(scopeFilter) {
     return Array.isArray(scopeFilter) && scopeFilter.length === 0;
 }
+function hasFtsIndex(indices) {
+    return Array.isArray(indices) && indices.some((idx) => idx?.indexType === "FTS" ||
+        (Array.isArray(idx?.columns) && idx.columns.includes("text")));
+}
 function scoreLexicalHit(query, candidates) {
     const normalizedQuery = normalizeSearchText(query);
     if (!normalizedQuery)
@@ -152,6 +157,39 @@ function scoreLexicalHit(query, candidates) {
         }
     }
     return score;
+}
+function parseBooleanEnvFlag(value) {
+    return /^(1|true|yes|on)$/i.test((value ?? "").trim());
+}
+function toNumberVector(value) {
+    if (!value || typeof value !== "object")
+        return [];
+    const maybeArrayLike = value;
+    if (typeof maybeArrayLike.length !== "number" || maybeArrayLike.length < 0) {
+        return [];
+    }
+    const vector = Array.from(maybeArrayLike, (item) => Number(item));
+    return vector.every(Number.isFinite) ? vector : [];
+}
+function cosineSimilarity(left, right) {
+    if (!Array.isArray(left) || left.length === 0 || right.length !== left.length)
+        return 0;
+    let dot = 0;
+    let leftNorm = 0;
+    let rightNorm = 0;
+    for (let index = 0; index < left.length; index++) {
+        const l = Number(left[index]);
+        const r = Number(right[index]);
+        if (!Number.isFinite(l) || !Number.isFinite(r))
+            return 0;
+        dot += l * r;
+        leftNorm += l * l;
+        rightNorm += r * r;
+    }
+    const denominator = Math.sqrt(leftNorm) * Math.sqrt(rightNorm);
+    if (denominator <= 0)
+        return 0;
+    return Math.max(-1, Math.min(1, dot / denominator));
 }
 // ============================================================================
 // Storage Path Validation
@@ -241,6 +279,71 @@ export function validateStoragePath(dbPath) {
     }
     return resolvedPath;
 }
+/**
+ * Async variant of {@link validateStoragePath}. Use this on runtime paths so
+ * slow filesystems do not block OpenClaw's event loop during startup.
+ */
+export async function validateStoragePathAsync(dbPath) {
+    let resolvedPath = normalizeStoragePath(dbPath);
+    // Resolve symlinks (including dangling symlinks)
+    try {
+        const stats = await lstatAsync(dbPath);
+        if (stats.isSymbolicLink()) {
+            try {
+                resolvedPath = await realpathAsync(dbPath);
+            }
+            catch (err) {
+                throw new Error(`dbPath "${dbPath}" is a symlink whose target does not exist.\n` +
+                    `  Fix: Create the target directory, or update the symlink to point to a valid path.\n` +
+                    `  Details: ${err.code || ""} ${err.message}`);
+            }
+        }
+    }
+    catch (err) {
+        // Missing path is OK (it will be created below)
+        if (err?.code === "ENOENT") {
+            // no-op
+        }
+        else if (typeof err?.message === "string" &&
+            err.message.includes("symlink whose target does not exist")) {
+            throw err;
+        }
+        else {
+            // Other lstat failures — continue with original path
+        }
+    }
+    // Create directory if it doesn't exist
+    let pathExists = false;
+    try {
+        await accessAsync(resolvedPath, constants.F_OK);
+        pathExists = true;
+    }
+    catch {
+        pathExists = false;
+    }
+    if (!pathExists) {
+        try {
+            await mkdirAsync(resolvedPath, { recursive: true });
+        }
+        catch (err) {
+            throw new Error(`Failed to create dbPath directory "${resolvedPath}".\n` +
+                `  Fix: Ensure the parent directory "${dirname(resolvedPath)}" exists and is writable,\n` +
+                `       or create it manually: mkdir -p "${resolvedPath}"\n` +
+                `  Details: ${err.code || ""} ${err.message}`);
+        }
+    }
+    // Check write permissions
+    try {
+        await accessAsync(resolvedPath, constants.W_OK);
+    }
+    catch (err) {
+        throw new Error(`dbPath directory "${resolvedPath}" is not writable.\n` +
+            `  Fix: Check permissions with: ls -la "${dirname(resolvedPath)}"\n` +
+            `       Or grant write access: chmod u+w "${resolvedPath}"\n` +
+            `  Details: ${err.code || ""} ${err.message}`);
+    }
+    return resolvedPath;
+}
 // ============================================================================
 // Memory Store
 // ============================================================================
@@ -250,7 +353,9 @@ export class MemoryStore {
     table = null;
     initPromise = null;
     ftsIndexCreated = false;
+    _lastFtsError = null;
     updateQueue = Promise.resolve();
+    nativeCosineFallbackLogged = false;
     // Cross-call batch accumulator（Issue #690）
     // 多個 concurrent bulkStore() 會先累積在這裡，每 100ms flush 一次，
     // 合併成一個 lock acquisition，大幅降低 lock contention。
@@ -272,11 +377,14 @@ export class MemoryStore {
     // 當 pending callers 超過此值時，block 並同步 flush，確保 pendingBatch 不會無限膨胀。
     static MAX_PENDING_BATCH_SIZE = 1000;
     config;
+    disableNativeCosine;
     constructor(config) {
+        const envDisablesNativeCosine = parseBooleanEnvFlag(process.env.MEMORY_LANCEDB_DISABLE_NATIVE_COSINE);
         this.config = {
             ...config,
             dbPath: normalizeStoragePath(config.dbPath),
         };
+        this.disableNativeCosine = config.disableNativeCosine === true || envDisablesNativeCosine;
     }
     async runWithFileLock(fn) {
         const lockfile = await loadLockfile();
@@ -420,6 +528,13 @@ export class MemoryStore {
         return this.initPromise;
     }
     async doInitialize() {
+        try {
+            this.config.dbPath = await validateStoragePathAsync(this.config.dbPath);
+        }
+        catch (err) {
+            this.config.onStoragePathWarning?.(`memory-lancedb-pro: storage path issue — ${String(err)}\n` +
+                `  The plugin will still attempt to start, but writes may fail.`);
+        }
         const lancedb = await loadLanceDB();
         let db;
         try {
@@ -510,10 +625,12 @@ export class MemoryStore {
         try {
             await this.createFtsIndex(table);
             this.ftsIndexCreated = true;
+            this._lastFtsError = null;
         }
         catch (err) {
             console.warn("Failed to create FTS index, falling back to vector-only search:", err);
             this.ftsIndexCreated = false;
+            this._lastFtsError = err instanceof Error ? err.message : String(err);
         }
         this.db = db;
         this.table = table;
@@ -612,8 +729,7 @@ export class MemoryStore {
         try {
             // Check if FTS index already exists
             const indices = await table.listIndices();
-            const hasFtsIndex = indices?.some((idx) => idx.indexType === "FTS" || idx.columns?.includes("text"));
-            if (!hasFtsIndex) {
+            if (!hasFtsIndex(indices)) {
                 // LanceDB @lancedb/lancedb >=0.26: use Index.fts() config
                 const lancedb = await loadLanceDB();
                 await table.createIndex("text", {
@@ -1066,7 +1182,22 @@ export class MemoryStore {
         const inactiveFilter = options?.excludeInactive ?? false;
         const overFetchMultiplier = inactiveFilter ? 20 : 10;
         const fetchLimit = Math.min(safeLimit * overFetchMultiplier, 200);
-        let query = this.table.vectorSearch(vector).distanceType('cosine').limit(fetchLimit);
+        if (this.disableNativeCosine && !this.nativeCosineFallbackLogged) {
+            console.warn("memory-lancedb-pro: LanceDB native vector cosine disabled; scanning candidates and using JS cosine rerank fallback");
+            this.nativeCosineFallbackLogged = true;
+        }
+        let query = this.disableNativeCosine
+            ? this.table.query().select([
+                "id",
+                "text",
+                "vector",
+                "category",
+                "scope",
+                "importance",
+                "timestamp",
+                "metadata",
+            ])
+            : this.table.vectorSearch(vector).distanceType("cosine").limit(fetchLimit);
         // Apply scope filter if provided
         if (scopeFilter && scopeFilter.length > 0) {
             const scopeConditions = scopeFilter
@@ -1077,7 +1208,12 @@ export class MemoryStore {
         const results = await query.toArray();
         const mapped = [];
         for (const row of results) {
-            const distance = Number(row._distance ?? 0);
+            const rowVector = toNumberVector(row.vector);
+            if (rowVector.length !== vector.length)
+                continue;
+            const distance = this.disableNativeCosine
+                ? 1 - cosineSimilarity(vector, rowVector)
+                : Number(row._distance ?? 0);
             const score = 1 / (1 + distance);
             if (score < minScore)
                 continue;
@@ -1091,7 +1227,7 @@ export class MemoryStore {
             const entry = {
                 id: row.id,
                 text: row.text,
-                vector: row.vector,
+                vector: rowVector,
                 category: row.category,
                 scope: rowScope,
                 importance: Number(row.importance),
@@ -1103,10 +1239,13 @@ export class MemoryStore {
                 continue;
             }
             mapped.push({ entry, score });
-            if (mapped.length >= safeLimit)
+            if (!this.disableNativeCosine && mapped.length >= safeLimit)
                 break;
         }
-        return mapped;
+        if (this.disableNativeCosine) {
+            mapped.sort((a, b) => b.score - a.score);
+        }
+        return mapped.slice(0, safeLimit);
     }
     async bm25Search(query, limit = 5, scopeFilter, options) {
         await this.ensureInitialized();
@@ -1116,7 +1255,7 @@ export class MemoryStore {
         const inactiveFilter = options?.excludeInactive ?? false;
         // Over-fetch when filtering inactive records to avoid crowding
         const fetchLimit = inactiveFilter ? Math.min(safeLimit * 20, 200) : safeLimit;
-        if (!this.ftsIndexCreated) {
+        if (!this.ftsIndexCreated && !(await this.refreshFtsSupportFromTable())) {
             return this.lexicalFallbackSearch(query, safeLimit, scopeFilter, options);
         }
         try {
@@ -1235,17 +1374,22 @@ export class MemoryStore {
             throw new Error(`Memory ${id} is outside accessible scopes`);
         }
         // Support both full UUID and short prefix (8+ hex chars)
+        // Also support legacy mem-md-N format from older memory-lancedb-pro versions
         const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
         const prefixRegex = /^[0-9a-f]{8,}$/i;
+        const legacyRegex = /^mem-md-\d+$/i;
         const isFullId = uuidRegex.test(id);
         const isPrefix = !isFullId && prefixRegex.test(id);
-        if (!isFullId && !isPrefix) {
+        const isLegacy = !isFullId && !isPrefix && legacyRegex.test(id);
+        if (!isFullId && !isPrefix && !isLegacy) {
             throw new Error(`Invalid memory ID format: ${id}`);
         }
         let candidates;
-        if (isFullId) {
+        if (isFullId || isLegacy) {
+            // Legacy IDs use exact string match like full UUIDs
+            const safeId = escapeSqlLiteral(id);
             candidates = await this.table.query()
-                .where(`id = '${id}'`)
+                .where(`id = '${safeId}'`)
                 .limit(1)
                 .toArray();
         }
@@ -1280,7 +1424,6 @@ export class MemoryStore {
         await this.ensureInitialized();
         if (isExplicitDenyAllScopeFilter(scopeFilter))
             return [];
-        let query = this.table.query();
         // Build where conditions
         const conditions = [];
         if (scopeFilter && scopeFilter.length > 0) {
@@ -1292,12 +1435,9 @@ export class MemoryStore {
         if (category) {
             conditions.push(`category = '${escapeSqlLiteral(category)}'`);
         }
-        if (conditions.length > 0) {
-            query = query.where(conditions.join(" AND "));
-        }
+        const applyConditions = (query) => conditions.length > 0 ? query.where(conditions.join(" AND ")) : query;
         // Fetch all matching rows (no pre-limit) so app-layer sort is correct across full dataset
-        const results = await query
-            .select([
+        const results = await this.queryRowsWithProjectionFallback(applyConditions, [
             "id",
             "text",
             "category",
@@ -1305,8 +1445,7 @@ export class MemoryStore {
             "importance",
             "timestamp",
             "metadata",
-        ])
-            .toArray();
+        ]);
         return results
             .map((row) => ({
             id: row.id,
@@ -1321,8 +1460,21 @@ export class MemoryStore {
             .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))
             .slice(offset, offset + limit);
     }
+    async queryRowsWithProjectionFallback(applyFilters, columns) {
+        const projectedRows = await applyFilters(this.table.query())
+            .select(columns)
+            .toArray();
+        if (projectedRows.length > 0) {
+            return projectedRows;
+        }
+        // Some LanceDB upgrades have returned empty projected metadata reads while
+        // the underlying table still has rows. Retry the identical query without
+        // projection so list/stats stay aligned with recall/vector reads.
+        return await applyFilters(this.table.query()).toArray();
+    }
     async stats(scopeFilter) {
         await this.ensureInitialized();
+        await this.refreshFtsSupportFromTable();
         if (isExplicitDenyAllScopeFilter(scopeFilter)) {
             return {
                 totalCount: 0,
@@ -1330,14 +1482,15 @@ export class MemoryStore {
                 categoryCounts: {},
             };
         }
-        let query = this.table.query();
+        const conditions = [];
         if (scopeFilter && scopeFilter.length > 0) {
             const scopeConditions = scopeFilter
                 .map((scope) => `scope = '${escapeSqlLiteral(scope)}'`)
                 .join(" OR ");
-            query = query.where(`((${scopeConditions}) OR scope IS NULL)`);
+            conditions.push(`((${scopeConditions}) OR scope IS NULL)`);
         }
-        const results = await query.select(["scope", "category"]).toArray();
+        const applyConditions = (query) => conditions.length > 0 ? query.where(conditions.join(" AND ")) : query;
+        const results = await this.queryRowsWithProjectionFallback(applyConditions, ["scope", "category"]);
         const scopeCounts = {};
         const categoryCounts = {};
         for (const row of results) {
@@ -1359,15 +1512,19 @@ export class MemoryStore {
         }
         return this.runWithFileLock(() => this.runSerializedUpdate(async () => {
             // Support both full UUID and short prefix (8+ hex chars), same as delete()
+            // Also support legacy mem-md-N format from older memory-lancedb-pro versions
             const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
             const prefixRegex = /^[0-9a-f]{8,}$/i;
+            const legacyRegex = /^mem-md-\d+$/i;
             const isFullId = uuidRegex.test(id);
             const isPrefix = !isFullId && prefixRegex.test(id);
-            if (!isFullId && !isPrefix) {
+            const isLegacy = !isFullId && !isPrefix && legacyRegex.test(id);
+            if (!isFullId && !isPrefix && !isLegacy) {
                 throw new Error(`Invalid memory ID format: ${id}`);
             }
             let rows;
-            if (isFullId) {
+            if (isFullId || isLegacy) {
+                // Legacy IDs use exact string match like full UUIDs
                 const safeId = escapeSqlLiteral(id);
                 rows = await this.table.query()
                     .where(`id = '${safeId}'`)
@@ -1507,10 +1664,29 @@ export class MemoryStore {
     get hasFtsSupport() {
         return this.ftsIndexCreated;
     }
-    /** Last FTS error for diagnostics */
-    _lastFtsError = null;
     get lastFtsError() {
         return this._lastFtsError;
+    }
+    async refreshFtsSupportFromTable() {
+        if (!this.table)
+            return this.ftsIndexCreated;
+        try {
+            const indices = await this.table.listIndices();
+            const available = hasFtsIndex(indices);
+            this.ftsIndexCreated = available;
+            if (available)
+                this._lastFtsError = null;
+            return available;
+        }
+        catch (err) {
+            this.ftsIndexCreated = false;
+            this._lastFtsError = err instanceof Error ? err.message : String(err);
+            return false;
+        }
+    }
+    async refreshFtsSupport() {
+        await this.ensureInitialized();
+        return this.refreshFtsSupportFromTable();
     }
     /** Get FTS index health status */
     getFtsStatus() {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "test:storage-and-schema": "node scripts/run-ci-tests.mjs --group storage-and-schema",
     "test:llm-clients-and-auth": "node scripts/run-ci-tests.mjs --group llm-clients-and-auth",
     "test:packaging-and-workflow": "node scripts/verify-ci-test-manifest.mjs && node scripts/run-ci-tests.mjs --group packaging-and-workflow",
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build && node scripts/verify-package-runtime.mjs",
     "bench": "jiti benchmark/run.ts",
     "bench:locomo": "jiti benchmark/run.ts --benchmark locomo",
     "bench:longmemeval": "jiti benchmark/run.ts --benchmark longmemeval",

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -33,6 +33,7 @@ export const CI_TEST_MANIFEST = [
   { group: "core-regression", runner: "node", file: "test/memory-capability-runtime.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/corpus-indexer.test.mjs" },
   { group: "packaging-and-workflow", runner: "node", file: "test/plugin-manifest-regression.mjs" },
+  { group: "packaging-and-workflow", runner: "node", file: "test/package-runtime.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/session-summary-before-reset.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/self-improvement-reset-note.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/self-improvement.test.mjs", args: ["--test"] },

--- a/scripts/verify-package-runtime.mjs
+++ b/scripts/verify-package-runtime.mjs
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+function fail(message) {
+  throw new Error(`package runtime verification failed: ${message}`);
+}
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(path.join(repoRoot, relativePath), "utf8"));
+}
+
+function normalizeRuntimePath(value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail(`invalid runtime path ${JSON.stringify(value)}`);
+  }
+  return value.replace(/^\.\//, "");
+}
+
+function verifyCompiledRuntime(relativePath, sourceLabel) {
+  const normalized = normalizeRuntimePath(relativePath);
+  if (!/^dist\/.+\.m?js$/i.test(normalized)) {
+    fail(`${sourceLabel} must point at compiled JavaScript under dist/, got ${relativePath}`);
+  }
+
+  const absolutePath = path.join(repoRoot, normalized);
+  if (!existsSync(absolutePath)) {
+    fail(`${sourceLabel} points to missing file ${relativePath}; run npm run build before packaging`);
+  }
+  if (!statSync(absolutePath).isFile()) {
+    fail(`${sourceLabel} does not point to a file: ${relativePath}`);
+  }
+}
+
+const pkg = readJson("package.json");
+
+verifyCompiledRuntime(pkg.main, "package.json main");
+
+const extensions = pkg.openclaw?.extensions;
+if (!Array.isArray(extensions) || extensions.length === 0) {
+  fail("package.json openclaw.extensions must list at least one runtime entry");
+}
+
+for (const extension of extensions) {
+  verifyCompiledRuntime(extension, "package.json openclaw.extensions entry");
+}
+
+const files = Array.isArray(pkg.files) ? pkg.files : [];
+if (!files.includes("dist/**/*")) {
+  fail('package.json files must include "dist/**/*" so compiled runtime output is published');
+}
+
+console.log("Package runtime entries point to compiled dist output");

--- a/test/package-runtime.test.mjs
+++ b/test/package-runtime.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+
+assert.equal(pkg.scripts?.build, "tsc -p tsconfig.json");
+assert.equal(
+  pkg.scripts?.prepack,
+  "npm run build && node scripts/verify-package-runtime.mjs",
+  "prepack should build and verify compiled runtime output before publishing",
+);
+assert.equal(pkg.main, "dist/index.js");
+assert.deepEqual(pkg.openclaw?.extensions, ["./dist/index.js"]);
+assert.ok(
+  pkg.files?.includes("dist/**/*"),
+  "published package files should include compiled dist output",
+);
+
+const result = spawnSync(process.execPath, ["scripts/verify-package-runtime.mjs"], {
+  cwd: new URL("..", import.meta.url),
+  encoding: "utf8",
+});
+
+assert.equal(
+  result.status,
+  0,
+  result.stderr || result.stdout || "verify-package-runtime.mjs should pass",
+);


### PR DESCRIPTION
## Summary

Fixes #821.

- add a `build` script that compiles TypeScript into `dist/`
- run `npm run build` from `prepack` so published packages include compiled runtime output
- add `scripts/verify-package-runtime.mjs` to fail packaging when `package.json main` or `openclaw.extensions` point at missing/non-dist runtime files
- add a packaging regression test and include it in the packaging CI group
- refresh tracked `dist/` output from the current TypeScript sources

## Why

OpenClaw package installs require compiled JavaScript runtime output. Without a build/prepack guard, a clean publish path can ship a package that still points at `./index.ts` or lacks `dist/index.js`, causing install/update failures in ClawHub consumers.

## Validation

```text
node test/package-runtime.test.mjs
node scripts/verify-ci-test-manifest.mjs
node scripts/run-ci-tests.mjs --group packaging-and-workflow
npm pack --dry-run
git diff --check
```
