### PR TITLE
Add memory_store force override

### DIFF
--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -568,9 +568,12 @@ export function registerMemoryStoreTool(api, context) {
                 scope: Type.Optional(Type.String({
                     description: "Memory scope (optional, defaults to agent scope)",
                 })),
+                force: Type.Optional(Type.Boolean({
+                    description: "Store even when the duplicate pre-check finds a very similar existing memory",
+                })),
             }),
             async execute(_toolCallId, params) {
-                const { text, importance = 0.7, category = "other", scope, } = params;
+                const { text, importance = 0.7, category = "other", scope, force = false, } = params;
                 try {
                     // Guard: strip envelope metadata first, reject only if nothing remains (P2 fix)
                     const stripped = stripEnvelopeMetadata(text);
@@ -670,20 +673,21 @@ export function registerMemoryStoreTool(api, context) {
                     catch (err) {
                         console.warn(`memory-lancedb-pro: duplicate pre-check failed, continue store: ${String(err)}`);
                     }
-                    if (existing.length > 0 && existing[0].score > 0.98) {
+                    const duplicateCandidate = existing[0]?.score > 0.98 ? existing[0] : undefined;
+                    if (duplicateCandidate && !force) {
                         return {
                             content: [
                                 {
                                     type: "text",
-                                    text: `Similar memory already exists: "${existing[0].entry.text}"`,
+                                    text: `Similar memory already exists: "${duplicateCandidate.entry.text}"`,
                                 },
                             ],
                             details: {
                                 action: "duplicate",
-                                existingId: existing[0].entry.id,
-                                existingText: existing[0].entry.text,
-                                existingScope: existing[0].entry.scope,
-                                similarity: existing[0].score,
+                                existingId: duplicateCandidate.entry.id,
+                                existingText: duplicateCandidate.entry.text,
+                                existingScope: duplicateCandidate.entry.scope,
+                                similarity: duplicateCandidate.score,
                             },
                         };
                     }
@@ -808,6 +812,14 @@ export function registerMemoryStoreTool(api, context) {
                             scope: entry.scope,
                             category: entry.category,
                             importance: entry.importance,
+                            ...(duplicateCandidate && force
+                                ? { duplicateOverride: {
+                                        existingId: duplicateCandidate.entry.id,
+                                        existingText: duplicateCandidate.entry.text,
+                                        existingScope: duplicateCandidate.entry.scope,
+                                        similarity: duplicateCandidate.score,
+                                    } }
+                                : {}),
                         },
                     };
                 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -742,6 +742,11 @@ export function registerMemoryStoreTool(
             description: "Memory scope (optional, defaults to agent scope)",
           }),
         ),
+        force: Type.Optional(
+          Type.Boolean({
+            description: "Store even when the duplicate pre-check finds a very similar existing memory",
+          }),
+        ),
       }),
       async execute(_toolCallId, params) {
         const {
@@ -749,11 +754,13 @@ export function registerMemoryStoreTool(
           importance = 0.7,
           category = "other",
           scope,
+          force = false,
         } = params as {
           text: string;
           importance?: number;
           category?: string;
           scope?: string;
+          force?: boolean;
         };
 
         try {
@@ -868,20 +875,21 @@ export function registerMemoryStoreTool(
             );
           }
 
-          if (existing.length > 0 && existing[0].score > 0.98) {
+          const duplicateCandidate = existing[0]?.score > 0.98 ? existing[0] : undefined;
+          if (duplicateCandidate && !force) {
             return {
               content: [
                 {
                   type: "text",
-                  text: `Similar memory already exists: "${existing[0].entry.text}"`,
+                  text: `Similar memory already exists: "${duplicateCandidate.entry.text}"`,
                 },
               ],
               details: {
                 action: "duplicate",
-                existingId: existing[0].entry.id,
-                existingText: existing[0].entry.text,
-                existingScope: existing[0].entry.scope,
-                similarity: existing[0].score,
+                existingId: duplicateCandidate.entry.id,
+                existingText: duplicateCandidate.entry.text,
+                existingScope: duplicateCandidate.entry.scope,
+                similarity: duplicateCandidate.score,
               },
             };
           }
@@ -1039,6 +1047,14 @@ export function registerMemoryStoreTool(
               scope: entry.scope,
               category: entry.category,
               importance: entry.importance,
+              ...(duplicateCandidate && force
+                ? { duplicateOverride: {
+                  existingId: duplicateCandidate.entry.id,
+                  existingText: duplicateCandidate.entry.text,
+                  existingScope: duplicateCandidate.entry.scope,
+                  similarity: duplicateCandidate.score,
+                } }
+                : {}),
             },
           };
         } catch (error) {

--- a/test/is-latest-auto-supersede.test.mjs
+++ b/test/is-latest-auto-supersede.test.mjs
@@ -292,6 +292,29 @@ async function runTests() {
     console.log("  ✅ facts are not auto-superseded (only preference/entity)");
   }
 
+  // Test 10: exact duplicate is skipped unless force=true
+  {
+    console.log("Test 10: force=true overrides exact duplicate skip...");
+    const duplicateText = "Remember that the dashboard runs on port 5173";
+    const store = makeMockStore();
+    const oldId = "old-duplicate-1";
+    const oldEntry = makeOldEntry(oldId, duplicateText, "fact");
+    store.seed(oldEntry);
+
+    store.setNextSearchResults([{ entry: oldEntry, score: 0.99 }]);
+    const tool = createTool(registerMemoryStoreTool, makeContext(store));
+    const skipped = await tool.execute(null, { text: duplicateText, category: "fact" });
+    assert.equal(skipped.details.action, "duplicate", "duplicates should still skip by default");
+    assert.equal(skipped.details.existingId, oldId);
+
+    store.setNextSearchResults([{ entry: oldEntry, score: 0.99 }]);
+    const forced = await tool.execute(null, { text: duplicateText, category: "fact", force: true });
+    assert.equal(forced.details.action, "created", "force=true should store despite duplicate");
+    assert.equal(forced.details.duplicateOverride.existingId, oldId);
+    assert.equal(store._entries.size, 2, "forced duplicate should add a new entry");
+    console.log("  ✅ force=true stores despite exact duplicate");
+  }
+
   console.log("\n✅ All is-latest auto-supersede tests passed!");
 }
 


### PR DESCRIPTION
Fixes #30.

## Summary
- add `force?: boolean` to `memory_store`
- preserve the existing duplicate skip by default
- allow `force: true` to store anyway and return duplicate override details

## Validation
- `node test/is-latest-auto-supersede.test.mjs`
- `npx tsc -p tsconfig.json`
