### PR TITLE
Add memory_reflection_resolve tool

### DIFF
--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -13,7 +13,7 @@ import { appendRelation, buildSmartMetadata, deriveFactKey, parseSmartMetadata, 
 import { classifyTemporal, inferExpiry } from "./temporal-classifier.js";
 import { TEMPORAL_VERSIONED_CATEGORIES } from "./memory-categories.js";
 import { appendSelfImprovementEntry, countSelfImprovementEntries, DEFAULT_SELF_IMPROVEMENT_MAX_ENTRIES, ensureSelfImprovementLearningFiles, } from "./self-improvement-files.js";
-import { getDisplayCategoryTag } from "./reflection-metadata.js";
+import { getDisplayCategoryTag, parseReflectionMetadata } from "./reflection-metadata.js";
 import { filterUserMdExclusiveRecallResults, isUserMdExclusiveMemory, } from "./workspace-boundary.js";
 // ============================================================================
 // Types
@@ -78,6 +78,32 @@ function sanitizeMemoryForSerialization(results) {
         score: r.score,
         sources: r.sources,
     }));
+}
+function isUnresolvedReflectionItem(entry) {
+    const metadata = parseReflectionMetadata(entry.metadata);
+    return metadata.type === "memory-reflection-item" && metadata.resolvedAt === undefined;
+}
+function formatReflectionResolveCandidate(result) {
+    const metadata = parseReflectionMetadata(result.entry.metadata);
+    return {
+        id: result.entry.id,
+        text: truncateText(normalizeInlineText(result.entry.text), 220),
+        itemKind: metadata.itemKind,
+        agentId: metadata.agentId,
+        score: result.score,
+    };
+}
+function formatReflectionResolvePreview(candidates) {
+    const lines = candidates.map((candidate, idx) => {
+        const metadata = parseReflectionMetadata(candidate.entry.metadata);
+        const itemKind = typeof metadata.itemKind === "string" ? metadata.itemKind : "item";
+        const scoreText = typeof candidate.score === "number" ? ` score=${candidate.score.toFixed(3)}` : "";
+        return `${idx + 1}. [${candidate.entry.id}] ${itemKind}${scoreText}: ${truncateText(normalizeInlineText(candidate.entry.text), 180)}`;
+    });
+    return [
+        `Reflection resolve preview: ${candidates.length} candidate(s). No changes made.`,
+        ...lines,
+    ].join("\n");
 }
 const _warnedMissingAgentId = new Set();
 /** @internal Exported for testing only — resets the missing-agent warning throttle. */
@@ -1654,6 +1680,180 @@ export function registerMemoryArchiveTool(api, context) {
         };
     }, { name: "memory_archive" });
 }
+export function registerMemoryReflectionResolveTool(api, context) {
+    api.registerTool((toolCtx) => {
+        const runtimeContext = resolveToolContext(context, toolCtx);
+        return {
+            name: "memory_reflection_resolve",
+            label: "Memory Reflection Resolve",
+            description: "Mark a single memory-reflection item resolved so it stops participating in reflection recall.",
+            parameters: Type.Object({
+                memoryId: Type.Optional(Type.String({ description: "Reflection item id or id prefix." })),
+                query: Type.Optional(Type.String({ description: "Search query to preview matching unresolved reflection items." })),
+                scope: Type.Optional(Type.String({ description: "Optional scope filter." })),
+                dryRun: Type.Optional(Type.Boolean({ description: "Preview only. Defaults to true for query mode and false for memoryId mode." })),
+                note: Type.Optional(Type.String({ description: "Optional resolution note for audit trail." })),
+                limit: Type.Optional(Type.Number({ description: "Maximum query candidates to preview (default 5, max 20)." })),
+            }),
+            async execute(_toolCallId, params, _signal, _onUpdate, runtimeCtx) {
+                const { memoryId, query, scope, dryRun, note, limit = 5, } = params;
+                const trimmedMemoryId = memoryId?.trim();
+                const trimmedQuery = query?.trim();
+                if (!trimmedMemoryId && !trimmedQuery) {
+                    return {
+                        content: [{ type: "text", text: "Provide memoryId or query." }],
+                        details: { error: "missing_selector" },
+                    };
+                }
+                if (trimmedMemoryId && trimmedQuery) {
+                    return {
+                        content: [{ type: "text", text: "Provide only one of memoryId or query." }],
+                        details: { error: "ambiguous_selector" },
+                    };
+                }
+                const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
+                let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
+                if (scope) {
+                    if (!context.scopeManager.isAccessible(scope, agentId)) {
+                        return {
+                            content: [{ type: "text", text: `Access denied to scope: ${scope}` }],
+                            details: { error: "scope_access_denied", requestedScope: scope },
+                        };
+                    }
+                    scopeFilter = [scope];
+                }
+                const shouldDryRun = dryRun ?? Boolean(trimmedQuery);
+                const safeLimit = clampInt(limit, 1, 20);
+                let candidates = [];
+                if (trimmedMemoryId) {
+                    const exactMatch = await runtimeContext.store.getById(trimmedMemoryId, scopeFilter);
+                    if (exactMatch) {
+                        const metadata = parseReflectionMetadata(exactMatch.metadata);
+                        if (metadata.type !== "memory-reflection-item") {
+                            return {
+                                content: [{ type: "text", text: `Memory ${trimmedMemoryId.slice(0, 8)} is not a reflection item.` }],
+                                details: { error: "not_reflection_item", memoryId: trimmedMemoryId },
+                            };
+                        }
+                        if (metadata.resolvedAt !== undefined) {
+                            return {
+                                content: [{ type: "text", text: `Reflection item ${trimmedMemoryId.slice(0, 8)} is already resolved.` }],
+                                details: { error: "already_resolved", memoryId: trimmedMemoryId, resolvedAt: metadata.resolvedAt },
+                            };
+                        }
+                        candidates = [{ entry: exactMatch }];
+                    }
+                    else {
+                        const entries = await runtimeContext.store.list(scopeFilter, "reflection", 1000, 0);
+                        const reflectionItemMatches = entries
+                            .filter((entry) => entry.id.startsWith(trimmedMemoryId))
+                            .filter((entry) => parseReflectionMetadata(entry.metadata).type === "memory-reflection-item");
+                        const matches = reflectionItemMatches
+                            .filter(isUnresolvedReflectionItem);
+                        if (matches.length === 0) {
+                            const alreadyResolved = reflectionItemMatches[0];
+                            if (alreadyResolved) {
+                                return {
+                                    content: [{ type: "text", text: `Reflection item ${trimmedMemoryId.slice(0, 8)} is already resolved.` }],
+                                    details: {
+                                        error: "already_resolved",
+                                        memoryId: trimmedMemoryId,
+                                        resolvedAt: parseReflectionMetadata(alreadyResolved.metadata).resolvedAt,
+                                    },
+                                };
+                            }
+                            return {
+                                content: [{ type: "text", text: `Unresolved reflection item ${trimmedMemoryId.slice(0, 8)} not found.` }],
+                                details: { error: "not_found", memoryId: trimmedMemoryId },
+                            };
+                        }
+                        if (matches.length > 1) {
+                            return {
+                                content: [{ type: "text", text: `Reflection item prefix ${trimmedMemoryId} is ambiguous; use a longer id.` }],
+                                details: {
+                                    error: "ambiguous_memory_id",
+                                    memoryId: trimmedMemoryId,
+                                    matches: matches.map((entry) => entry.id).slice(0, 20),
+                                },
+                            };
+                        }
+                        candidates = [{ entry: matches[0] }];
+                    }
+                }
+                else if (trimmedQuery) {
+                    const results = await retrieveWithRetry(runtimeContext.retriever, {
+                        query: trimmedQuery,
+                        limit: safeLimit,
+                        scopeFilter,
+                        category: "reflection",
+                        source: "cli",
+                    }, () => runtimeContext.store.count());
+                    candidates = results
+                        .filter((result) => isUnresolvedReflectionItem(result.entry))
+                        .map((result) => ({ entry: result.entry, score: result.score }));
+                    if (candidates.length === 0) {
+                        return {
+                            content: [{ type: "text", text: "No unresolved reflection items matched." }],
+                            details: { action: "empty", query: trimmedQuery, scopeFilter },
+                        };
+                    }
+                }
+                if (shouldDryRun) {
+                    return {
+                        content: [{ type: "text", text: formatReflectionResolvePreview(candidates) }],
+                        details: {
+                            action: "preview",
+                            query: trimmedQuery,
+                            memoryId: trimmedMemoryId,
+                            candidates: candidates.map(formatReflectionResolveCandidate),
+                        },
+                    };
+                }
+                if (trimmedQuery && candidates.length !== 1) {
+                    return {
+                        content: [{
+                                type: "text",
+                                text: `Query matched ${candidates.length} unresolved reflection items. Preview first, then resolve a specific memoryId.`,
+                            }],
+                        details: {
+                            error: "ambiguous_query",
+                            query: trimmedQuery,
+                            candidates: candidates.map(formatReflectionResolveCandidate),
+                        },
+                    };
+                }
+                const target = candidates[0]?.entry;
+                if (!target) {
+                    return {
+                        content: [{ type: "text", text: "No unresolved reflection item selected." }],
+                        details: { error: "not_found" },
+                    };
+                }
+                const patch = {
+                    resolvedAt: Date.now(),
+                    resolvedBy: agentId,
+                    ...(typeof note === "string" && note.trim() ? { resolutionNote: note.trim() } : {}),
+                };
+                const updated = await runtimeContext.store.patchMetadata(target.id, patch, scopeFilter);
+                if (!updated) {
+                    return {
+                        content: [{ type: "text", text: `Failed to resolve reflection item ${target.id.slice(0, 8)}.` }],
+                        details: { error: "resolve_failed", id: target.id },
+                    };
+                }
+                return {
+                    content: [{ type: "text", text: `Resolved reflection item ${target.id.slice(0, 8)}.` }],
+                    details: {
+                        action: "resolved",
+                        id: target.id,
+                        resolvedBy: agentId,
+                        note: patch.resolutionNote,
+                    },
+                };
+            },
+        };
+    }, { name: "memory_reflection_resolve" });
+}
 export function registerMemoryCompactTool(api, context) {
     api.registerTool((toolCtx) => {
         const runtimeContext = resolveToolContext(context, toolCtx);
@@ -1813,6 +2013,7 @@ export function registerAllMemoryTools(api, context, options = {}) {
         registerMemoryListTool(api, context);
         registerMemoryPromoteTool(api, context);
         registerMemoryArchiveTool(api, context);
+        registerMemoryReflectionResolveTool(api, context);
         registerMemoryCompactTool(api, context);
         registerMemoryExplainRankTool(api, context);
     }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -29,7 +29,7 @@ import {
   DEFAULT_SELF_IMPROVEMENT_MAX_ENTRIES,
   ensureSelfImprovementLearningFiles,
 } from "./self-improvement-files.js";
-import { getDisplayCategoryTag } from "./reflection-metadata.js";
+import { getDisplayCategoryTag, parseReflectionMetadata } from "./reflection-metadata.js";
 import type { RetrievalTrace } from "./retrieval-trace.js";
 import {
   filterUserMdExclusiveRecallResults,
@@ -121,6 +121,38 @@ function sanitizeMemoryForSerialization(results: RetrievalResult[]) {
     score: r.score,
     sources: r.sources,
   }));
+}
+
+function isUnresolvedReflectionItem(entry: MemoryEntry): boolean {
+  const metadata = parseReflectionMetadata(entry.metadata);
+  return metadata.type === "memory-reflection-item" && metadata.resolvedAt === undefined;
+}
+
+function formatReflectionResolveCandidate(result: {
+  entry: MemoryEntry;
+  score?: number;
+}): Record<string, unknown> {
+  const metadata = parseReflectionMetadata(result.entry.metadata);
+  return {
+    id: result.entry.id,
+    text: truncateText(normalizeInlineText(result.entry.text), 220),
+    itemKind: metadata.itemKind,
+    agentId: metadata.agentId,
+    score: result.score,
+  };
+}
+
+function formatReflectionResolvePreview(candidates: Array<{ entry: MemoryEntry; score?: number }>): string {
+  const lines = candidates.map((candidate, idx) => {
+    const metadata = parseReflectionMetadata(candidate.entry.metadata);
+    const itemKind = typeof metadata.itemKind === "string" ? metadata.itemKind : "item";
+    const scoreText = typeof candidate.score === "number" ? ` score=${candidate.score.toFixed(3)}` : "";
+    return `${idx + 1}. [${candidate.entry.id}] ${itemKind}${scoreText}: ${truncateText(normalizeInlineText(candidate.entry.text), 180)}`;
+  });
+  return [
+    `Reflection resolve preview: ${candidates.length} candidate(s). No changes made.`,
+    ...lines,
+  ].join("\n");
 }
 
 const _warnedMissingAgentId = new Set<string>();
@@ -2098,6 +2130,209 @@ export function registerMemoryArchiveTool(
   );
 }
 
+export function registerMemoryReflectionResolveTool(
+  api: OpenClawPluginApi,
+  context: ToolContext,
+) {
+  api.registerTool(
+    (toolCtx) => {
+      const runtimeContext = resolveToolContext(context, toolCtx);
+      return {
+        name: "memory_reflection_resolve",
+        label: "Memory Reflection Resolve",
+        description:
+          "Mark a single memory-reflection item resolved so it stops participating in reflection recall.",
+        parameters: Type.Object({
+          memoryId: Type.Optional(Type.String({ description: "Reflection item id or id prefix." })),
+          query: Type.Optional(Type.String({ description: "Search query to preview matching unresolved reflection items." })),
+          scope: Type.Optional(Type.String({ description: "Optional scope filter." })),
+          dryRun: Type.Optional(Type.Boolean({ description: "Preview only. Defaults to true for query mode and false for memoryId mode." })),
+          note: Type.Optional(Type.String({ description: "Optional resolution note for audit trail." })),
+          limit: Type.Optional(Type.Number({ description: "Maximum query candidates to preview (default 5, max 20)." })),
+        }),
+        async execute(_toolCallId, params, _signal, _onUpdate, runtimeCtx) {
+          const {
+            memoryId,
+            query,
+            scope,
+            dryRun,
+            note,
+            limit = 5,
+          } = params as {
+            memoryId?: string;
+            query?: string;
+            scope?: string;
+            dryRun?: boolean;
+            note?: string;
+            limit?: number;
+          };
+
+          const trimmedMemoryId = memoryId?.trim();
+          const trimmedQuery = query?.trim();
+          if (!trimmedMemoryId && !trimmedQuery) {
+            return {
+              content: [{ type: "text", text: "Provide memoryId or query." }],
+              details: { error: "missing_selector" },
+            };
+          }
+          if (trimmedMemoryId && trimmedQuery) {
+            return {
+              content: [{ type: "text", text: "Provide only one of memoryId or query." }],
+              details: { error: "ambiguous_selector" },
+            };
+          }
+
+          const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
+          let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
+          if (scope) {
+            if (!context.scopeManager.isAccessible(scope, agentId)) {
+              return {
+                content: [{ type: "text", text: `Access denied to scope: ${scope}` }],
+                details: { error: "scope_access_denied", requestedScope: scope },
+              };
+            }
+            scopeFilter = [scope];
+          }
+
+          const shouldDryRun = dryRun ?? Boolean(trimmedQuery);
+          const safeLimit = clampInt(limit, 1, 20);
+          let candidates: Array<{ entry: MemoryEntry; score?: number }> = [];
+
+          if (trimmedMemoryId) {
+            const exactMatch = await runtimeContext.store.getById(trimmedMemoryId, scopeFilter);
+            if (exactMatch) {
+              const metadata = parseReflectionMetadata(exactMatch.metadata);
+              if (metadata.type !== "memory-reflection-item") {
+                return {
+                  content: [{ type: "text", text: `Memory ${trimmedMemoryId.slice(0, 8)} is not a reflection item.` }],
+                  details: { error: "not_reflection_item", memoryId: trimmedMemoryId },
+                };
+              }
+              if (metadata.resolvedAt !== undefined) {
+                return {
+                  content: [{ type: "text", text: `Reflection item ${trimmedMemoryId.slice(0, 8)} is already resolved.` }],
+                  details: { error: "already_resolved", memoryId: trimmedMemoryId, resolvedAt: metadata.resolvedAt },
+                };
+              }
+              candidates = [{ entry: exactMatch }];
+            } else {
+              const entries = await runtimeContext.store.list(scopeFilter, "reflection", 1000, 0);
+              const reflectionItemMatches = entries
+                .filter((entry) => entry.id.startsWith(trimmedMemoryId))
+                .filter((entry) => parseReflectionMetadata(entry.metadata).type === "memory-reflection-item");
+              const matches = reflectionItemMatches
+                .filter(isUnresolvedReflectionItem);
+              if (matches.length === 0) {
+                const alreadyResolved = reflectionItemMatches[0];
+                if (alreadyResolved) {
+                  return {
+                    content: [{ type: "text", text: `Reflection item ${trimmedMemoryId.slice(0, 8)} is already resolved.` }],
+                    details: {
+                      error: "already_resolved",
+                      memoryId: trimmedMemoryId,
+                      resolvedAt: parseReflectionMetadata(alreadyResolved.metadata).resolvedAt,
+                    },
+                  };
+                }
+                return {
+                  content: [{ type: "text", text: `Unresolved reflection item ${trimmedMemoryId.slice(0, 8)} not found.` }],
+                  details: { error: "not_found", memoryId: trimmedMemoryId },
+                };
+              }
+              if (matches.length > 1) {
+                return {
+                  content: [{ type: "text", text: `Reflection item prefix ${trimmedMemoryId} is ambiguous; use a longer id.` }],
+                  details: {
+                    error: "ambiguous_memory_id",
+                    memoryId: trimmedMemoryId,
+                    matches: matches.map((entry) => entry.id).slice(0, 20),
+                  },
+                };
+              }
+              candidates = [{ entry: matches[0] }];
+            }
+          } else if (trimmedQuery) {
+            const results = await retrieveWithRetry(runtimeContext.retriever, {
+              query: trimmedQuery,
+              limit: safeLimit,
+              scopeFilter,
+              category: "reflection",
+              source: "cli",
+            }, () => runtimeContext.store.count());
+            candidates = results
+              .filter((result) => isUnresolvedReflectionItem(result.entry))
+              .map((result) => ({ entry: result.entry, score: result.score }));
+            if (candidates.length === 0) {
+              return {
+                content: [{ type: "text", text: "No unresolved reflection items matched." }],
+                details: { action: "empty", query: trimmedQuery, scopeFilter },
+              };
+            }
+          }
+
+          if (shouldDryRun) {
+            return {
+              content: [{ type: "text", text: formatReflectionResolvePreview(candidates) }],
+              details: {
+                action: "preview",
+                query: trimmedQuery,
+                memoryId: trimmedMemoryId,
+                candidates: candidates.map(formatReflectionResolveCandidate),
+              },
+            };
+          }
+
+          if (trimmedQuery && candidates.length !== 1) {
+            return {
+              content: [{
+                type: "text",
+                text: `Query matched ${candidates.length} unresolved reflection items. Preview first, then resolve a specific memoryId.`,
+              }],
+              details: {
+                error: "ambiguous_query",
+                query: trimmedQuery,
+                candidates: candidates.map(formatReflectionResolveCandidate),
+              },
+            };
+          }
+
+          const target = candidates[0]?.entry;
+          if (!target) {
+            return {
+              content: [{ type: "text", text: "No unresolved reflection item selected." }],
+              details: { error: "not_found" },
+            };
+          }
+
+          const patch = {
+            resolvedAt: Date.now(),
+            resolvedBy: agentId,
+            ...(typeof note === "string" && note.trim() ? { resolutionNote: note.trim() } : {}),
+          };
+          const updated = await runtimeContext.store.patchMetadata(target.id, patch, scopeFilter);
+          if (!updated) {
+            return {
+              content: [{ type: "text", text: `Failed to resolve reflection item ${target.id.slice(0, 8)}.` }],
+              details: { error: "resolve_failed", id: target.id },
+            };
+          }
+
+          return {
+            content: [{ type: "text", text: `Resolved reflection item ${target.id.slice(0, 8)}.` }],
+            details: {
+              action: "resolved",
+              id: target.id,
+              resolvedBy: agentId,
+              note: patch.resolutionNote,
+            },
+          };
+        },
+      };
+    },
+    { name: "memory_reflection_resolve" },
+  );
+}
+
 export function registerMemoryCompactTool(
   api: OpenClawPluginApi,
   context: ToolContext,
@@ -2301,6 +2536,7 @@ export function registerAllMemoryTools(
     registerMemoryListTool(api, context);
     registerMemoryPromoteTool(api, context);
     registerMemoryArchiveTool(api, context);
+    registerMemoryReflectionResolveTool(api, context);
     registerMemoryCompactTool(api, context);
     registerMemoryExplainRankTool(api, context);
   }

--- a/test/memory-governance-tools.test.mjs
+++ b/test/memory-governance-tools.test.mjs
@@ -165,4 +165,161 @@ describe("memory governance tools", () => {
     assert.match(explainRes.content[0].text, /state=confirmed/);
     assert.match(explainRes.content[0].text, /layer=working/);
   });
+
+  it("previews reflection resolve query results without mutating", async () => {
+    const now = Date.now();
+    const entries = [
+      {
+        id: "c1111111-1111-4111-8111-111111111111",
+        text: "Verify line numbers before reporting completion.",
+        category: "reflection",
+        scope: "global",
+        importance: 0.7,
+        timestamp: now,
+        metadata: JSON.stringify({
+          type: "memory-reflection-item",
+          itemKind: "derived",
+          agentId: "main",
+        }),
+      },
+      {
+        id: "c2222222-2222-4222-8222-222222222222",
+        text: "Verify completion comments include the exact check output.",
+        category: "reflection",
+        scope: "global",
+        importance: 0.7,
+        timestamp: now - 1,
+        metadata: JSON.stringify({
+          type: "memory-reflection-item",
+          itemKind: "derived",
+          agentId: "main",
+        }),
+      },
+    ];
+    const patchCalls = [];
+    const context = {
+      agentId: "main",
+      workspaceDir: "/tmp",
+      mdMirror: null,
+      scopeManager: {
+        getAccessibleScopes: () => ["global"],
+        isAccessible: () => true,
+        getDefaultScope: () => "global",
+      },
+      retriever: {
+        async retrieve() {
+          return [
+            {
+              entry: entries[0],
+              score: 0.91,
+              sources: { vector: { score: 0.91, rank: 1 } },
+            },
+            {
+              entry: entries[1],
+              score: 0.83,
+              sources: { vector: { score: 0.83, rank: 2 } },
+            },
+          ];
+        },
+        getConfig() {
+          return { mode: "hybrid" };
+        },
+      },
+      store: {
+        async patchMetadata(id, patch) {
+          patchCalls.push({ id, patch });
+          return entries.find((e) => e.id === id) ?? null;
+        },
+        async getById(id) { return entries.find((e) => e.id === id) ?? null; },
+        async list() { return entries; },
+        async count() { return entries.length; },
+      },
+      embedder: { async embedPassage() { return [0.1, 0.2, 0.3]; } },
+    };
+
+    const tools = createToolSet(context);
+    const resolve = tools.get("memory_reflection_resolve");
+    const res = await resolve.execute(null, { query: "line numbers" });
+
+    assert.match(res.content[0].text, /Reflection resolve preview/);
+    assert.equal(res.details.action, "preview");
+    assert.equal(res.details.candidates[0].id, entries[0].id);
+    assert.equal(patchCalls.length, 0);
+
+    const applyRes = await resolve.execute(null, { query: "verify completion", dryRun: false });
+    assert.match(applyRes.content[0].text, /Preview first, then resolve a specific memoryId/);
+    assert.equal(applyRes.details.error, "ambiguous_query");
+    assert.equal(patchCalls.length, 0);
+  });
+
+  it("resolves an explicit reflection item with audit metadata", async () => {
+    const now = Date.now();
+    const entries = [
+      {
+        id: "d2222222-2222-4222-8222-222222222222",
+        text: "Retry the manifest check after packaging changes.",
+        category: "reflection",
+        scope: "global",
+        importance: 0.7,
+        timestamp: now,
+        metadata: JSON.stringify({
+          type: "memory-reflection-item",
+          itemKind: "invariant",
+          agentId: "main",
+        }),
+      },
+    ];
+    const patchCalls = [];
+    const context = {
+      agentId: "main",
+      workspaceDir: "/tmp",
+      mdMirror: null,
+      scopeManager: {
+        getAccessibleScopes: () => ["global"],
+        isAccessible: () => true,
+        getDefaultScope: () => "global",
+      },
+      retriever: {
+        async retrieve() { return []; },
+        getConfig() {
+          return { mode: "hybrid" };
+        },
+      },
+      store: {
+        async patchMetadata(id, patch) {
+          patchCalls.push({ id, patch });
+          const entry = entries.find((e) => e.id === id);
+          if (!entry) return null;
+          const metadata = JSON.parse(entry.metadata || "{}");
+          entry.metadata = JSON.stringify({ ...metadata, ...patch });
+          return entry;
+        },
+        async getById(id) { return entries.find((e) => e.id === id) ?? null; },
+        async list() { return entries; },
+        async count() { return entries.length; },
+      },
+      embedder: { async embedPassage() { return [0.1, 0.2, 0.3]; } },
+    };
+
+    const tools = createToolSet(context);
+    const resolve = tools.get("memory_reflection_resolve");
+    const res = await resolve.execute(
+      null,
+      { memoryId: "d2222222", note: "covered by packaging regression" },
+      undefined,
+      undefined,
+      { agentId: "reviewer" },
+    );
+
+    assert.match(res.content[0].text, /Resolved reflection item/);
+    assert.equal(res.details.action, "resolved");
+    assert.equal(res.details.resolvedBy, "reviewer");
+    assert.equal(patchCalls.length, 1);
+    assert.equal(patchCalls[0].id, entries[0].id);
+    assert.equal(typeof patchCalls[0].patch.resolvedAt, "number");
+    assert.equal(patchCalls[0].patch.resolvedBy, "reviewer");
+    assert.equal(patchCalls[0].patch.resolutionNote, "covered by packaging regression");
+    const metadata = JSON.parse(entries[0].metadata);
+    assert.equal(metadata.resolvedBy, "reviewer");
+  });
 });


### PR DESCRIPTION
## Summary

- add the `memory_reflection_resolve` management tool for resolving individual `memory-reflection-item` rows
- make query mode preview-only by default and block ambiguous query applies so agents resolve explicit items after preview
- stamp `resolvedAt`, `resolvedBy`, and optional `resolutionNote` audit metadata when resolving
- add governance-tool coverage for dry-run query preview, ambiguous query safety, and explicit item resolve

Closes #558.

## Validation

- `npx tsc -p tsconfig.json`
- `node --test test/memory-governance-tools.test.mjs`
- `node test/plugin-manifest-regression.mjs`
- `git diff --check`

## Notes

I also ran `node --test test/memory-reflection.test.mjs`; it currently fails on pre-existing legacy reflection/default-config expectations unrelated to this tool:
- `loads legacy combined rows for backward compatibility`
- `filters prompt-control lines from legacy reflection rows before injection`
- `defaults to systemSessionMemory when neither field is set`
- `defaults writeLegacyCombined=true for memoryReflection config`
