### PR TITLE
fix: cap rerank topN by candidate pool

### DIFF
--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -1283,6 +1283,10 @@ export class MemoryRetriever {
         const endpoint =
           this.config.rerankEndpoint || "https://api.jina.ai/v1/rerank";
         const documents = results.map((r) => r.entry.text);
+        const rerankTopN = Math.min(
+          results.length,
+          Math.max(1, this.config.candidatePoolSize),
+        );
 
         // Build provider-specific request
         const { headers, body } = buildRerankRequest(
@@ -1291,7 +1295,7 @@ export class MemoryRetriever {
           model,
           query,
           documents,
-          results.length,
+          rerankTopN,
         );
 
         // Timeout: configurable via rerankTimeoutMs (default: 5000ms)

--- a/test/retriever-rerank-regression.mjs
+++ b/test/retriever-rerank-regression.mjs
@@ -132,6 +132,69 @@ await runTeiScenario();
 
 console.log("OK: rerank regression test passed");
 
+async function runRerankTopNCapScenario() {
+  const entries = Array.from({ length: 6 }, (_, index) => ({
+    ...entry,
+    id: `rerank-topn-${index}`,
+    text: `candidate ${index}`,
+  }));
+  const store = {
+    hasFtsSupport: true,
+    async vectorSearch() {
+      return entries.map((candidate, index) => ({
+        entry: candidate,
+        score: 0.9 - index * 0.05,
+      }));
+    },
+    async bm25Search() {
+      return [];
+    },
+    async hasId(id) {
+      return entries.some((candidate) => candidate.id === id);
+    },
+  };
+  const originalFetch = globalThis.fetch;
+  let capturedBody;
+
+  globalThis.fetch = async (_url, init) => {
+    capturedBody = JSON.parse(init.body);
+    return {
+      ok: true,
+      async json() {
+        return {
+          results: [
+            { index: 0, relevance_score: 0.99 },
+            { index: 1, relevance_score: 0.98 },
+          ],
+        };
+      },
+    };
+  };
+
+  try {
+    const retriever = createRetriever(store, fakeEmbedder, {
+      ...retrieverConfig,
+      candidatePoolSize: 2,
+      minScore: 0,
+      hardMinScore: 0,
+    });
+    await retriever.retrieve({
+      query: "topN cap",
+      limit: 5,
+      scopeFilter: ["global"],
+    });
+
+    assert.equal(capturedBody.documents.length, entries.length);
+    assert.equal(capturedBody.top_n, 2, "rerank top_n should be capped by candidatePoolSize");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+await runRerankTopNCapScenario();
+
+console.log("OK: rerank topN cap test passed");
+
 async function runRerankFallbackDiagnosticsScenario() {
   const originalFetch = globalThis.fetch;
   const originalWarn = console.warn;


### PR DESCRIPTION
## Summary

Addresses the narrow rerank `topN` portion of #786.

- cap provider rerank `top_n`/`top_k` to `retrieval.candidatePoolSize`
- keep candidate documents unchanged for now; this PR only bounds the requested reranked output count
- add a regression test proving Jina `top_n` no longer scales to the full candidate array length

## Why

`rerankResults()` previously passed `results.length` as the provider `topN`, so large candidate sets could ask the reranker to score/return every candidate even when the configured candidate pool was smaller. Capping the requested output count makes the API request respect the configured retrieval budget.

## Validation

```text
node test/retriever-rerank-regression.mjs
npx tsc --noEmit
git diff --check
```
