### PR TITLE
fix: prevent duplicate session memory summaries

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4444,6 +4444,21 @@ const memoryLanceDBProPlugin = {
 
     if (config.sessionStrategy === "systemSessionMemory") {
       const sessionMessageCount = config.sessionMemory?.messageCount ?? 15;
+      const SESSION_SUMMARY_GUARD = Symbol.for("openclaw.memory-lancedb-pro.session-summary-guard");
+      const SESSION_SUMMARY_GUARD_TTL_MS = 24 * 60 * 60 * 1000;
+      const getSessionSummaryGuard = (): Map<string, number> => {
+        const g = globalThis as Record<symbol, unknown>;
+        if (!g[SESSION_SUMMARY_GUARD]) g[SESSION_SUMMARY_GUARD] = new Map<string, number>();
+        return g[SESSION_SUMMARY_GUARD] as Map<string, number>;
+      };
+      const pruneSessionSummaryGuard = (now: number) => {
+        const guard = getSessionSummaryGuard();
+        for (const [key, storedAt] of guard) {
+          if (now - storedAt > SESSION_SUMMARY_GUARD_TTL_MS) {
+            guard.delete(key);
+          }
+        }
+      };
 
       const storeSystemSessionSummary = async (params: {
         agentId: string;
@@ -4526,6 +4541,18 @@ const memoryLanceDBProPlugin = {
               ? ctx.sessionId
               : "unknown";
           const source = resolveSourceFromSessionKey(sessionKey);
+          const guardKey = `${defaultScope}::${sessionKey || "(none)"}::${currentSessionId}`;
+          const guard = getSessionSummaryGuard();
+          const now = Date.now();
+          pruneSessionSummaryGuard(now);
+          if (guard.has(guardKey)) {
+            api.logger.debug?.(
+              `session-memory: duplicate session summary skipped for ${currentSessionId} (agent: ${agentId}, scope: ${defaultScope})`,
+            );
+            return;
+          }
+          guard.set(guardKey, now);
+
           const sessionContent =
             summarizeRecentConversationMessages(event.messages ?? [], sessionMessageCount) ??
             (typeof event.sessionFile === "string"
@@ -4533,6 +4560,7 @@ const memoryLanceDBProPlugin = {
               : null);
 
           if (!sessionContent) {
+            guard.delete(guardKey);
             api.logger.debug("session-memory: no session content found, skipping");
             return;
           }
@@ -4546,6 +4574,19 @@ const memoryLanceDBProPlugin = {
             sessionContent,
           });
         } catch (err) {
+          const sessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : "";
+          const agentId = resolveHookAgentId(
+            typeof ctx.agentId === "string" ? ctx.agentId : undefined,
+            sessionKey,
+          );
+          const defaultScope = isSystemBypassId(agentId)
+            ? config.scopes?.default ?? "global"
+            : scopeManager.getDefaultScope(agentId);
+          const currentSessionId =
+            typeof ctx.sessionId === "string" && ctx.sessionId.trim().length > 0
+              ? ctx.sessionId
+              : "unknown";
+          getSessionSummaryGuard().delete(`${defaultScope}::${sessionKey || "(none)"}::${currentSessionId}`);
           api.logger.warn(`session-memory: failed to save: ${String(err)}`);
         }
       });

--- a/test/session-summary-before-reset.test.mjs
+++ b/test/session-summary-before-reset.test.mjs
@@ -176,6 +176,44 @@ describe("systemSessionMemory before_reset", { concurrency: false }, () => {
     );
   });
 
+  it("stores only one session-summary row for concurrent /new events for the same session", async () => {
+    const dbPath = path.join(workDir, "db-concurrent-idempotent");
+    const logs = [];
+    const api = createApiHarness({ dbPath, embeddingBaseURL });
+    api.logger.debug = (message) => logs.push(["debug", message]);
+    api.logger.warn = (message) => logs.push(["warn", message]);
+
+    memoryLanceDBProPlugin.register(api);
+
+    const event = {
+      reason: "new",
+      messages: [
+        { role: "user", content: "Concurrent reset hooks should not duplicate this." },
+        { role: "assistant", content: "Only one summary should survive." },
+      ],
+    };
+    const ctx = {
+      agentId: "main",
+      sessionKey: "agent:main:telegram:group:-100123:topic:100",
+      sessionId: "session-concurrent-idempotent",
+      workspaceDir: workDir,
+    };
+
+    await Promise.all([
+      api.hooks.before_reset(event, ctx),
+      api.hooks.before_reset(event, ctx),
+      api.hooks.before_reset(event, ctx),
+    ]);
+
+    const store = new MemoryStore({ dbPath, vectorDim: EMBEDDING_DIMENSIONS });
+    const entries = await store.list(undefined, undefined, 10, 0);
+    assert.equal(entries.length, 1, JSON.stringify(logs));
+    assert.equal(
+      logs.filter(([, message]) => message.includes("duplicate session summary skipped")).length,
+      2,
+    );
+  });
+
   it("skips writes for /reset", async () => {
     const dbPath = path.join(workDir, "db-reset");
     const api = createApiHarness({ dbPath, embeddingBaseURL });

--- a/test/session-summary-before-reset.test.mjs
+++ b/test/session-summary-before-reset.test.mjs
@@ -9,6 +9,7 @@ import jitiFactory from "jiti";
 const jiti = jitiFactory(import.meta.url, { interopDefault: true });
 const pluginModule = jiti("../index.ts");
 const memoryLanceDBProPlugin = pluginModule.default || pluginModule;
+const resetRegistration = pluginModule.resetRegistration ?? (() => {});
 const { MemoryStore } = jiti("../src/store.ts");
 
 const EMBEDDING_DIMENSIONS = 4;
@@ -79,12 +80,13 @@ function createApiHarness({ dbPath, embeddingBaseURL }) {
   };
 }
 
-describe("systemSessionMemory before_reset", () => {
+describe("systemSessionMemory before_reset", { concurrency: false }, () => {
   let workDir;
   let embeddingServer;
   let embeddingBaseURL;
 
   beforeEach(async () => {
+    resetRegistration();
     workDir = mkdtempSync(path.join(tmpdir(), "memory-session-summary-"));
     embeddingServer = createEmbeddingServer();
     await new Promise((resolve) => embeddingServer.listen(0, "127.0.0.1", resolve));
@@ -136,6 +138,42 @@ describe("systemSessionMemory before_reset", () => {
     assert.match(entry.text, /Conversation Summary:/);
     assert.match(entry.text, /user: Need to fix the OAuth endpoint\./);
     assert.match(entry.text, /assistant: Patched the endpoint and verified the login flow\./);
+  });
+
+  it("stores only one session-summary row for repeated /new events for the same session", async () => {
+    const dbPath = path.join(workDir, "db-idempotent");
+    const logs = [];
+    const api = createApiHarness({ dbPath, embeddingBaseURL });
+    api.logger.debug = (message) => logs.push(["debug", message]);
+    api.logger.warn = (message) => logs.push(["warn", message]);
+
+    memoryLanceDBProPlugin.register(api);
+
+    const event = {
+      reason: "new",
+      messages: [
+        { role: "user", content: "Summarize this session exactly once." },
+        { role: "assistant", content: "I will write one summary." },
+      ],
+    };
+    const ctx = {
+      agentId: "main",
+      sessionKey: "agent:main:telegram:group:-100123:topic:99",
+      sessionId: "session-idempotent",
+      workspaceDir: workDir,
+    };
+
+    await api.hooks.before_reset(event, ctx);
+    await api.hooks.before_reset(event, ctx);
+    await api.hooks.before_reset(event, ctx);
+
+    const store = new MemoryStore({ dbPath, vectorDim: EMBEDDING_DIMENSIONS });
+    const entries = await store.list(undefined, undefined, 10, 0);
+    assert.equal(entries.length, 1, JSON.stringify(logs));
+    assert.equal(
+      logs.filter(([, message]) => message.includes("duplicate session summary skipped")).length,
+      2,
+    );
   });
 
   it("skips writes for /reset", async () => {


### PR DESCRIPTION
## Summary

Fixes #580.

- add a global idempotency guard for `systemSessionMemory` `/new` summaries
- key the guard by scope, session key, and session id so repeated `before_reset` events for the same rollover do not write duplicate rows
- keep the guard shared across plugin reloads via `Symbol.for(...)`
- release the guard on no-content or failed writes so legitimate retries can still happen
- add a regression test for repeated `/new` events writing exactly one session-summary row

## Why

A single `/new` rollover could trigger repeated `before_reset` executions and persist the same session summary multiple times. That pollutes memory and can make reset/rollover look stuck while duplicate summaries are being embedded and stored.

## Validation

```text
node --test test/session-summary-before-reset.test.mjs
npx tsc --noEmit
git diff --check
```
