### PR TITLE
fix: scan import-markdown dedup candidates

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -799,7 +799,7 @@ export async function runImportMarkdown(
       if (dedupEnabled) {
         try {
           const existing = await ctx.store.bm25Search(text, 5, [effectiveScope]);
-          if (existing.length > 0 && existing[0].entry.text === text) {
+          if (existing.some((result) => result.entry.text === text)) {
             skipped++;
             fileSkipped++;
             if (!options.dryRun) {

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -527,7 +527,7 @@ export async function runImportMarkdown(ctx, workspaceGlob, options) {
             if (dedupEnabled) {
                 try {
                     const existing = await ctx.store.bm25Search(text, 5, [effectiveScope]);
-                    if (existing.length > 0 && existing[0].entry.text === text) {
+                    if (existing.some((result) => result.entry.text === text)) {
                         skipped++;
                         if (!options.dryRun) {
                             console.log(`  [skip] already imported: ${text.slice(0, 60)}${text.length > 60 ? "..." : ""}`);

--- a/test/import-markdown/import-markdown.test.mjs
+++ b/test/import-markdown/import-markdown.test.mjs
@@ -266,6 +266,48 @@ describe("import-markdown CLI", () => {
       assert.strictEqual(mockStore.storedRecords.length, 2); // Two entries, different scopes
     });
 
+    it("skips an exact duplicate even when BM25 ranks it below a similar result", async () => {
+      const wsDir = await setupWorkspace("dedup-rank-test");
+      await writeFile(join(wsDir, "MEMORY.md"), "- Exact duplicate memory\n", "utf-8");
+
+      const rankedStore = {
+        ...mockStore,
+        async bm25Search(query, limit = 1, scopeFilter = []) {
+          assert.strictEqual(query, "Exact duplicate memory");
+          assert.deepStrictEqual(scopeFilter, ["dedup-rank-test"]);
+          return [
+            {
+              entry: {
+                text: "Similar but not exact duplicate memory",
+                scope: "dedup-rank-test",
+              },
+              score: 1.0,
+            },
+            {
+              entry: {
+                text: "Exact duplicate memory",
+                scope: "dedup-rank-test",
+              },
+              score: 0.95,
+            },
+          ].slice(0, limit);
+        },
+      };
+
+      const { imported, skipped } = await runImportMarkdown(
+        { embedder: mockEmbedder, store: rankedStore },
+        {
+          openclawHome: testWorkspaceDir,
+          workspaceGlob: "dedup-rank-test",
+          dedup: true,
+        },
+      );
+
+      assert.strictEqual(imported, 0);
+      assert.strictEqual(skipped, 1);
+      assert.strictEqual(mockStore.storedRecords.length, 0);
+    });
+
     it("batch imports mixed valid, short, duplicate, and cross-scope bullets", async () => {
       const isolatedHome = join(tmpdir(), "import-markdown-batch-dedup-test-" + Date.now());
       const workspaceA = join(isolatedHome, "workspace", "workspace-a");


### PR DESCRIPTION
## Summary
- Fix import-markdown dedup to scan all returned BM25 candidates for exact text matches instead of only rank 1.
- Add a regression where BM25 returns a similar non-exact result first and the exact duplicate second.
- Keep the fix intentionally narrow: no semantic retrieval, no reranker, and no broader Bloom/hash implementation.

## Validation
- `node --test test/import-markdown/import-markdown.test.mjs`
- `node scripts/run-ci-tests.mjs --group cli-smoke`

Addresses the narrow dedup follow-up in #715.
