### PR TITLE
Fix default scopes for memory management tools

### DIFF
--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -128,6 +128,23 @@ async function retrieveWithRetry(retriever, params, countStore) {
     }
     return results;
 }
+function resolveReadableToolScopeFilter(scopeManager, agentId, scope) {
+    if (scope) {
+        if (scopeManager.isAccessible(scope, agentId)) {
+            return { scopeFilter: [scope] };
+        }
+        return {
+            error: {
+                content: [{ type: "text", text: `Access denied to scope: ${scope}` }],
+                details: {
+                    error: "scope_access_denied",
+                    requestedScope: scope,
+                },
+            },
+        };
+    }
+    return { scopeFilter: resolveScopeFilter(scopeManager, agentId) };
+}
 async function resolveMemoryId(context, memoryRef, scopeFilter) {
     const trimmed = memoryRef.trim();
     if (!trimmed) {
@@ -1213,7 +1230,7 @@ export function registerMemoryStatsTool(api, context) {
         return {
             name: "memory_stats",
             label: "Memory Statistics",
-            description: "Get statistics about memory usage, scopes, and categories.",
+            description: "Get statistics about memory usage, scopes, and categories. Defaults to the caller's accessible scopes when scope is omitted.",
             parameters: Type.Object({
                 scope: Type.Optional(Type.String({
                     description: "Specific scope to get stats for (optional)",
@@ -1223,24 +1240,10 @@ export function registerMemoryStatsTool(api, context) {
                 const { scope } = params;
                 try {
                     const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
-                    // Determine accessible scopes
-                    let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
-                    if (scope) {
-                        if (context.scopeManager.isAccessible(scope, agentId)) {
-                            scopeFilter = [scope];
-                        }
-                        else {
-                            return {
-                                content: [
-                                    { type: "text", text: `Access denied to scope: ${scope}` },
-                                ],
-                                details: {
-                                    error: "scope_access_denied",
-                                    requestedScope: scope,
-                                },
-                            };
-                        }
-                    }
+                    const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
+                    if ("error" in resolvedScopes)
+                        return resolvedScopes.error;
+                    const { scopeFilter } = resolvedScopes;
                     const stats = await context.store.stats(scopeFilter);
                     const scopeManagerStats = context.scopeManager.getStats();
                     const retrievalConfig = context.retriever.getConfig();
@@ -1276,6 +1279,7 @@ export function registerMemoryStatsTool(api, context) {
                         details: {
                             stats,
                             scopeManagerStats,
+                            scopes: scopeFilter,
                             retrievalConfig: {
                                 ...retrievalConfig,
                                 rerankApiKey: retrievalConfig.rerankApiKey ? "***" : undefined,
@@ -1402,7 +1406,7 @@ export function registerMemoryListTool(api, context) {
         return {
             name: "memory_list",
             label: "Memory List",
-            description: "List recent memories with optional filtering by scope and category.",
+            description: "List recent memories with optional filtering by scope and category. Defaults to the caller's accessible scopes when scope is omitted.",
             parameters: Type.Object({
                 limit: Type.Optional(Type.Number({
                     description: "Max memories to list (default: 10, max: 50)",
@@ -1419,24 +1423,10 @@ export function registerMemoryListTool(api, context) {
                     const safeLimit = clampInt(limit, 1, 50);
                     const safeOffset = clampInt(offset, 0, 1000);
                     const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
-                    // Determine accessible scopes
-                    let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
-                    if (scope) {
-                        if (context.scopeManager.isAccessible(scope, agentId)) {
-                            scopeFilter = [scope];
-                        }
-                        else {
-                            return {
-                                content: [
-                                    { type: "text", text: `Access denied to scope: ${scope}` },
-                                ],
-                                details: {
-                                    error: "scope_access_denied",
-                                    requestedScope: scope,
-                                },
-                            };
-                        }
-                    }
+                    const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
+                    if ("error" in resolvedScopes)
+                        return resolvedScopes.error;
+                    const { scopeFilter } = resolvedScopes;
                     const entries = await context.store.list(scopeFilter, category, safeLimit, safeOffset);
                     if (entries.length === 0) {
                         return {
@@ -1445,6 +1435,7 @@ export function registerMemoryListTool(api, context) {
                                 count: 0,
                                 filters: {
                                     scope,
+                                    scopes: scopeFilter,
                                     category,
                                     limit: safeLimit,
                                     offset: safeOffset,
@@ -1481,6 +1472,7 @@ export function registerMemoryListTool(api, context) {
                             })),
                             filters: {
                                 scope,
+                                scopes: scopeFilter,
                                 category,
                                 limit: safeLimit,
                                 offset: safeOffset,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -197,6 +197,34 @@ async function retrieveWithRetry(
   return results;
 }
 
+function resolveReadableToolScopeFilter(
+  scopeManager: MemoryScopeManager,
+  agentId: string | undefined,
+  scope?: string,
+): { scopeFilter: string[] | undefined } | {
+  error: {
+    content: Array<{ type: "text"; text: string }>;
+    details: { error: "scope_access_denied"; requestedScope: string };
+  };
+} {
+  if (scope) {
+    if (scopeManager.isAccessible(scope, agentId)) {
+      return { scopeFilter: [scope] };
+    }
+    return {
+      error: {
+        content: [{ type: "text", text: `Access denied to scope: ${scope}` }],
+        details: {
+          error: "scope_access_denied",
+          requestedScope: scope,
+        },
+      },
+    };
+  }
+
+  return { scopeFilter: resolveScopeFilter(scopeManager, agentId) };
+}
+
 async function resolveMemoryId(
   context: ToolContext,
   memoryRef: string,
@@ -1526,7 +1554,7 @@ export function registerMemoryStatsTool(
       return {
         name: "memory_stats",
       label: "Memory Statistics",
-      description: "Get statistics about memory usage, scopes, and categories.",
+      description: "Get statistics about memory usage, scopes, and categories. Defaults to the caller's accessible scopes when scope is omitted.",
       parameters: Type.Object({
         scope: Type.Optional(
           Type.String({
@@ -1539,23 +1567,9 @@ export function registerMemoryStatsTool(
 
         try {
           const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
-          // Determine accessible scopes
-          let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
-          if (scope) {
-            if (context.scopeManager.isAccessible(scope, agentId)) {
-              scopeFilter = [scope];
-            } else {
-              return {
-                content: [
-                  { type: "text", text: `Access denied to scope: ${scope}` },
-                ],
-                details: {
-                  error: "scope_access_denied",
-                  requestedScope: scope,
-                },
-              };
-            }
-          }
+          const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
+          if ("error" in resolvedScopes) return resolvedScopes.error;
+          const { scopeFilter } = resolvedScopes;
 
           const stats = await context.store.stats(scopeFilter);
           const scopeManagerStats = context.scopeManager.getStats();
@@ -1609,6 +1623,7 @@ export function registerMemoryStatsTool(
             details: {
               stats,
               scopeManagerStats,
+              scopes: scopeFilter,
               retrievalConfig: {
                 ...retrievalConfig,
                 rerankApiKey: retrievalConfig.rerankApiKey ? "***" : undefined,
@@ -1759,7 +1774,7 @@ export function registerMemoryListTool(
         name: "memory_list",
       label: "Memory List",
       description:
-        "List recent memories with optional filtering by scope and category.",
+        "List recent memories with optional filtering by scope and category. Defaults to the caller's accessible scopes when scope is omitted.",
       parameters: Type.Object({
         limit: Type.Optional(
           Type.Number({
@@ -1794,23 +1809,9 @@ export function registerMemoryListTool(
           const safeOffset = clampInt(offset, 0, 1000);
           const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
 
-          // Determine accessible scopes
-          let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
-          if (scope) {
-            if (context.scopeManager.isAccessible(scope, agentId)) {
-              scopeFilter = [scope];
-            } else {
-              return {
-                content: [
-                  { type: "text", text: `Access denied to scope: ${scope}` },
-                ],
-                details: {
-                  error: "scope_access_denied",
-                  requestedScope: scope,
-                },
-              };
-            }
-          }
+          const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
+          if ("error" in resolvedScopes) return resolvedScopes.error;
+          const { scopeFilter } = resolvedScopes;
 
           const entries = await context.store.list(
             scopeFilter,
@@ -1826,6 +1827,7 @@ export function registerMemoryListTool(
                 count: 0,
                 filters: {
                   scope,
+                  scopes: scopeFilter,
                   category,
                   limit: safeLimit,
                   offset: safeOffset,
@@ -1864,6 +1866,7 @@ export function registerMemoryListTool(
               })),
               filters: {
                 scope,
+                scopes: scopeFilter,
                 category,
                 limit: safeLimit,
                 offset: safeOffset,

--- a/test/memory-governance-tools.test.mjs
+++ b/test/memory-governance-tools.test.mjs
@@ -24,6 +24,72 @@ function createToolSet(context) {
 }
 
 describe("memory governance tools", () => {
+  it("defaults stats and list to the caller's accessible scopes", async () => {
+    const statsScopeFilters = [];
+    const listScopeFilters = [];
+    const context = {
+      agentId: "main",
+      workspaceDir: "/tmp",
+      mdMirror: null,
+      scopeManager: {
+        getAccessibleScopes: (agentId) => ["global", `agent:${agentId}`, `reflection:agent:${agentId}`],
+        getScopeFilter: (agentId) => ["global", `agent:${agentId}`, `reflection:agent:${agentId}`],
+        isAccessible: (scope, agentId) => ["global", `agent:${agentId}`, `reflection:agent:${agentId}`].includes(scope),
+        getDefaultScope: (agentId) => `agent:${agentId}`,
+        getStats: () => ({ totalScopes: 3, agentsWithCustomAccess: 0, scopesByType: {} }),
+      },
+      retriever: {
+        getConfig() {
+          return { mode: "hybrid" };
+        },
+        getStatsCollector() {
+          return { count: 0 };
+        },
+      },
+      store: {
+        hasFtsSupport: true,
+        async stats(scopeFilter) {
+          statsScopeFilters.push(scopeFilter);
+          return {
+            totalCount: scopeFilter.includes("agent:main") ? 1 : 0,
+            scopeCounts: { "agent:main": 1 },
+            categoryCounts: { fact: 1 },
+          };
+        },
+        async list(scopeFilter) {
+          listScopeFilters.push(scopeFilter);
+          return scopeFilter.includes("agent:main")
+            ? [{
+              id: "agent-memory-1",
+              text: "agent private preference",
+              category: "fact",
+              scope: "agent:main",
+              importance: 0.7,
+              timestamp: Date.now(),
+              metadata: "{}",
+            }]
+            : [];
+        },
+      },
+      embedder: { async embedPassage() { return [0.1, 0.2, 0.3]; } },
+    };
+
+    const tools = createToolSet(context);
+    const stats = tools.get("memory_stats");
+    const list = tools.get("memory_list");
+
+    const statsRes = await stats.execute(null, {});
+    const listRes = await list.execute(null, {});
+
+    const expectedScopes = ["global", "agent:main", "reflection:agent:main"];
+    assert.deepEqual(statsScopeFilters[0], expectedScopes);
+    assert.deepEqual(listScopeFilters[0], expectedScopes);
+    assert.deepEqual(statsRes.details.scopes, expectedScopes);
+    assert.deepEqual(listRes.details.filters.scopes, expectedScopes);
+    assert.equal(statsRes.details.stats.totalCount, 1);
+    assert.equal(listRes.details.count, 1);
+  });
+
   it("promotes and archives memory entries", async () => {
     const entries = [
       {


### PR DESCRIPTION
Fixes #378.

## Summary
- centralize readable scope resolution for `memory_stats` and `memory_list`
- keep explicit `scope` access checks unchanged
- make omitted `scope` use the caller's resolved accessible scopes, including private `agent:<id>` scope
- return the resolved scopes in tool details so empty results are easier to diagnose
- clarify the default scope behavior in the tool descriptions

## Validation
- `node --test test/memory-governance-tools.test.mjs`
- `npx tsc -p tsconfig.json`
