### PR TITLE
Warn on costly auto-recall rerank config

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,17 @@ If auto-recall consistently times out, check your embedding API latency first. T
 </details>
 
 <details>
+<summary><strong>Auto-recall rerank cost model</strong></summary>
+
+When `autoRecall=true` and `retrieval.rerank="cross-encoder"` with an external rerank API such as Jina, every eligible prompt can make a rerank request. The number of documents sent to that request is governed by `retrieval.candidatePoolSize` (and the retrieval safety minimum), not by the final `autoRecallMaxItems` injection cap.
+
+For example, with `autoRecallMaxItems: 3` and the default `candidatePoolSize: 20`, the plugin may rerank up to 20 candidates before injecting at most 3 memories. To reduce external rerank usage, lower `retrieval.candidatePoolSize`, switch `retrieval.rerank` to `"lightweight"` or `"none"`, increase `autoRecallMinLength`, or keep auto-recall disabled and use manual `memory_recall` where appropriate.
+
+Startup logs warn when auto-recall plus cross-encoder rerank is configured with a large candidate pool, and debug auto-recall stats include the effective `candidatePoolSize`, `retrieveLimit`, `rerank`, and `rerankProvider`.
+
+</details>
+
+<details>
 <summary><strong>Session Memory</strong></summary>
 
 - Triggered on `/new` command — saves previous session summary to LanceDB

--- a/README.md
+++ b/README.md
@@ -712,11 +712,11 @@ If auto-recall consistently times out, check your embedding API latency first. T
 <details>
 <summary><strong>Auto-recall rerank cost model</strong></summary>
 
-When `autoRecall=true` and `retrieval.rerank="cross-encoder"` with an external rerank API such as Jina, every eligible prompt can make a rerank request. The number of documents sent to that request is governed by `retrieval.candidatePoolSize` (and the retrieval safety minimum), not by the final `autoRecallMaxItems` injection cap.
+When `autoRecall=true` and hybrid retrieval uses `retrieval.rerank="cross-encoder"` with an external rerank API such as Jina, every eligible prompt can make a rerank request. The number of documents sent to that request is governed by auto-recall's retrieve limit and the retriever's rerank input window, not directly by `retrieval.candidatePoolSize` or by the final `autoRecallMaxItems` injection cap.
 
-For example, with `autoRecallMaxItems: 3` and the default `candidatePoolSize: 20`, the plugin may rerank up to 20 candidates before injecting at most 3 memories. To reduce external rerank usage, lower `retrieval.candidatePoolSize`, switch `retrieval.rerank` to `"lightweight"` or `"none"`, increase `autoRecallMinLength`, or keep auto-recall disabled and use manual `memory_recall` where appropriate.
+For example, with `autoRecallMaxItems: 3`, auto-recall asks retrieval for 6 items and hybrid retrieval may send up to 12 candidates to the external reranker before injecting at most 3 memories. To reduce external rerank usage, lower `autoRecallMaxItems` or `maxRecallPerTurn`, switch `retrieval.rerank` to `"lightweight"` or `"none"`, increase `autoRecallMinLength`, or keep auto-recall disabled and use manual `memory_recall` where appropriate.
 
-Startup logs warn when auto-recall plus cross-encoder rerank is configured with a large candidate pool, and debug auto-recall stats include the effective `candidatePoolSize`, `retrieveLimit`, `rerank`, and `rerankProvider`.
+Startup logs warn when auto-recall plus hybrid cross-encoder rerank can send more items to the reranker than it will inject. Debug auto-recall stats include the actual `rerankInput`, `rerankInputLimit`, `retrieveLimit`, `rerank`, `rerankProvider`, and configured `retrievalCandidatePoolSize`.
 
 </details>
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -135,25 +135,28 @@ function getEffectiveAutoRecallMaxItems(config) {
 function getAutoRecallRetrieveLimit(autoRecallMaxItems) {
     return clampInt(Math.max(autoRecallMaxItems * 2, autoRecallMaxItems), 1, 20);
 }
-function getEffectiveRerankCandidatePoolSize(retrievalConfig, retrieveLimit) {
-    return Math.max(retrievalConfig.candidatePoolSize, retrieveLimit * 2);
+function getAutoRecallRerankInputLimit(retrieveLimit) {
+    return clampInt(retrieveLimit, 1, 20) * 2;
 }
 export function buildAutoRecallRerankCostWarning(config, retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...(config.retrieval || {}) }) {
     if (config.autoRecall !== true || config.recallMode === "off")
+        return null;
+    if (retrievalConfig.mode === "vector")
         return null;
     if (retrievalConfig.rerank !== "cross-encoder" || !retrievalConfig.rerankApiKey)
         return null;
     const autoRecallMaxItems = getEffectiveAutoRecallMaxItems(config);
     const retrieveLimit = getAutoRecallRetrieveLimit(autoRecallMaxItems);
-    const candidatePoolSize = getEffectiveRerankCandidatePoolSize(retrievalConfig, retrieveLimit);
-    if (candidatePoolSize <= autoRecallMaxItems * 4)
+    const rerankInputLimit = getAutoRecallRerankInputLimit(retrieveLimit);
+    if (rerankInputLimit <= autoRecallMaxItems)
         return null;
     const provider = retrievalConfig.rerankProvider || "jina";
-    return (`[memory-lancedb-pro] autoRecall=true with cross-encoder rerank (${provider}) can send up to ` +
-        `${candidatePoolSize} candidates to the reranker for each prompt while injecting at most ` +
-        `${autoRecallMaxItems} memories. External rerank cost follows retrieval.candidatePoolSize, not ` +
-        `autoRecallMaxItems. Lower retrieval.candidatePoolSize, set retrieval.rerank to "lightweight" ` +
-        `or "none", or raise autoRecallMinLength to reduce calls.`);
+    return (`[memory-lancedb-pro] autoRecall=true with hybrid cross-encoder rerank (${provider}) can send up to ` +
+        `${rerankInputLimit} candidates to the reranker for each prompt while injecting at most ` +
+        `${autoRecallMaxItems} memories. External rerank cost follows the auto-recall rerank input window ` +
+        `(${retrieveLimit} retrieved items x2), not retrieval.candidatePoolSize or the final ` +
+        `autoRecallMaxItems injection cap. Lower autoRecallMaxItems or maxRecallPerTurn, set ` +
+        `retrieval.rerank to "lightweight" or "none", or raise autoRecallMinLength to reduce calls.`);
 }
 function resolveLlmTimeoutMs(config) {
     return parsePositiveInt(config.llm?.timeoutMs) ?? 30000;
@@ -2203,7 +2206,7 @@ const memoryLanceDBProPlugin = {
                     const autoRecallPerItemMaxChars = clampInt(config.autoRecallPerItemMaxChars ?? 180, 32, 1000);
                     const retrieveLimit = getAutoRecallRetrieveLimit(autoRecallMaxItems);
                     const retrievalConfig = retriever.getConfig();
-                    const rerankCandidatePoolSize = getEffectiveRerankCandidatePoolSize(retrievalConfig, retrieveLimit);
+                    const rerankInputLimit = getAutoRecallRerankInputLimit(retrieveLimit);
                     // Adaptive intent analysis (zero-LLM-cost pattern matching)
                     const intent = recallMode === "adaptive" ? analyzeIntent(recallQuery) : undefined;
                     if (intent) {
@@ -2389,7 +2392,9 @@ const memoryLanceDBProPlugin = {
                     };
                     const memoryContext = selected.map((item) => item.line).join("\n");
                     const injectedIds = selected.map((item) => item.id).join(",") || "(none)";
-                    api.logger.debug?.(`memory-lancedb-pro: auto-recall stats hits=${results.length}, dedupFiltered=${dedupFilteredCount}, stateFiltered=${stateFilteredCount}, suppressedFiltered=${suppressedFilteredCount}, preBudgetItems=${preBudgetItems}, preBudgetChars=${preBudgetChars}, postBudgetItems=${selected.length}, postBudgetChars=${usedChars}, maxItems=${autoRecallMaxItems}, maxChars=${autoRecallMaxChars}, perItemMaxChars=${autoRecallPerItemMaxChars}, retrieveLimit=${retrieveLimit}, rerank=${retrievalConfig.rerank}, rerankProvider=${retrievalConfig.rerankProvider || "default"}, candidatePoolSize=${rerankCandidatePoolSize}, injectedIds=${injectedIds}`);
+                    const retrievalDiagnostics = retriever.getLastDiagnostics();
+                    const rerankInputCount = retrievalDiagnostics?.stageCounts.rerankInput;
+                    api.logger.debug?.(`memory-lancedb-pro: auto-recall stats hits=${results.length}, dedupFiltered=${dedupFilteredCount}, stateFiltered=${stateFilteredCount}, suppressedFiltered=${suppressedFilteredCount}, preBudgetItems=${preBudgetItems}, preBudgetChars=${preBudgetChars}, postBudgetItems=${selected.length}, postBudgetChars=${usedChars}, maxItems=${autoRecallMaxItems}, maxChars=${autoRecallMaxChars}, perItemMaxChars=${autoRecallPerItemMaxChars}, retrieveLimit=${retrieveLimit}, rerank=${retrievalConfig.rerank}, rerankProvider=${retrievalConfig.rerankProvider || "default"}, rerankInput=${rerankInputCount ?? "(unknown)"}, rerankInputLimit=${rerankInputLimit}, retrievalCandidatePoolSize=${retrievalConfig.candidatePoolSize}, injectedIds=${injectedIds}`);
                     api.logger.info?.(`memory-lancedb-pro: injecting ${selected.length} memories into context for agent ${agentId}`);
                     // Create or update pendingRecall for this turn so the feedback hook
                     // (which runs in the NEXT turn's before_prompt_build after agent_end)

--- a/dist/index.js
+++ b/dist/index.js
@@ -2392,7 +2392,9 @@ const memoryLanceDBProPlugin = {
                     };
                     const memoryContext = selected.map((item) => item.line).join("\n");
                     const injectedIds = selected.map((item) => item.id).join(",") || "(none)";
-                    const retrievalDiagnostics = retriever.getLastDiagnostics();
+                    const retrievalDiagnostics = typeof retriever.getLastDiagnostics === "function"
+                        ? retriever.getLastDiagnostics()
+                        : undefined;
                     const rerankInputCount = retrievalDiagnostics?.stageCounts.rerankInput;
                     api.logger.debug?.(`memory-lancedb-pro: auto-recall stats hits=${results.length}, dedupFiltered=${dedupFilteredCount}, stateFiltered=${stateFilteredCount}, suppressedFiltered=${suppressedFilteredCount}, preBudgetItems=${preBudgetItems}, preBudgetChars=${preBudgetChars}, postBudgetItems=${selected.length}, postBudgetChars=${usedChars}, maxItems=${autoRecallMaxItems}, maxChars=${autoRecallMaxChars}, perItemMaxChars=${autoRecallPerItemMaxChars}, retrieveLimit=${retrieveLimit}, rerank=${retrievalConfig.rerank}, rerankProvider=${retrievalConfig.rerankProvider || "default"}, rerankInput=${rerankInputCount ?? "(unknown)"}, rerankInputLimit=${rerankInputLimit}, retrievalCandidatePoolSize=${retrievalConfig.candidatePoolSize}, injectedIds=${injectedIds}`);
                     api.logger.info?.(`memory-lancedb-pro: injecting ${selected.length} memories into context for agent ${agentId}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -127,6 +127,34 @@ function clampInt(value, min, max) {
         return min;
     return Math.min(max, Math.max(min, Math.floor(value)));
 }
+function getEffectiveAutoRecallMaxItems(config) {
+    const configMaxItems = clampInt(config.autoRecallMaxItems ?? 3, 1, 20);
+    const maxPerTurn = clampInt(config.maxRecallPerTurn ?? 10, 1, 50);
+    return Math.min(configMaxItems, maxPerTurn);
+}
+function getAutoRecallRetrieveLimit(autoRecallMaxItems) {
+    return clampInt(Math.max(autoRecallMaxItems * 2, autoRecallMaxItems), 1, 20);
+}
+function getEffectiveRerankCandidatePoolSize(retrievalConfig, retrieveLimit) {
+    return Math.max(retrievalConfig.candidatePoolSize, retrieveLimit * 2);
+}
+export function buildAutoRecallRerankCostWarning(config, retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...(config.retrieval || {}) }) {
+    if (config.autoRecall !== true || config.recallMode === "off")
+        return null;
+    if (retrievalConfig.rerank !== "cross-encoder" || !retrievalConfig.rerankApiKey)
+        return null;
+    const autoRecallMaxItems = getEffectiveAutoRecallMaxItems(config);
+    const retrieveLimit = getAutoRecallRetrieveLimit(autoRecallMaxItems);
+    const candidatePoolSize = getEffectiveRerankCandidatePoolSize(retrievalConfig, retrieveLimit);
+    if (candidatePoolSize <= autoRecallMaxItems * 4)
+        return null;
+    const provider = retrievalConfig.rerankProvider || "jina";
+    return (`[memory-lancedb-pro] autoRecall=true with cross-encoder rerank (${provider}) can send up to ` +
+        `${candidatePoolSize} candidates to the reranker for each prompt while injecting at most ` +
+        `${autoRecallMaxItems} memories. External rerank cost follows retrieval.candidatePoolSize, not ` +
+        `autoRecallMaxItems. Lower retrieval.candidatePoolSize, set retrieval.rerank to "lightweight" ` +
+        `or "none", or raise autoRecallMinLength to reduce calls.`);
+}
 function resolveLlmTimeoutMs(config) {
     return parsePositiveInt(config.llm?.timeoutMs) ?? 30000;
 }
@@ -1530,7 +1558,12 @@ function _initPluginState(api) {
         ...DEFAULT_TIER_CONFIG,
         ...(config.tier || {}),
     });
-    const retriever = createRetriever(store, embedder, { ...DEFAULT_RETRIEVAL_CONFIG, ...config.retrieval }, { decayEngine });
+    const retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...config.retrieval };
+    const retriever = createRetriever(store, embedder, retrievalConfig, { decayEngine });
+    const rerankCostWarning = buildAutoRecallRerankCostWarning(config, retrievalConfig);
+    if (rerankCostWarning) {
+        api.logger.warn(rerankCostWarning);
+    }
     const scopeManager = createScopeManager(config.scopes);
     const canonicalCorpusIndexer = new CanonicalCorpusIndexer({
         store,
@@ -2164,13 +2197,13 @@ const memoryLanceDBProPlugin = {
                         recallQuery = recallQuery.slice(0, MAX_RECALL_QUERY_LENGTH);
                         api.logger.info(`memory-lancedb-pro: auto-recall query truncated from ${originalLength} to ${MAX_RECALL_QUERY_LENGTH} chars`);
                     }
-                    const configMaxItems = clampInt(config.autoRecallMaxItems ?? 3, 1, 20);
-                    const maxPerTurn = clampInt(config.maxRecallPerTurn ?? 10, 1, 50);
                     // maxRecallPerTurn acts as a hard ceiling on top of autoRecallMaxItems (#345)
-                    const autoRecallMaxItems = Math.min(configMaxItems, maxPerTurn);
+                    const autoRecallMaxItems = getEffectiveAutoRecallMaxItems(config);
                     const autoRecallMaxChars = clampInt(config.autoRecallMaxChars ?? 600, 64, 8000);
                     const autoRecallPerItemMaxChars = clampInt(config.autoRecallPerItemMaxChars ?? 180, 32, 1000);
-                    const retrieveLimit = clampInt(Math.max(autoRecallMaxItems * 2, autoRecallMaxItems), 1, 20);
+                    const retrieveLimit = getAutoRecallRetrieveLimit(autoRecallMaxItems);
+                    const retrievalConfig = retriever.getConfig();
+                    const rerankCandidatePoolSize = getEffectiveRerankCandidatePoolSize(retrievalConfig, retrieveLimit);
                     // Adaptive intent analysis (zero-LLM-cost pattern matching)
                     const intent = recallMode === "adaptive" ? analyzeIntent(recallQuery) : undefined;
                     if (intent) {
@@ -2356,7 +2389,7 @@ const memoryLanceDBProPlugin = {
                     };
                     const memoryContext = selected.map((item) => item.line).join("\n");
                     const injectedIds = selected.map((item) => item.id).join(",") || "(none)";
-                    api.logger.debug?.(`memory-lancedb-pro: auto-recall stats hits=${results.length}, dedupFiltered=${dedupFilteredCount}, stateFiltered=${stateFilteredCount}, suppressedFiltered=${suppressedFilteredCount}, preBudgetItems=${preBudgetItems}, preBudgetChars=${preBudgetChars}, postBudgetItems=${selected.length}, postBudgetChars=${usedChars}, maxItems=${autoRecallMaxItems}, maxChars=${autoRecallMaxChars}, perItemMaxChars=${autoRecallPerItemMaxChars}, injectedIds=${injectedIds}`);
+                    api.logger.debug?.(`memory-lancedb-pro: auto-recall stats hits=${results.length}, dedupFiltered=${dedupFilteredCount}, stateFiltered=${stateFilteredCount}, suppressedFiltered=${suppressedFilteredCount}, preBudgetItems=${preBudgetItems}, preBudgetChars=${preBudgetChars}, postBudgetItems=${selected.length}, postBudgetChars=${usedChars}, maxItems=${autoRecallMaxItems}, maxChars=${autoRecallMaxChars}, perItemMaxChars=${autoRecallPerItemMaxChars}, retrieveLimit=${retrieveLimit}, rerank=${retrievalConfig.rerank}, rerankProvider=${retrievalConfig.rerankProvider || "default"}, candidatePoolSize=${rerankCandidatePoolSize}, injectedIds=${injectedIds}`);
                     api.logger.info?.(`memory-lancedb-pro: injecting ${selected.length} memories into context for agent ${agentId}`);
                     // Create or update pendingRecall for this turn so the feedback hook
                     // (which runs in the NEXT turn's before_prompt_build after agent_end)

--- a/index.ts
+++ b/index.ts
@@ -3081,7 +3081,9 @@ const memoryLanceDBProPlugin = {
           const memoryContext = selected.map((item) => item.line).join("\n");
 
           const injectedIds = selected.map((item) => item.id).join(",") || "(none)";
-          const retrievalDiagnostics = retriever.getLastDiagnostics();
+          const retrievalDiagnostics = typeof retriever.getLastDiagnostics === "function"
+            ? retriever.getLastDiagnostics()
+            : undefined;
           const rerankInputCount = retrievalDiagnostics?.stageCounts.rerankInput;
           api.logger.debug?.(
             `memory-lancedb-pro: auto-recall stats hits=${results.length}, dedupFiltered=${dedupFilteredCount}, stateFiltered=${stateFilteredCount}, suppressedFiltered=${suppressedFilteredCount}, preBudgetItems=${preBudgetItems}, preBudgetChars=${preBudgetChars}, postBudgetItems=${selected.length}, postBudgetChars=${usedChars}, maxItems=${autoRecallMaxItems}, maxChars=${autoRecallMaxChars}, perItemMaxChars=${autoRecallPerItemMaxChars}, retrieveLimit=${retrieveLimit}, rerank=${retrievalConfig.rerank}, rerankProvider=${retrievalConfig.rerankProvider || "default"}, rerankInput=${rerankInputCount ?? "(unknown)"}, rerankInputLimit=${rerankInputLimit}, retrievalCandidatePoolSize=${retrievalConfig.candidatePoolSize}, injectedIds=${injectedIds}`,

--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,7 @@ import {
   createEmbedder,
   getEffectiveVectorDimensions,
 } from "./src/embedder.js";
-import { createRetriever, DEFAULT_RETRIEVAL_CONFIG } from "./src/retriever.js";
+import { createRetriever, DEFAULT_RETRIEVAL_CONFIG, type RetrievalConfig } from "./src/retriever.js";
 import { createScopeManager, resolveScopeFilter, isSystemBypassId, parseAgentIdFromSessionKey } from "./src/scopes.js";
 import { createMigrator } from "./src/migrate.js";
 import { registerAllMemoryTools } from "./src/tools.js";
@@ -373,6 +373,45 @@ function parseNonNegativeInt(value: unknown): number | undefined {
 function clampInt(value: number, min: number, max: number): number {
   if (!Number.isFinite(value)) return min;
   return Math.min(max, Math.max(min, Math.floor(value)));
+}
+
+function getEffectiveAutoRecallMaxItems(config: PluginConfig): number {
+  const configMaxItems = clampInt(config.autoRecallMaxItems ?? 3, 1, 20);
+  const maxPerTurn = clampInt(config.maxRecallPerTurn ?? 10, 1, 50);
+  return Math.min(configMaxItems, maxPerTurn);
+}
+
+function getAutoRecallRetrieveLimit(autoRecallMaxItems: number): number {
+  return clampInt(Math.max(autoRecallMaxItems * 2, autoRecallMaxItems), 1, 20);
+}
+
+function getEffectiveRerankCandidatePoolSize(
+  retrievalConfig: RetrievalConfig,
+  retrieveLimit: number,
+): number {
+  return Math.max(retrievalConfig.candidatePoolSize, retrieveLimit * 2);
+}
+
+export function buildAutoRecallRerankCostWarning(
+  config: PluginConfig,
+  retrievalConfig: RetrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...(config.retrieval || {}) },
+): string | null {
+  if (config.autoRecall !== true || config.recallMode === "off") return null;
+  if (retrievalConfig.rerank !== "cross-encoder" || !retrievalConfig.rerankApiKey) return null;
+
+  const autoRecallMaxItems = getEffectiveAutoRecallMaxItems(config);
+  const retrieveLimit = getAutoRecallRetrieveLimit(autoRecallMaxItems);
+  const candidatePoolSize = getEffectiveRerankCandidatePoolSize(retrievalConfig, retrieveLimit);
+  if (candidatePoolSize <= autoRecallMaxItems * 4) return null;
+
+  const provider = retrievalConfig.rerankProvider || "jina";
+  return (
+    `[memory-lancedb-pro] autoRecall=true with cross-encoder rerank (${provider}) can send up to ` +
+    `${candidatePoolSize} candidates to the reranker for each prompt while injecting at most ` +
+    `${autoRecallMaxItems} memories. External rerank cost follows retrieval.candidatePoolSize, not ` +
+    `autoRecallMaxItems. Lower retrieval.candidatePoolSize, set retrieval.rerank to "lightweight" ` +
+    `or "none", or raise autoRecallMinLength to reduce calls.`
+  );
 }
 
 function resolveLlmTimeoutMs(config: PluginConfig): number {
@@ -2031,12 +2070,17 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
     ...DEFAULT_TIER_CONFIG,
     ...(config.tier || {}),
   });
+  const retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...config.retrieval };
   const retriever = createRetriever(
     store,
     embedder,
-    { ...DEFAULT_RETRIEVAL_CONFIG, ...config.retrieval },
+    retrievalConfig,
     { decayEngine },
   );
+  const rerankCostWarning = buildAutoRecallRerankCostWarning(config, retrievalConfig);
+  if (rerankCostWarning) {
+    api.logger.warn(rerankCostWarning);
+  }
   const scopeManager = createScopeManager(config.scopes);
   const canonicalCorpusIndexer = new CanonicalCorpusIndexer({
     store,
@@ -2819,13 +2863,13 @@ const memoryLanceDBProPlugin = {
             );
           }
 
-          const configMaxItems = clampInt(config.autoRecallMaxItems ?? 3, 1, 20);
-          const maxPerTurn = clampInt(config.maxRecallPerTurn ?? 10, 1, 50);
           // maxRecallPerTurn acts as a hard ceiling on top of autoRecallMaxItems (#345)
-          const autoRecallMaxItems = Math.min(configMaxItems, maxPerTurn);
+          const autoRecallMaxItems = getEffectiveAutoRecallMaxItems(config);
           const autoRecallMaxChars = clampInt(config.autoRecallMaxChars ?? 600, 64, 8000);
           const autoRecallPerItemMaxChars = clampInt(config.autoRecallPerItemMaxChars ?? 180, 32, 1000);
-          const retrieveLimit = clampInt(Math.max(autoRecallMaxItems * 2, autoRecallMaxItems), 1, 20);
+          const retrieveLimit = getAutoRecallRetrieveLimit(autoRecallMaxItems);
+          const retrievalConfig = retriever.getConfig();
+          const rerankCandidatePoolSize = getEffectiveRerankCandidatePoolSize(retrievalConfig, retrieveLimit);
 
           // Adaptive intent analysis (zero-LLM-cost pattern matching)
           const intent = recallMode === "adaptive" ? analyzeIntent(recallQuery) : undefined;
@@ -3039,7 +3083,7 @@ const memoryLanceDBProPlugin = {
 
           const injectedIds = selected.map((item) => item.id).join(",") || "(none)";
           api.logger.debug?.(
-            `memory-lancedb-pro: auto-recall stats hits=${results.length}, dedupFiltered=${dedupFilteredCount}, stateFiltered=${stateFilteredCount}, suppressedFiltered=${suppressedFilteredCount}, preBudgetItems=${preBudgetItems}, preBudgetChars=${preBudgetChars}, postBudgetItems=${selected.length}, postBudgetChars=${usedChars}, maxItems=${autoRecallMaxItems}, maxChars=${autoRecallMaxChars}, perItemMaxChars=${autoRecallPerItemMaxChars}, injectedIds=${injectedIds}`,
+            `memory-lancedb-pro: auto-recall stats hits=${results.length}, dedupFiltered=${dedupFilteredCount}, stateFiltered=${stateFilteredCount}, suppressedFiltered=${suppressedFilteredCount}, preBudgetItems=${preBudgetItems}, preBudgetChars=${preBudgetChars}, postBudgetItems=${selected.length}, postBudgetChars=${usedChars}, maxItems=${autoRecallMaxItems}, maxChars=${autoRecallMaxChars}, perItemMaxChars=${autoRecallPerItemMaxChars}, retrieveLimit=${retrieveLimit}, rerank=${retrievalConfig.rerank}, rerankProvider=${retrievalConfig.rerankProvider || "default"}, candidatePoolSize=${rerankCandidatePoolSize}, injectedIds=${injectedIds}`,
           );
 
           api.logger.info?.(

--- a/index.ts
+++ b/index.ts
@@ -385,11 +385,8 @@ function getAutoRecallRetrieveLimit(autoRecallMaxItems: number): number {
   return clampInt(Math.max(autoRecallMaxItems * 2, autoRecallMaxItems), 1, 20);
 }
 
-function getEffectiveRerankCandidatePoolSize(
-  retrievalConfig: RetrievalConfig,
-  retrieveLimit: number,
-): number {
-  return Math.max(retrievalConfig.candidatePoolSize, retrieveLimit * 2);
+function getAutoRecallRerankInputLimit(retrieveLimit: number): number {
+  return clampInt(retrieveLimit, 1, 20) * 2;
 }
 
 export function buildAutoRecallRerankCostWarning(
@@ -397,20 +394,22 @@ export function buildAutoRecallRerankCostWarning(
   retrievalConfig: RetrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...(config.retrieval || {}) },
 ): string | null {
   if (config.autoRecall !== true || config.recallMode === "off") return null;
+  if (retrievalConfig.mode === "vector") return null;
   if (retrievalConfig.rerank !== "cross-encoder" || !retrievalConfig.rerankApiKey) return null;
 
   const autoRecallMaxItems = getEffectiveAutoRecallMaxItems(config);
   const retrieveLimit = getAutoRecallRetrieveLimit(autoRecallMaxItems);
-  const candidatePoolSize = getEffectiveRerankCandidatePoolSize(retrievalConfig, retrieveLimit);
-  if (candidatePoolSize <= autoRecallMaxItems * 4) return null;
+  const rerankInputLimit = getAutoRecallRerankInputLimit(retrieveLimit);
+  if (rerankInputLimit <= autoRecallMaxItems) return null;
 
   const provider = retrievalConfig.rerankProvider || "jina";
   return (
-    `[memory-lancedb-pro] autoRecall=true with cross-encoder rerank (${provider}) can send up to ` +
-    `${candidatePoolSize} candidates to the reranker for each prompt while injecting at most ` +
-    `${autoRecallMaxItems} memories. External rerank cost follows retrieval.candidatePoolSize, not ` +
-    `autoRecallMaxItems. Lower retrieval.candidatePoolSize, set retrieval.rerank to "lightweight" ` +
-    `or "none", or raise autoRecallMinLength to reduce calls.`
+    `[memory-lancedb-pro] autoRecall=true with hybrid cross-encoder rerank (${provider}) can send up to ` +
+    `${rerankInputLimit} candidates to the reranker for each prompt while injecting at most ` +
+    `${autoRecallMaxItems} memories. External rerank cost follows the auto-recall rerank input window ` +
+    `(${retrieveLimit} retrieved items x2), not retrieval.candidatePoolSize or the final ` +
+    `autoRecallMaxItems injection cap. Lower autoRecallMaxItems or maxRecallPerTurn, set ` +
+    `retrieval.rerank to "lightweight" or "none", or raise autoRecallMinLength to reduce calls.`
   );
 }
 
@@ -2869,7 +2868,7 @@ const memoryLanceDBProPlugin = {
           const autoRecallPerItemMaxChars = clampInt(config.autoRecallPerItemMaxChars ?? 180, 32, 1000);
           const retrieveLimit = getAutoRecallRetrieveLimit(autoRecallMaxItems);
           const retrievalConfig = retriever.getConfig();
-          const rerankCandidatePoolSize = getEffectiveRerankCandidatePoolSize(retrievalConfig, retrieveLimit);
+          const rerankInputLimit = getAutoRecallRerankInputLimit(retrieveLimit);
 
           // Adaptive intent analysis (zero-LLM-cost pattern matching)
           const intent = recallMode === "adaptive" ? analyzeIntent(recallQuery) : undefined;
@@ -3082,8 +3081,10 @@ const memoryLanceDBProPlugin = {
           const memoryContext = selected.map((item) => item.line).join("\n");
 
           const injectedIds = selected.map((item) => item.id).join(",") || "(none)";
+          const retrievalDiagnostics = retriever.getLastDiagnostics();
+          const rerankInputCount = retrievalDiagnostics?.stageCounts.rerankInput;
           api.logger.debug?.(
-            `memory-lancedb-pro: auto-recall stats hits=${results.length}, dedupFiltered=${dedupFilteredCount}, stateFiltered=${stateFilteredCount}, suppressedFiltered=${suppressedFilteredCount}, preBudgetItems=${preBudgetItems}, preBudgetChars=${preBudgetChars}, postBudgetItems=${selected.length}, postBudgetChars=${usedChars}, maxItems=${autoRecallMaxItems}, maxChars=${autoRecallMaxChars}, perItemMaxChars=${autoRecallPerItemMaxChars}, retrieveLimit=${retrieveLimit}, rerank=${retrievalConfig.rerank}, rerankProvider=${retrievalConfig.rerankProvider || "default"}, candidatePoolSize=${rerankCandidatePoolSize}, injectedIds=${injectedIds}`,
+            `memory-lancedb-pro: auto-recall stats hits=${results.length}, dedupFiltered=${dedupFilteredCount}, stateFiltered=${stateFilteredCount}, suppressedFiltered=${suppressedFilteredCount}, preBudgetItems=${preBudgetItems}, preBudgetChars=${preBudgetChars}, postBudgetItems=${selected.length}, postBudgetChars=${usedChars}, maxItems=${autoRecallMaxItems}, maxChars=${autoRecallMaxChars}, perItemMaxChars=${autoRecallPerItemMaxChars}, retrieveLimit=${retrieveLimit}, rerank=${retrievalConfig.rerank}, rerankProvider=${retrievalConfig.rerankProvider || "default"}, rerankInput=${rerankInputCount ?? "(unknown)"}, rerankInputLimit=${rerankInputLimit}, retrievalCandidatePoolSize=${retrievalConfig.candidatePoolSize}, injectedIds=${injectedIds}`,
           );
 
           api.logger.info?.(

--- a/test/auto-recall-rerank-cost-warning.test.mjs
+++ b/test/auto-recall-rerank-cost-warning.test.mjs
@@ -34,11 +34,12 @@ function makeConfig(overrides = {}) {
 
 {
   const warning = buildAutoRecallRerankCostWarning(makeConfig());
-  assert.ok(warning, "high candidatePoolSize cross-encoder auto-recall should warn");
-  assert.match(warning, /candidatePoolSize/);
+  assert.ok(warning, "hybrid cross-encoder auto-recall should warn when rerank input exceeds injected items");
+  assert.match(warning, /rerank input window/);
   assert.match(warning, /autoRecallMaxItems/);
-  assert.match(warning, /20 candidates/);
+  assert.match(warning, /12 candidates/);
   assert.match(warning, /3 memories/);
+  assert.doesNotMatch(warning, /cost follows retrieval\.candidatePoolSize/);
 }
 
 {
@@ -64,7 +65,19 @@ function makeConfig(overrides = {}) {
       candidatePoolSize: 6,
     },
   }));
-  assert.equal(warning, null, "small candidate pools should not warn");
+  assert.match(warning, /12 candidates/, "configured candidatePoolSize below the rerank window should not hide the warning");
+}
+
+{
+  const warning = buildAutoRecallRerankCostWarning(makeConfig({
+    retrieval: {
+      mode: "vector",
+      rerank: "cross-encoder",
+      rerankApiKey: "dummy",
+      candidatePoolSize: 20,
+    },
+  }));
+  assert.equal(warning, null, "vector-only retrieval should not warn because it does not call cross-encoder rerank");
 }
 
 console.log("OK: auto-recall rerank cost warning test passed");

--- a/test/auto-recall-rerank-cost-warning.test.mjs
+++ b/test/auto-recall-rerank-cost-warning.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import Module from "node:module";
+
+import jitiFactory from "jiti";
+
+process.env.NODE_PATH = [
+  process.env.NODE_PATH,
+  "/opt/homebrew/lib/node_modules/openclaw/node_modules",
+  "/opt/homebrew/lib/node_modules",
+].filter(Boolean).join(":");
+Module._initPaths();
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const {
+  buildAutoRecallRerankCostWarning,
+  parsePluginConfig,
+} = jiti("../index.ts");
+
+function makeConfig(overrides = {}) {
+  return parsePluginConfig({
+    embedding: { apiKey: "dummy" },
+    autoRecall: true,
+    autoRecallMaxItems: 3,
+    maxRecallPerTurn: 10,
+    retrieval: {
+      rerank: "cross-encoder",
+      rerankApiKey: "dummy",
+      rerankProvider: "jina",
+      candidatePoolSize: 20,
+    },
+    ...overrides,
+  });
+}
+
+{
+  const warning = buildAutoRecallRerankCostWarning(makeConfig());
+  assert.ok(warning, "high candidatePoolSize cross-encoder auto-recall should warn");
+  assert.match(warning, /candidatePoolSize/);
+  assert.match(warning, /autoRecallMaxItems/);
+  assert.match(warning, /20 candidates/);
+  assert.match(warning, /3 memories/);
+}
+
+{
+  const warning = buildAutoRecallRerankCostWarning(makeConfig({ autoRecall: false }));
+  assert.equal(warning, null, "manual-only retrieval should not warn");
+}
+
+{
+  const warning = buildAutoRecallRerankCostWarning(makeConfig({
+    retrieval: {
+      rerank: "lightweight",
+      candidatePoolSize: 20,
+    },
+  }));
+  assert.equal(warning, null, "local lightweight rerank should not warn");
+}
+
+{
+  const warning = buildAutoRecallRerankCostWarning(makeConfig({
+    retrieval: {
+      rerank: "cross-encoder",
+      rerankApiKey: "dummy",
+      candidatePoolSize: 6,
+    },
+  }));
+  assert.equal(warning, null, "small candidate pools should not warn");
+}
+
+console.log("OK: auto-recall rerank cost warning test passed");

--- a/test/recall-text-cleanup.test.mjs
+++ b/test/recall-text-cleanup.test.mjs
@@ -81,6 +81,14 @@ function getAutoRecallHook(eventHandlers) {
   return autoRecallHook;
 }
 
+function confirmedMetadata(overrides = {}) {
+  return JSON.stringify({
+    state: "confirmed",
+    memory_layer: "durable",
+    ...overrides,
+  });
+}
+
 function makeResults() {
   return [
     {
@@ -91,6 +99,7 @@ function makeResults() {
         scope: "global",
         importance: 0.7,
         timestamp: Date.now(),
+        metadata: confirmedMetadata(),
       },
       score: 0.82,
       sources: {
@@ -107,6 +116,7 @@ function makeResults() {
         scope: "global",
         importance: 0.8,
         timestamp: Date.now(),
+        metadata: confirmedMetadata(),
       },
       score: 0.77,
       sources: {
@@ -128,6 +138,7 @@ function makeExpandedResults() {
         scope: "project",
         importance: 0.5,
         timestamp: Date.now(),
+        metadata: confirmedMetadata(),
       },
       score: 0.65,
       sources: {
@@ -216,6 +227,7 @@ function makeManyResults(count = 7) {
         scope: "global",
         importance: 0.5,
         timestamp: Date.now(),
+        metadata: confirmedMetadata(),
       },
       score: 0.9 - i * 0.05,
       sources: {
@@ -973,7 +985,7 @@ describe("recall text cleanup", () => {
           scope: "global",
           importance: 0.8,
           timestamp: ts,
-          metadata: JSON.stringify({ folder: "Goals", source: "manual" }),
+          metadata: confirmedMetadata({ folder: "Goals", source: "manual" }),
         },
         score: 0.9,
         sources: { vector: { score: 0.9, rank: 1 } },
@@ -1005,6 +1017,7 @@ describe("recall text cleanup", () => {
           scope: "global",
           importance: 0.7,
           timestamp: Date.now(),
+          metadata: confirmedMetadata(),
         },
         score: 0.85,
         sources: { vector: { score: 0.85, rank: 1 } },
@@ -1033,7 +1046,7 @@ describe("recall text cleanup", () => {
           scope: "global",
           importance: 0.7,
           timestamp: Date.now(),
-          metadata: JSON.stringify({ folder: "Preferences", source: "manual" }),
+          metadata: confirmedMetadata({ folder: "Preferences", source: "manual" }),
         },
         score: 0.85,
         sources: { vector: { score: 0.85, rank: 1 } },
@@ -1062,7 +1075,7 @@ describe("recall text cleanup", () => {
           scope: "global",
           importance: 0.9,
           timestamp: Date.now(),
-          metadata: JSON.stringify({ tier: "l1" }),
+          metadata: confirmedMetadata({ tier: "l1" }),
         },
         score: 0.88,
         sources: { vector: { score: 0.88, rank: 1 } },
@@ -1075,7 +1088,7 @@ describe("recall text cleanup", () => {
           scope: "global",
           importance: 0.85,
           timestamp: Date.now(),
-          metadata: JSON.stringify({ tier: "l2" }),
+          metadata: confirmedMetadata({ tier: "l2" }),
         },
         score: 0.82,
         sources: { vector: { score: 0.82, rank: 2 } },


### PR DESCRIPTION
Fixes #429.

## Summary
- warn at startup when auto-recall uses external cross-encoder rerank with a large candidate pool
- add effective rerank/candidate-pool fields to auto-recall debug stats
- document that external rerank cost follows `retrieval.candidatePoolSize`, not the final `autoRecallMaxItems` injection cap

## Validation
- `node test/auto-recall-rerank-cost-warning.test.mjs`
- `node -e "import('./dist/index.js').then((m)=>console.log(typeof m.buildAutoRecallRerankCostWarning))"`
- `npx tsc -p tsconfig.json`
