### PR TITLE
fix: filter meta frustration before smart extraction

### DIFF
--- a/dist/src/noise-filter.js
+++ b/dist/src/noise-filter.js
@@ -32,6 +32,13 @@ const META_QUESTION_PATTERNS = [
     /你[知晓]道.+吗/,
     /我(?:之前|上次|以前)(?:说|提|讲).*(?:吗|呢|？|\?)/,
 ];
+const META_FRUSTRATION_PATTERNS = [
+    /\byou (never|don'?t|do not|can'?t|cannot) (remember|recall|get|understand)\b/i,
+    /\bwhy (do|can) you (keep )?(forget|not remember|never remember)\b/i,
+    /\bdid you (get|understand) what i (said|told you|meant)\b/i,
+    /^\s*what (just )?changed\??\s*$/i,
+    /\bwhy (is|are) (my|the) memor(y|ies) (wrong|missing|broken|not working)\b/i,
+];
 // Session boilerplate
 const BOILERPLATE_PATTERNS = [
     /^(hi|hello|hey|good morning|good evening|greetings)/i,
@@ -65,6 +72,10 @@ const DEFAULT_OPTIONS = {
     filterMetaQuestions: true,
     filterBoilerplate: true,
 };
+export function isMetaFrustrationNoise(text) {
+    const trimmed = text.trim();
+    return META_FRUSTRATION_PATTERNS.some(p => p.test(trimmed));
+}
 /**
  * Check if a memory text is noise that should be filtered out.
  * Returns true if the text is noise.
@@ -76,7 +87,7 @@ export function isNoise(text, options = {}) {
         return true;
     if (opts.filterDenials && DENIAL_PATTERNS.some(p => p.test(trimmed)))
         return true;
-    if (opts.filterMetaQuestions && META_QUESTION_PATTERNS.some(p => p.test(trimmed)))
+    if (opts.filterMetaQuestions && (META_QUESTION_PATTERNS.some(p => p.test(trimmed)) || isMetaFrustrationNoise(trimmed)))
         return true;
     if (opts.filterBoilerplate && BOILERPLATE_PATTERNS.some(p => p.test(trimmed)))
         return true;

--- a/dist/src/smart-extractor.js
+++ b/dist/src/smart-extractor.js
@@ -8,7 +8,7 @@
 import { buildExtractionPrompt, buildDedupPrompt, buildMergePrompt, } from "./extraction-prompts.js";
 import { AdmissionController, } from "./admission-control.js";
 import { ALWAYS_MERGE_CATEGORIES, MERGE_SUPPORTED_CATEGORIES, TEMPORAL_VERSIONED_CATEGORIES, normalizeCategory, } from "./memory-categories.js";
-import { isNoise } from "./noise-filter.js";
+import { isMetaFrustrationNoise, isNoise } from "./noise-filter.js";
 import { appendRelation, buildSmartMetadata, deriveFactKey, parseSmartMetadata, stringifySmartMetadata, parseSupportInfo, updateSupportStats, } from "./smart-metadata.js";
 import { isUserMdExclusiveMemory, } from "./workspace-boundary.js";
 import { classifyTemporal, inferExpiry } from "./temporal-classifier.js";
@@ -302,26 +302,34 @@ export class SmartExtractor {
     // Embedding Noise Pre-Filter
     // --------------------------------------------------------------------------
     /**
-     * Filter out texts that match noise prototypes by embedding similarity.
-     * Long texts (>300 chars) are passed through without checking.
-     * Only active when noiseBank is configured and initialized.
+     * Filter out texts that match cheap static noise patterns first, then
+     * filter remaining texts that match noise prototypes by embedding similarity.
+     * Long texts (>300 chars) are passed through without embedding checks.
+     * Embedding checks are only active when noiseBank is configured and initialized.
      *
      * Uses batch embedding to reduce API round-trips from N to 1.
      */
     async filterNoiseByEmbedding(texts) {
+        const staticFiltered = texts.filter((text) => {
+            const noisy = isMetaFrustrationNoise(text);
+            if (noisy) {
+                this.debugLog(`memory-lancedb-pro: smart-extractor: static noise filtered: ${text.slice(0, 80)}`);
+            }
+            return !noisy;
+        });
         const noiseBank = this.config.noiseBank;
         if (!noiseBank || !noiseBank.initialized)
-            return texts;
+            return staticFiltered;
         // Partition: short/long texts bypass noise check; mid-length need embedding
         const SHORT_THRESHOLD = 8;
         const LONG_THRESHOLD = 300;
-        const bypassFlags = texts.map((t) => t.length <= SHORT_THRESHOLD || t.length > LONG_THRESHOLD);
+        const bypassFlags = staticFiltered.map((t) => t.length <= SHORT_THRESHOLD || t.length > LONG_THRESHOLD);
         const needsEmbedIndices = [];
         const needsEmbedTexts = [];
-        for (let i = 0; i < texts.length; i++) {
+        for (let i = 0; i < staticFiltered.length; i++) {
             if (!bypassFlags[i]) {
                 needsEmbedIndices.push(i);
-                needsEmbedTexts.push(texts[i]);
+                needsEmbedTexts.push(staticFiltered[i]);
             }
         }
         // Batch embed all mid-length texts in a single API call
@@ -332,14 +340,14 @@ export class SmartExtractor {
             }
             catch {
                 // Batch failed — pass all through
-                return texts.slice();
+                return staticFiltered.slice();
             }
         }
-        const result = new Array(texts.length);
+        const result = new Array(staticFiltered.length);
         // First, fill in bypass texts (always kept)
-        for (let i = 0; i < texts.length; i++) {
+        for (let i = 0; i < staticFiltered.length; i++) {
             if (bypassFlags[i]) {
-                result[i] = texts[i];
+                result[i] = staticFiltered[i];
             }
         }
         // Then, check noise for embedded texts
@@ -347,15 +355,15 @@ export class SmartExtractor {
             const idx = needsEmbedIndices[j];
             const vec = vectors[j];
             if (!vec || vec.length === 0) {
-                result[idx] = texts[idx];
+                result[idx] = staticFiltered[idx];
                 continue;
             }
             if (noiseBank.isNoise(vec)) {
-                this.debugLog(`memory-lancedb-pro: smart-extractor: embedding noise filtered: ${texts[idx].slice(0, 80)}`);
+                this.debugLog(`memory-lancedb-pro: smart-extractor: embedding noise filtered: ${staticFiltered[idx].slice(0, 80)}`);
                 // Leave result[idx] as undefined — will be compacted below
             }
             else {
-                result[idx] = texts[idx];
+                result[idx] = staticFiltered[idx];
             }
         }
         // Compact: remove undefined slots (filtered-out entries).

--- a/src/noise-filter.ts
+++ b/src/noise-filter.ts
@@ -35,6 +35,14 @@ const META_QUESTION_PATTERNS = [
   /我(?:之前|上次|以前)(?:说|提|讲).*(?:吗|呢|？|\?)/,
 ];
 
+const META_FRUSTRATION_PATTERNS = [
+  /\byou (never|don'?t|do not|can'?t|cannot) (remember|recall|get|understand)\b/i,
+  /\bwhy (do|can) you (keep )?(forget|not remember|never remember)\b/i,
+  /\bdid you (get|understand) what i (said|told you|meant)\b/i,
+  /^\s*what (just )?changed\??\s*$/i,
+  /\bwhy (is|are) (my|the) memor(y|ies) (wrong|missing|broken|not working)\b/i,
+];
+
 // Session boilerplate
 const BOILERPLATE_PATTERNS = [
   /^(hi|hello|hey|good morning|good evening|greetings)/i,
@@ -81,6 +89,11 @@ const DEFAULT_OPTIONS: Required<NoiseFilterOptions> = {
   filterBoilerplate: true,
 };
 
+export function isMetaFrustrationNoise(text: string): boolean {
+  const trimmed = text.trim();
+  return META_FRUSTRATION_PATTERNS.some(p => p.test(trimmed));
+}
+
 /**
  * Check if a memory text is noise that should be filtered out.
  * Returns true if the text is noise.
@@ -92,7 +105,7 @@ export function isNoise(text: string, options: NoiseFilterOptions = {}): boolean
   if (trimmed.length < 5) return true;
 
   if (opts.filterDenials && DENIAL_PATTERNS.some(p => p.test(trimmed))) return true;
-  if (opts.filterMetaQuestions && META_QUESTION_PATTERNS.some(p => p.test(trimmed))) return true;
+  if (opts.filterMetaQuestions && (META_QUESTION_PATTERNS.some(p => p.test(trimmed)) || isMetaFrustrationNoise(trimmed))) return true;
   if (opts.filterBoilerplate && BOILERPLATE_PATTERNS.some(p => p.test(trimmed))) return true;
   if (DIAGNOSTIC_ARTIFACT_PATTERNS.some(p => p.test(trimmed))) return true;
 

--- a/src/smart-extractor.ts
+++ b/src/smart-extractor.ts
@@ -32,7 +32,7 @@ import {
   TEMPORAL_VERSIONED_CATEGORIES,
   normalizeCategory,
 } from "./memory-categories.js";
-import { isNoise } from "./noise-filter.js";
+import { isMetaFrustrationNoise, isNoise } from "./noise-filter.js";
 import type { NoisePrototypeBank } from "./noise-prototypes.js";
 import {
   appendRelation,
@@ -452,29 +452,40 @@ export class SmartExtractor {
   // --------------------------------------------------------------------------
 
   /**
-   * Filter out texts that match noise prototypes by embedding similarity.
-   * Long texts (>300 chars) are passed through without checking.
-   * Only active when noiseBank is configured and initialized.
+   * Filter out texts that match cheap static noise patterns first, then
+   * filter remaining texts that match noise prototypes by embedding similarity.
+   * Long texts (>300 chars) are passed through without embedding checks.
+   * Embedding checks are only active when noiseBank is configured and initialized.
    *
    * Uses batch embedding to reduce API round-trips from N to 1.
    */
   async filterNoiseByEmbedding(texts: string[]): Promise<string[]> {
+    const staticFiltered = texts.filter((text) => {
+      const noisy = isMetaFrustrationNoise(text);
+      if (noisy) {
+        this.debugLog(
+          `memory-lancedb-pro: smart-extractor: static noise filtered: ${text.slice(0, 80)}`,
+        );
+      }
+      return !noisy;
+    });
+
     const noiseBank = this.config.noiseBank;
-    if (!noiseBank || !noiseBank.initialized) return texts;
+    if (!noiseBank || !noiseBank.initialized) return staticFiltered;
 
     // Partition: short/long texts bypass noise check; mid-length need embedding
     const SHORT_THRESHOLD = 8;
     const LONG_THRESHOLD = 300;
-    const bypassFlags: boolean[] = texts.map(
+    const bypassFlags: boolean[] = staticFiltered.map(
       (t) => t.length <= SHORT_THRESHOLD || t.length > LONG_THRESHOLD,
     );
 
     const needsEmbedIndices: number[] = [];
     const needsEmbedTexts: string[] = [];
-    for (let i = 0; i < texts.length; i++) {
+    for (let i = 0; i < staticFiltered.length; i++) {
       if (!bypassFlags[i]) {
         needsEmbedIndices.push(i);
-        needsEmbedTexts.push(texts[i]);
+        needsEmbedTexts.push(staticFiltered[i]);
       }
     }
 
@@ -485,15 +496,15 @@ export class SmartExtractor {
         vectors = await this.embedder.embedBatch(needsEmbedTexts);
       } catch {
         // Batch failed — pass all through
-        return texts.slice();
+        return staticFiltered.slice();
       }
     }
 
-    const result: string[] = new Array(texts.length);
+    const result: string[] = new Array(staticFiltered.length);
     // First, fill in bypass texts (always kept)
-    for (let i = 0; i < texts.length; i++) {
+    for (let i = 0; i < staticFiltered.length; i++) {
       if (bypassFlags[i]) {
-        result[i] = texts[i];
+        result[i] = staticFiltered[i];
       }
     }
 
@@ -502,16 +513,16 @@ export class SmartExtractor {
       const idx = needsEmbedIndices[j];
       const vec = vectors[j];
       if (!vec || vec.length === 0) {
-        result[idx] = texts[idx];
+        result[idx] = staticFiltered[idx];
         continue;
       }
       if (noiseBank.isNoise(vec)) {
         this.debugLog(
-          `memory-lancedb-pro: smart-extractor: embedding noise filtered: ${texts[idx].slice(0, 80)}`,
+          `memory-lancedb-pro: smart-extractor: embedding noise filtered: ${staticFiltered[idx].slice(0, 80)}`,
         );
         // Leave result[idx] as undefined — will be compacted below
       } else {
-        result[idx] = texts[idx];
+        result[idx] = staticFiltered[idx];
       }
     }
 

--- a/test/smart-extractor-batch-embed.test.mjs
+++ b/test/smart-extractor-batch-embed.test.mjs
@@ -195,6 +195,28 @@ describe("SmartExtractor batch embedding paths", () => {
       `Expected 0 embed calls (batch path), got ${calls.embed}`);
   });
 
+  it("filters meta-frustration text before smart extraction embedding", async () => {
+    const { embedder, calls } = makeCountingEmbedder();
+    const llm = makeLlm([]);
+    const store = makeStore();
+    const extractor = makeExtractor(embedder, llm, store);
+
+    const inputTexts = [
+      "you never remember anything I say",
+      "did you get what i said",
+      "what just changed?",
+      "My favorite editor is Zed because it keeps the interface quiet.",
+    ];
+
+    const result = await extractor.filterNoiseByEmbedding(inputTexts);
+
+    assert.deepStrictEqual(result, [
+      "My favorite editor is Zed because it keeps the interface quiet.",
+    ]);
+    assert.strictEqual(calls.embedBatch, 0, "static filter should not call embedBatch without a noise bank");
+    assert.strictEqual(calls.embed, 0, "static filter should not call embed without a noise bank");
+  });
+
   // --------------------------------------------------------------------------
   // Test 3: Batch pre-compute for non-profile candidates uses embedBatch
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a narrow meta/frustration noise pattern set for phrases like "you never remember", "did you get what I said", and "what just changed?".
- Apply those cheap static patterns before smart extraction embedding/LLM work, so obvious frustration/meta turns do not become candidate memories.
- Keep the broader embedding noise-bank behavior unchanged for non-frustration text.

## Validation
- `node test/smart-extractor-batch-embed.test.mjs`
- `node test/smart-extractor-branches.mjs`

Note: `node scripts/run-ci-tests.mjs --group core-regression` currently also trips existing `test/recall-text-cleanup.test.mjs` auto-recall fixture assertions locally; those failures are outside this smart-extractor/noise-filter path.

Fixes #635.
