### PR TITLE
Fix reflection legacy upgrade classification

### DIFF
--- a/dist/src/memory-upgrader.js
+++ b/dist/src/memory-upgrader.js
@@ -13,6 +13,29 @@
  *   4. Write enriched metadata back via store.update()
  */
 import { buildSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
+const CURRENT_REFLECTION_METADATA_TYPES = new Set([
+    "memory-reflection",
+    "memory-reflection-event",
+    "memory-reflection-item",
+    "memory-reflection-mapped",
+]);
+function parseMetadata(metadata) {
+    if (!metadata)
+        return null;
+    try {
+        const parsed = JSON.parse(metadata);
+        return parsed && typeof parsed === "object" ? parsed : null;
+    }
+    catch {
+        return null;
+    }
+}
+function isCurrentReflectionMemory(entry) {
+    if (entry.category === "reflection")
+        return true;
+    const meta = parseMetadata(entry.metadata);
+    return typeof meta?.type === "string" && CURRENT_REFLECTION_METADATA_TYPES.has(meta.type);
+}
 // ============================================================================
 // Reverse Category Mapping
 // ============================================================================
@@ -105,18 +128,20 @@ export class MemoryUpgrader {
     /**
      * Check if a memory entry is in legacy format (needs upgrade).
      * Legacy = no metadata, or metadata lacks `memory_category`.
+     * Reflection rows are first-class current-format memories with their own
+     * metadata schema and read path, so they intentionally do not carry
+     * SmartExtractor `memory_category`.
      */
     isLegacyMemory(entry) {
+        if (isCurrentReflectionMemory(entry))
+            return false;
         if (!entry.metadata)
             return true;
-        try {
-            const meta = JSON.parse(entry.metadata);
-            // If it has memory_category, it was created by SmartExtractor → new format
-            return !meta.memory_category;
-        }
-        catch {
+        const meta = parseMetadata(entry.metadata);
+        if (!meta)
             return true;
-        }
+        // If it has memory_category, it was created by SmartExtractor → new format
+        return !meta.memory_category;
     }
     /**
      * Scan and count legacy memories without modifying them.

--- a/src/memory-upgrader.ts
+++ b/src/memory-upgrader.ts
@@ -62,6 +62,29 @@ interface EnrichedMetadata {
   upgraded_at: number;   // timestamp of upgrade
 }
 
+const CURRENT_REFLECTION_METADATA_TYPES = new Set([
+  "memory-reflection",
+  "memory-reflection-event",
+  "memory-reflection-item",
+  "memory-reflection-mapped",
+]);
+
+function parseMetadata(metadata: string | undefined): Record<string, unknown> | null {
+  if (!metadata) return null;
+  try {
+    const parsed = JSON.parse(metadata);
+    return parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : null;
+  } catch {
+    return null;
+  }
+}
+
+function isCurrentReflectionMemory(entry: MemoryEntry): boolean {
+  if (entry.category === "reflection") return true;
+  const meta = parseMetadata(entry.metadata);
+  return typeof meta?.type === "string" && CURRENT_REFLECTION_METADATA_TYPES.has(meta.type);
+}
+
 // ============================================================================
 // Reverse Category Mapping
 // ============================================================================
@@ -171,16 +194,17 @@ export class MemoryUpgrader {
   /**
    * Check if a memory entry is in legacy format (needs upgrade).
    * Legacy = no metadata, or metadata lacks `memory_category`.
+   * Reflection rows are first-class current-format memories with their own
+   * metadata schema and read path, so they intentionally do not carry
+   * SmartExtractor `memory_category`.
    */
   isLegacyMemory(entry: MemoryEntry): boolean {
+    if (isCurrentReflectionMemory(entry)) return false;
     if (!entry.metadata) return true;
-    try {
-      const meta = JSON.parse(entry.metadata);
-      // If it has memory_category, it was created by SmartExtractor → new format
-      return !meta.memory_category;
-    } catch {
-      return true;
-    }
+    const meta = parseMetadata(entry.metadata);
+    if (!meta) return true;
+    // If it has memory_category, it was created by SmartExtractor → new format
+    return !meta.memory_category;
   }
 
   /**

--- a/test/memory-upgrader-diagnostics.test.mjs
+++ b/test/memory-upgrader-diagnostics.test.mjs
@@ -14,6 +14,12 @@ const jiti = jitiFactory(import.meta.url, { interopDefault: true });
 const { createMemoryUpgrader } = jiti("../src/memory-upgrader.ts");
 
 async function runTest() {
+  await testLegacyUpgradeFallbackDiagnostic();
+  await testReflectionRowsAreNotLegacy();
+  console.log("memory-upgrader diagnostics test passed");
+}
+
+async function testLegacyUpgradeFallbackDiagnostic() {
   const logs = [];
   const updates = [];
   const legacyEntry = {
@@ -61,8 +67,72 @@ async function runTest() {
   );
   assert.equal(typeof updates[0].patch.text, "string");
   assert.ok(updates[0].patch.metadata.includes("upgraded_at"));
+}
 
-  console.log("memory-upgrader diagnostics test passed");
+async function testReflectionRowsAreNotLegacy() {
+  const updates = [];
+  const reflectionRows = [
+    {
+      id: "reflection-event-1",
+      text: "reflection-event · global",
+      category: "reflection",
+      scope: "global",
+      importance: 0.55,
+      timestamp: Date.now(),
+      metadata: JSON.stringify({
+        type: "memory-reflection-event",
+        reflectionVersion: 4,
+        eventId: "refl-1",
+      }),
+    },
+    {
+      id: "reflection-item-1",
+      text: "Always verify migration banners before upgrading.",
+      category: "reflection",
+      scope: "global",
+      importance: 0.82,
+      timestamp: Date.now(),
+      metadata: JSON.stringify({
+        type: "memory-reflection-item",
+        reflectionVersion: 4,
+        itemKind: "invariant",
+      }),
+    },
+    {
+      id: "reflection-mapped-1",
+      text: "User prefers release-ready validation notes.",
+      category: "reflection",
+      scope: "global",
+      importance: 0.75,
+      timestamp: Date.now(),
+      metadata: JSON.stringify({
+        type: "memory-reflection-mapped",
+        reflectionVersion: 4,
+        mappedKind: "user-model",
+      }),
+    },
+  ];
+
+  const store = {
+    async list() {
+      return reflectionRows;
+    },
+    async update(id, patch) {
+      updates.push({ id, patch });
+      return true;
+    },
+  };
+
+  const upgrader = createMemoryUpgrader(store, null, { log: () => {} });
+  const count = await upgrader.countLegacy();
+  const dryRun = await upgrader.upgrade({ dryRun: true });
+
+  assert.equal(count.total, 3);
+  assert.equal(count.legacy, 0);
+  assert.deepEqual(count.byCategory, {});
+  assert.equal(dryRun.totalLegacy, 0);
+  assert.equal(dryRun.skipped, 3);
+  assert.equal(updates.length, 0);
 }
 
 runTest().catch((err) => {


### PR DESCRIPTION
Fixes #845.

## Summary
- teach `MemoryUpgrader.isLegacyMemory()` that reflection rows are first-class current-format memories
- exclude reflection-category rows and reflection metadata types from legacy upgrade classification
- add regression coverage for fresh reflection event/item/mapped rows so `countLegacy()` and dry-run `upgrade()` do not target them

## Validation
- `node test/memory-upgrader-diagnostics.test.mjs`
- `npx tsc -p tsconfig.json`
