### PR TITLE
Add memory recall compatibility aliases

### DIFF
--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -419,140 +419,162 @@ export function registerSelfImprovementReviewTool(api, context) {
 // ============================================================================
 // Core Tools (Backward Compatible)
 // ============================================================================
+const MEMORY_RECALL_PARAMETERS = Type.Object({
+    query: Type.String({
+        description: "Search query for finding relevant memories",
+    }),
+    limit: Type.Optional(Type.Number({
+        description: "Max results to return (default: 3, max: 20; summary mode soft max: 6)",
+    })),
+    includeFullText: Type.Optional(Type.Boolean({
+        description: "Return full memory text when true (default: false returns summary previews)",
+    })),
+    maxCharsPerItem: Type.Optional(Type.Number({
+        description: "Maximum characters per returned memory in summary mode (default: 180)",
+    })),
+    scope: Type.Optional(Type.String({
+        description: "Specific memory scope to search in (optional)",
+    })),
+    category: Type.Optional(stringEnum(MEMORY_CATEGORIES)),
+});
+function createMemoryRecallTool(runtimeContext, options) {
+    return {
+        name: options.name,
+        label: options.label,
+        description: options.description,
+        parameters: MEMORY_RECALL_PARAMETERS,
+        async execute(_toolCallId, params) {
+            const { query, limit = 3, includeFullText = false, maxCharsPerItem = 180, scope, category, } = params;
+            try {
+                const safeLimit = includeFullText
+                    ? clampInt(limit, 1, 20)
+                    : clampInt(limit, 1, 6);
+                const safeCharsPerItem = clampInt(maxCharsPerItem, 60, 1000);
+                const agentId = runtimeContext.agentId;
+                // Determine accessible scopes
+                let scopeFilter = resolveScopeFilter(runtimeContext.scopeManager, agentId);
+                if (scope) {
+                    if (runtimeContext.scopeManager.isAccessible(scope, agentId)) {
+                        scopeFilter = [scope];
+                    }
+                    else {
+                        return {
+                            content: [
+                                { type: "text", text: `Access denied to scope: ${scope}` },
+                            ],
+                            details: {
+                                error: "scope_access_denied",
+                                requestedScope: scope,
+                            },
+                        };
+                    }
+                }
+                const results = filterUserMdExclusiveRecallResults(await retrieveWithRetry(runtimeContext.retriever, {
+                    query,
+                    limit: safeLimit,
+                    scopeFilter,
+                    category,
+                    source: "manual",
+                }, () => runtimeContext.store.count()), runtimeContext.workspaceBoundary);
+                if (results.length === 0) {
+                    return {
+                        content: [{ type: "text", text: "No relevant memories found." }],
+                        details: { count: 0, query, scopes: scopeFilter },
+                    };
+                }
+                const now = Date.now();
+                await Promise.allSettled(results.map((result) => {
+                    const meta = parseSmartMetadata(result.entry.metadata, result.entry);
+                    return runtimeContext.store.patchMetadata(result.entry.id, {
+                        access_count: meta.access_count + 1,
+                        last_accessed_at: now,
+                        last_confirmed_use_at: now,
+                        bad_recall_count: 0,
+                        suppressed_until_turn: 0,
+                        // Manual recall is a strong positive signal — clear active
+                        // ms-based suppression too, matching pre-Tier1 semantics
+                        // where zeroing the turn field cleared the only suppression
+                        // mechanism. Without this, governance keeps suppressing a
+                        // memory the user just explicitly searched for.
+                        suppressed_until_ms: 0,
+                    }, scopeFilter);
+                }));
+                const text = results
+                    .map((r, i) => {
+                    const categoryTag = getDisplayCategoryTag(r.entry);
+                    const metadata = parseSmartMetadata(r.entry.metadata, r.entry);
+                    const base = includeFullText
+                        ? (metadata.l2_content || metadata.l1_overview || r.entry.text)
+                        : (metadata.l0_abstract || r.entry.text);
+                    const inline = normalizeInlineText(base);
+                    const rendered = includeFullText
+                        ? inline
+                        : truncateText(inline, safeCharsPerItem);
+                    return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${rendered}`;
+                })
+                    .join("\n");
+                const serializedMemories = sanitizeMemoryForSerialization(results);
+                if (includeFullText) {
+                    for (let i = 0; i < results.length; i++) {
+                        const metadata = parseSmartMetadata(results[i].entry.metadata, results[i].entry);
+                        serializedMemories[i].fullText =
+                            metadata.l2_content || metadata.l1_overview || results[i].entry.text;
+                    }
+                }
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `<relevant-memories>\n<mode:${includeFullText ? "full" : "summary"}>\nFound ${results.length} memories:\n\n${text}\n</relevant-memories>`,
+                        },
+                    ],
+                    details: {
+                        count: results.length,
+                        memories: serializedMemories,
+                        query,
+                        scopes: scopeFilter,
+                        retrievalMode: runtimeContext.retriever.getConfig().mode,
+                        recallMode: includeFullText ? "full" : "summary",
+                    },
+                };
+            }
+            catch (error) {
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Memory recall failed: ${error instanceof Error ? error.message : String(error)}`,
+                        },
+                    ],
+                    details: { error: "recall_failed", message: String(error) },
+                };
+            }
+        },
+    };
+}
 export function registerMemoryRecallTool(api, context) {
     api.registerTool((toolCtx) => {
         const runtimeContext = resolveToolContext(context, toolCtx);
-        return {
+        return createMemoryRecallTool(runtimeContext, {
             name: "memory_recall",
             label: "Memory Recall",
             description: "Search through long-term memories using hybrid retrieval (vector + keyword search). Use when you need context about user preferences, past decisions, or previously discussed topics.",
-            parameters: Type.Object({
-                query: Type.String({
-                    description: "Search query for finding relevant memories",
-                }),
-                limit: Type.Optional(Type.Number({
-                    description: "Max results to return (default: 3, max: 20; summary mode soft max: 6)",
-                })),
-                includeFullText: Type.Optional(Type.Boolean({
-                    description: "Return full memory text when true (default: false returns summary previews)",
-                })),
-                maxCharsPerItem: Type.Optional(Type.Number({
-                    description: "Maximum characters per returned memory in summary mode (default: 180)",
-                })),
-                scope: Type.Optional(Type.String({
-                    description: "Specific memory scope to search in (optional)",
-                })),
-                category: Type.Optional(stringEnum(MEMORY_CATEGORIES)),
-            }),
-            async execute(_toolCallId, params) {
-                const { query, limit = 3, includeFullText = false, maxCharsPerItem = 180, scope, category, } = params;
-                try {
-                    const safeLimit = includeFullText
-                        ? clampInt(limit, 1, 20)
-                        : clampInt(limit, 1, 6);
-                    const safeCharsPerItem = clampInt(maxCharsPerItem, 60, 1000);
-                    const agentId = runtimeContext.agentId;
-                    // Determine accessible scopes
-                    let scopeFilter = resolveScopeFilter(runtimeContext.scopeManager, agentId);
-                    if (scope) {
-                        if (runtimeContext.scopeManager.isAccessible(scope, agentId)) {
-                            scopeFilter = [scope];
-                        }
-                        else {
-                            return {
-                                content: [
-                                    { type: "text", text: `Access denied to scope: ${scope}` },
-                                ],
-                                details: {
-                                    error: "scope_access_denied",
-                                    requestedScope: scope,
-                                },
-                            };
-                        }
-                    }
-                    const results = filterUserMdExclusiveRecallResults(await retrieveWithRetry(runtimeContext.retriever, {
-                        query,
-                        limit: safeLimit,
-                        scopeFilter,
-                        category,
-                        source: "manual",
-                    }, () => runtimeContext.store.count()), runtimeContext.workspaceBoundary);
-                    if (results.length === 0) {
-                        return {
-                            content: [{ type: "text", text: "No relevant memories found." }],
-                            details: { count: 0, query, scopes: scopeFilter },
-                        };
-                    }
-                    const now = Date.now();
-                    await Promise.allSettled(results.map((result) => {
-                        const meta = parseSmartMetadata(result.entry.metadata, result.entry);
-                        return runtimeContext.store.patchMetadata(result.entry.id, {
-                            access_count: meta.access_count + 1,
-                            last_accessed_at: now,
-                            last_confirmed_use_at: now,
-                            bad_recall_count: 0,
-                            suppressed_until_turn: 0,
-                            // Manual recall is a strong positive signal — clear active
-                            // ms-based suppression too, matching pre-Tier1 semantics
-                            // where zeroing the turn field cleared the only suppression
-                            // mechanism. Without this, governance keeps suppressing a
-                            // memory the user just explicitly searched for.
-                            suppressed_until_ms: 0,
-                        }, scopeFilter);
-                    }));
-                    const text = results
-                        .map((r, i) => {
-                        const categoryTag = getDisplayCategoryTag(r.entry);
-                        const metadata = parseSmartMetadata(r.entry.metadata, r.entry);
-                        const base = includeFullText
-                            ? (metadata.l2_content || metadata.l1_overview || r.entry.text)
-                            : (metadata.l0_abstract || r.entry.text);
-                        const inline = normalizeInlineText(base);
-                        const rendered = includeFullText
-                            ? inline
-                            : truncateText(inline, safeCharsPerItem);
-                        return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${rendered}`;
-                    })
-                        .join("\n");
-                    const serializedMemories = sanitizeMemoryForSerialization(results);
-                    if (includeFullText) {
-                        for (let i = 0; i < results.length; i++) {
-                            const metadata = parseSmartMetadata(results[i].entry.metadata, results[i].entry);
-                            serializedMemories[i].fullText =
-                                metadata.l2_content || metadata.l1_overview || results[i].entry.text;
-                        }
-                    }
-                    return {
-                        content: [
-                            {
-                                type: "text",
-                                text: `<relevant-memories>\n<mode:${includeFullText ? "full" : "summary"}>\nFound ${results.length} memories:\n\n${text}\n</relevant-memories>`,
-                            },
-                        ],
-                        details: {
-                            count: results.length,
-                            memories: serializedMemories,
-                            query,
-                            scopes: scopeFilter,
-                            retrievalMode: runtimeContext.retriever.getConfig().mode,
-                            recallMode: includeFullText ? "full" : "summary",
-                        },
-                    };
-                }
-                catch (error) {
-                    return {
-                        content: [
-                            {
-                                type: "text",
-                                text: `Memory recall failed: ${error instanceof Error ? error.message : String(error)}`,
-                            },
-                        ],
-                        details: { error: "recall_failed", message: String(error) },
-                    };
-                }
-            },
-        };
+        });
     }, { name: "memory_recall" });
+}
+export function registerMemoryRecallAliasTool(api, context, alias) {
+    const label = alias === "memory_get" ? "Memory Get" : "Memory Search";
+    const description = alias === "memory_get"
+        ? "Compatibility alias for memory_recall. Search and return relevant long-term memories for OpenClaw profiles that request memory_get."
+        : "Compatibility alias for memory_recall. Search through long-term memories for OpenClaw profiles that request memory_search.";
+    api.registerTool((toolCtx) => {
+        const runtimeContext = resolveToolContext(context, toolCtx);
+        return createMemoryRecallTool(runtimeContext, {
+            name: alias,
+            label,
+            description,
+        });
+    }, { name: alias });
 }
 export function registerMemoryStoreTool(api, context) {
     api.registerTool((toolCtx) => {
@@ -1803,6 +1825,8 @@ export function registerMemoryExplainRankTool(api, context) {
 export function registerAllMemoryTools(api, context, options = {}) {
     // Core tools (always enabled)
     registerMemoryRecallTool(api, context);
+    registerMemoryRecallAliasTool(api, context, "memory_search");
+    registerMemoryRecallAliasTool(api, context, "memory_get");
     registerMemoryStoreTool(api, context);
     registerMemoryForgetTool(api, context);
     registerMemoryUpdateTool(api, context);

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,6 +2,8 @@
   "contracts": {
     "tools": [
       "memory_recall",
+      "memory_search",
+      "memory_get",
       "memory_store",
       "memory_forget",
       "memory_update",
@@ -2028,6 +2030,8 @@
   "contracts": {
     "tools": [
       "memory_recall",
+      "memory_search",
+      "memory_get",
       "memory_store",
       "memory_update",
       "memory_forget",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -542,45 +542,47 @@ export function registerSelfImprovementReviewTool(api: OpenClawPluginApi, contex
 // Core Tools (Backward Compatible)
 // ============================================================================
 
-export function registerMemoryRecallTool(
-  api: OpenClawPluginApi,
-  context: ToolContext,
+const MEMORY_RECALL_PARAMETERS = Type.Object({
+  query: Type.String({
+    description: "Search query for finding relevant memories",
+  }),
+  limit: Type.Optional(
+    Type.Number({
+      description: "Max results to return (default: 3, max: 20; summary mode soft max: 6)",
+    }),
+  ),
+  includeFullText: Type.Optional(
+    Type.Boolean({
+      description: "Return full memory text when true (default: false returns summary previews)",
+    }),
+  ),
+  maxCharsPerItem: Type.Optional(
+    Type.Number({
+      description: "Maximum characters per returned memory in summary mode (default: 180)",
+    }),
+  ),
+  scope: Type.Optional(
+    Type.String({
+      description: "Specific memory scope to search in (optional)",
+    }),
+  ),
+  category: Type.Optional(stringEnum(MEMORY_CATEGORIES)),
+});
+
+function createMemoryRecallTool(
+  runtimeContext: ToolContext,
+  options: {
+    name: string;
+    label: string;
+    description: string;
+  },
 ) {
-  api.registerTool(
-    (toolCtx) => {
-      const runtimeContext = resolveToolContext(context, toolCtx);
-      return {
-      name: "memory_recall",
-      label: "Memory Recall",
-      description:
-        "Search through long-term memories using hybrid retrieval (vector + keyword search). Use when you need context about user preferences, past decisions, or previously discussed topics.",
-      parameters: Type.Object({
-        query: Type.String({
-          description: "Search query for finding relevant memories",
-        }),
-        limit: Type.Optional(
-          Type.Number({
-            description: "Max results to return (default: 3, max: 20; summary mode soft max: 6)",
-          }),
-        ),
-        includeFullText: Type.Optional(
-          Type.Boolean({
-            description: "Return full memory text when true (default: false returns summary previews)",
-          }),
-        ),
-        maxCharsPerItem: Type.Optional(
-          Type.Number({
-            description: "Maximum characters per returned memory in summary mode (default: 180)",
-          }),
-        ),
-        scope: Type.Optional(
-          Type.String({
-            description: "Specific memory scope to search in (optional)",
-          }),
-        ),
-        category: Type.Optional(stringEnum(MEMORY_CATEGORIES)),
-      }),
-      async execute(_toolCallId, params) {
+  return {
+    name: options.name,
+    label: options.label,
+    description: options.description,
+    parameters: MEMORY_RECALL_PARAMETERS,
+    async execute(_toolCallId: unknown, params: unknown) {
         const {
           query,
           limit = 3,
@@ -712,10 +714,48 @@ export function registerMemoryRecallTool(
             details: { error: "recall_failed", message: String(error) },
           };
         }
-      },
-    };
+    },
+  };
+}
+
+export function registerMemoryRecallTool(
+  api: OpenClawPluginApi,
+  context: ToolContext,
+) {
+  api.registerTool(
+    (toolCtx) => {
+      const runtimeContext = resolveToolContext(context, toolCtx);
+      return createMemoryRecallTool(runtimeContext, {
+        name: "memory_recall",
+        label: "Memory Recall",
+        description:
+          "Search through long-term memories using hybrid retrieval (vector + keyword search). Use when you need context about user preferences, past decisions, or previously discussed topics.",
+      });
     },
     { name: "memory_recall" },
+  );
+}
+
+export function registerMemoryRecallAliasTool(
+  api: OpenClawPluginApi,
+  context: ToolContext,
+  alias: "memory_search" | "memory_get",
+) {
+  const label = alias === "memory_get" ? "Memory Get" : "Memory Search";
+  const description = alias === "memory_get"
+    ? "Compatibility alias for memory_recall. Search and return relevant long-term memories for OpenClaw profiles that request memory_get."
+    : "Compatibility alias for memory_recall. Search through long-term memories for OpenClaw profiles that request memory_search.";
+
+  api.registerTool(
+    (toolCtx) => {
+      const runtimeContext = resolveToolContext(context, toolCtx);
+      return createMemoryRecallTool(runtimeContext, {
+        name: alias,
+        label,
+        description,
+      });
+    },
+    { name: alias },
   );
 }
 
@@ -2290,6 +2330,8 @@ export function registerAllMemoryTools(
 ) {
   // Core tools (always enabled)
   registerMemoryRecallTool(api, context);
+  registerMemoryRecallAliasTool(api, context, "memory_search");
+  registerMemoryRecallAliasTool(api, context, "memory_get");
   registerMemoryStoreTool(api, context);
   registerMemoryForgetTool(api, context);
   registerMemoryUpdateTool(api, context);

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -80,6 +80,12 @@ assert.ok(
   Object.prototype.hasOwnProperty.call(manifest.configSchema.properties.llm.properties, "auth"),
   "configSchema should declare llm.auth",
 );
+for (const toolName of ["memory_recall", "memory_search", "memory_get", "memory_store"]) {
+  assert.ok(
+    manifest.contracts.tools.includes(toolName),
+    `contracts.tools should declare ${toolName}`,
+  );
+}
 assert.ok(
   Object.prototype.hasOwnProperty.call(manifest.configSchema.properties.llm.properties, "oauthPath"),
   "configSchema should declare llm.oauthPath",
@@ -223,6 +229,13 @@ try {
     "function",
     "plugin should register an OpenClaw memory capability runtime",
   );
+  for (const toolName of ["memory_recall", "memory_search", "memory_get"]) {
+    assert.equal(
+      typeof api.toolFactories[toolName],
+      "function",
+      `plugin should register ${toolName}`,
+    );
+  }
   assert.equal(
     typeof api.memoryCapability?.promptBuilder,
     "function",


### PR DESCRIPTION
Fixes #305.

## Summary
- register `memory_search` and `memory_get` as compatibility aliases for `memory_recall`
- reuse the same recall implementation and parameter schema for all three tool names
- expose the aliases in the plugin contract and regression coverage

## Validation
- `node test/plugin-manifest-regression.mjs`
- `npx tsc -p tsconfig.json`
