### PR TITLE
fix: clarify plugin config preflight errors

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3757,13 +3757,19 @@ const memoryLanceDBProPlugin = {
     },
 };
 export function parsePluginConfig(value) {
-    if (!value || typeof value !== "object" || Array.isArray(value)) {
-        throw new Error("memory-lancedb-pro config required");
+    if (value === undefined || value === null) {
+        throw new Error("memory-lancedb-pro: no plugin config supplied; top-level config.embedding is required when the plugin is activated. " +
+            "If this happens during OpenClaw CLI/preflight loading, the loader should skip validation when entry.config is undefined.");
+    }
+    if (typeof value !== "object" || Array.isArray(value)) {
+        throw new Error("memory-lancedb-pro: plugin config must be an object with a top-level embedding block at " +
+            "plugins.entries.memory-lancedb-pro.config.embedding.");
     }
     const cfg = value;
     const embedding = cfg.embedding;
     if (!embedding) {
-        throw new Error("embedding config is required");
+        throw new Error("memory-lancedb-pro: missing top-level config.embedding block. " +
+            "Set plugins.entries.memory-lancedb-pro.config.embedding; do not nest it as config.embedding.embedding.");
     }
     // Accept single key (string) or array of keys for round-robin rotation
     let apiKey;

--- a/index.ts
+++ b/index.ts
@@ -4775,14 +4775,26 @@ const memoryLanceDBProPlugin = {
 };
 
 export function parsePluginConfig(value: unknown): PluginConfig {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("memory-lancedb-pro config required");
+  if (value === undefined || value === null) {
+    throw new Error(
+      "memory-lancedb-pro: no plugin config supplied; top-level config.embedding is required when the plugin is activated. " +
+      "If this happens during OpenClaw CLI/preflight loading, the loader should skip validation when entry.config is undefined.",
+    );
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(
+      "memory-lancedb-pro: plugin config must be an object with a top-level embedding block at " +
+      "plugins.entries.memory-lancedb-pro.config.embedding.",
+    );
   }
   const cfg = value as Record<string, unknown>;
 
   const embedding = cfg.embedding as Record<string, unknown> | undefined;
   if (!embedding) {
-    throw new Error("embedding config is required");
+    throw new Error(
+      "memory-lancedb-pro: missing top-level config.embedding block. " +
+      "Set plugins.entries.memory-lancedb-pro.config.embedding; do not nest it as config.embedding.embedding.",
+    );
   }
 
   // Accept single key (string) or array of keys for round-robin rotation

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1436,10 +1436,7 @@
           }
         }
       }
-    },
-    "required": [
-      "embedding"
-    ]
+    }
   },
   "uiHints": {
     "embedding.apiKey": {

--- a/test/config-session-strategy-migration.test.mjs
+++ b/test/config-session-strategy-migration.test.mjs
@@ -23,6 +23,27 @@ function baseConfig() {
 }
 
 describe("sessionStrategy legacy compatibility mapping", () => {
+  it("explains undefined config as a preflight/activation mismatch", () => {
+    assert.throws(
+      () => parsePluginConfig(undefined),
+      /no plugin config supplied.*top-level config\.embedding.*preflight/i,
+    );
+  });
+
+  it("explains non-object config shape clearly", () => {
+    assert.throws(
+      () => parsePluginConfig("not-json"),
+      /plugin config must be an object.*plugins\.entries\.memory-lancedb-pro\.config\.embedding/i,
+    );
+  });
+
+  it("explains missing embedding as a top-level config shape issue", () => {
+    assert.throws(
+      () => parsePluginConfig({ enabled: true }),
+      /missing top-level config\.embedding.*do not nest it as config\.embedding\.embedding/i,
+    );
+  });
+
   it("maps legacy sessionMemory.enabled=true to systemSessionMemory", () => {
     const parsed = parsePluginConfig({
       ...baseConfig(),

--- a/test/config-session-strategy-migration.test.mjs
+++ b/test/config-session-strategy-migration.test.mjs
@@ -22,7 +22,7 @@ function baseConfig() {
   };
 }
 
-describe("sessionStrategy legacy compatibility mapping", () => {
+describe("plugin config error hints", () => {
   it("explains undefined config as a preflight/activation mismatch", () => {
     assert.throws(
       () => parsePluginConfig(undefined),
@@ -43,7 +43,9 @@ describe("sessionStrategy legacy compatibility mapping", () => {
       /missing top-level config\.embedding.*do not nest it as config\.embedding\.embedding/i,
     );
   });
+});
 
+describe("sessionStrategy legacy compatibility mapping", () => {
   it("maps legacy sessionMemory.enabled=true to systemSessionMemory", () => {
     const parsed = parsePluginConfig({
       ...baseConfig(),

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -109,6 +109,14 @@ assert.equal(
   true,
   "embedding.chunking schema default should match runtime default",
 );
+assert.ok(
+  !(manifest.configSchema.required ?? []).includes("embedding"),
+  "root configSchema should not require embedding because OpenClaw preflight validates undefined plugin config as {} before runtime parsePluginConfig can emit the clearer activation error",
+);
+assert.ok(
+  manifest.configSchema.properties.embedding.required.includes("apiKey"),
+  "embedding.apiKey should remain schema-required when an embedding block is supplied",
+);
 assert.equal(
   manifest.configSchema.properties.embedding.properties.omitDimensions?.type,
   "boolean",


### PR DESCRIPTION
## Summary
- Keep runtime config validation strict, but make missing/invalid root config errors actionable.
- Distinguish undefined preflight config, non-object config, and missing top-level `config.embedding`.
- Point users and loader maintainers at `plugins.entries.memory-lancedb-pro.config.embedding` instead of the confusing nested `embedding.embedding` interpretation.

## Validation
- `node --test test/config-session-strategy-migration.test.mjs`
- `node test/plugin-manifest-regression.mjs`

Fixes #685.
