### PR TITLE
fix: declare OpenClaw memory plugin contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,8 @@ openclaw config get plugins.slots.memory
     "dimensions": 1024,
     "taskQuery": "retrieval.query",
     "taskPassage": "retrieval.passage",
-    "normalized": true
+    "normalized": true,
+    "maxInputChars": 1400
   },
   "dbPath": "~/.openclaw/memory/lancedb-pro",
   "autoCapture": true,
@@ -373,6 +374,28 @@ openclaw config get plugins.slots.memory
 ```
 
 </details>
+
+### OpenClaw hook permissions
+
+Auto-capture uses OpenClaw's conversation hook surface. For non-bundled plugin installs, enable conversation access in your OpenClaw config:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "memory-lancedb-pro": {
+        "hooks": {
+          "allowConversationAccess": true
+        }
+      }
+    }
+  }
+}
+```
+
+Without this, OpenClaw will load recall but block the `agent_end` hook, so new memories will not be captured.
+
+`embedding.maxInputChars` can be set for local embedding servers with small token/batch limits. The plugin applies a conservative default for `nomic-embed-text`.
 
 ### Embedding Providers
 

--- a/index.ts
+++ b/index.ts
@@ -30,6 +30,7 @@ interface PluginConfig {
     model?: string;
     baseURL?: string;
     dimensions?: number;
+    maxInputChars?: number;
     taskQuery?: string;
     taskPassage?: string;
     normalized?: boolean;
@@ -310,6 +311,7 @@ const memoryLanceDBProPlugin = {
       model: config.embedding.model || "text-embedding-3-small",
       baseURL: config.embedding.baseURL,
       dimensions: config.embedding.dimensions,
+      maxInputChars: config.embedding.maxInputChars,
       taskQuery: config.embedding.taskQuery,
       taskPassage: config.embedding.taskPassage,
       normalized: config.embedding.normalized,
@@ -598,7 +600,7 @@ const memoryLanceDBProPlugin = {
 
     async function runBackup() {
       try {
-        const backupDir = api.resolvePath(join(resolvedDbPath, "..", "backups"));
+        const backupDir = join(resolvedDbPath, "..", "backups");
         await mkdir(backupDir, { recursive: true });
 
         const allMemories = await store.list(undefined, undefined, 10000, 0);
@@ -729,6 +731,7 @@ function parsePluginConfig(value: unknown): PluginConfig {
       // Accept number, numeric string, or env-var string (e.g. "${EMBED_DIM}").
       // Also accept legacy top-level `dimensions` for convenience.
       dimensions: parsePositiveInt(embedding.dimensions ?? cfg.dimensions),
+      maxInputChars: parsePositiveInt(embedding.maxInputChars ?? cfg.maxInputChars),
       taskQuery: typeof embedding.taskQuery === "string" ? embedding.taskQuery : undefined,
       taskPassage: typeof embedding.taskPassage === "string" ? embedding.taskPassage : undefined,
       normalized: typeof embedding.normalized === "boolean" ? embedding.normalized : undefined,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -40,6 +40,11 @@
           "normalized": {
             "type": "boolean",
             "description": "Request normalized embeddings when supported by the provider (e.g. Jina v5)"
+          },
+          "maxInputChars": {
+            "type": "integer",
+            "minimum": 100,
+            "description": "Maximum characters sent to the embedding provider per input. Useful for local embedding servers with small context/batch limits; omitted uses a model-specific safe default when known."
           }
         },
         "required": [
@@ -230,6 +235,11 @@
             }
           }
         }
+      },
+      "maxInputChars": {
+        "type": "integer",
+        "minimum": 100,
+        "description": "Legacy top-level alias for embedding.maxInputChars."
       }
     },
     "required": [
@@ -398,6 +408,26 @@
       "label": "Normalized Embeddings",
       "help": "Request normalized embeddings when the provider supports it (Jina v5). If unset, the field is not sent.",
       "advanced": true
+    },
+    "embedding.maxInputChars": {
+      "label": "Max Input Characters",
+      "help": "Maximum characters sent to the embedding provider per input. Set lower for local embedding servers with small context/batch limits.",
+      "advanced": true
+    },
+    "maxInputChars": {
+      "label": "Max Input Characters",
+      "help": "Legacy top-level alias for embedding.maxInputChars.",
+      "advanced": true
     }
+  },
+  "contracts": {
+    "tools": [
+      "memory_recall",
+      "memory_store",
+      "memory_forget",
+      "memory_update",
+      "memory_stats",
+      "memory_list"
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memory-lancedb-pro",
-  "version": "1.0.9",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memory-lancedb-pro",
-      "version": "1.0.9",
+      "version": "1.0.13",
       "license": "MIT",
       "dependencies": {
         "@lancedb/lancedb": "^0.26.2",

--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -94,6 +94,8 @@ export interface EmbeddingConfig {
   taskPassage?: string;
   /** Optional flag to request normalized embeddings (provider-dependent, e.g. Jina v5) */
   normalized?: boolean;
+  /** Optional max chars per embedding input; protects small local embedding servers. */
+  maxInputChars?: number;
 }
 
 // Known embedding model dimensions
@@ -116,6 +118,23 @@ const EMBEDDING_DIMENSIONS: Record<string, number> = {
 // ============================================================================
 // Utility Functions
 // ============================================================================
+
+function defaultMaxInputChars(model: string): number | undefined {
+  // Local llama.cpp embedding servers commonly run with small physical batch
+  // sizes; nomic-embed-text in particular can reject prompts just over 512
+  // tokens. Keep the default conservative for known local models while leaving
+  // hosted/OpenAI models unconstrained unless configured.
+  const normalized = model.toLowerCase();
+  if (normalized.includes("nomic-embed-text")) return 1400;
+  return undefined;
+}
+
+function truncateForEmbedding(text: string, maxChars?: number): string {
+  const trimmed = text.trim();
+  if (!maxChars || trimmed.length <= maxChars) return trimmed;
+  if (maxChars <= 1) return trimmed.slice(0, maxChars);
+  return trimmed.slice(0, maxChars - 1).trimEnd() + "…";
+}
 
 function resolveEnvVars(value: string): string {
   return value.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
@@ -158,6 +177,7 @@ export class Embedder {
 
   /** Optional requested dimensions to pass through to the embedding provider (OpenAI-compatible). */
   private readonly _requestDimensions?: number;
+  private readonly _maxInputChars?: number;
 
   constructor(config: EmbeddingConfig) {
     // Resolve environment variables in API key
@@ -168,6 +188,9 @@ export class Embedder {
     this._taskPassage = config.taskPassage;
     this._normalized = config.normalized;
     this._requestDimensions = config.dimensions;
+    this._maxInputChars = typeof config.maxInputChars === "number" && config.maxInputChars > 0
+      ? Math.floor(config.maxInputChars)
+      : defaultMaxInputChars(config.model);
 
     this.client = new OpenAI({
       apiKey: resolvedApiKey,
@@ -233,9 +256,13 @@ export class Embedder {
   }
 
   private buildPayload(input: string | string[], task?: string): any {
+    const safeInput = Array.isArray(input)
+      ? input.map((item) => truncateForEmbedding(item, this._maxInputChars))
+      : truncateForEmbedding(input, this._maxInputChars);
+
     const payload: any = {
       model: this.model,
-      input,
+      input: safeInput,
       // Force float output to avoid SDK default base64 decoding path.
       encoding_format: "float",
     };
@@ -259,18 +286,20 @@ export class Embedder {
     }
 
     // Check cache first
-    const cached = this._cache.get(text, task);
+    const inputText = truncateForEmbedding(text, this._maxInputChars);
+
+    const cached = this._cache.get(inputText, task);
     if (cached) return cached;
 
     try {
-      const response = await this.client.embeddings.create(this.buildPayload(text, task) as any);
+      const response = await this.client.embeddings.create(this.buildPayload(inputText, task) as any);
       const embedding = response.data[0]?.embedding as number[] | undefined;
       if (!embedding) {
         throw new Error("No embedding returned from provider");
       }
 
       this.validateEmbedding(embedding);
-      this._cache.set(text, task, embedding);
+      this._cache.set(inputText, task, embedding);
       return embedding;
     } catch (error) {
       if (error instanceof Error) {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -4,7 +4,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import { stringEnum } from "openclaw/plugin-sdk";
+import { stringEnum } from "openclaw/plugin-sdk/core";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { MemoryRetriever, RetrievalResult } from "./retriever.js";
 import type { MemoryStore } from "./store.js";


### PR DESCRIPTION
## Summary
- declare OpenClaw tool contracts for memory tools so current OpenClaw builds allow registration
- document required hooks.allowConversationAccess for agent_end auto-capture
- add embedding.maxInputChars and a conservative nomic-embed-text default to avoid small local embedding-server batch limits
- fix backup path construction when dbPath is already resolved
- update plugin-sdk import path for stringEnum

## Verification
- npm test
- openclaw plugins registry --refresh
- openclaw plugins doctor
- node/jiti import of index.ts

Note: a direct tsc --noEmit check still exposes pre-existing LanceDB/typebox typing issues in store/tools that are outside this compatibility patch.