### PR TITLE
fix: validate smart extraction bulk writes

### DIFF
--- a/dist/src/smart-extractor.js
+++ b/dist/src/smart-extractor.js
@@ -294,13 +294,78 @@ export class SmartExtractor {
             }
         }
         if (createEntries.length > 0) {
-            await this.store.bulkStore(createEntries);
+            await this.bulkStoreAndValidate(createEntries);
         }
         return stats;
     }
     // --------------------------------------------------------------------------
     // Embedding Noise Pre-Filter
     // --------------------------------------------------------------------------
+    async bulkStoreAndValidate(entries) {
+        const beforeCount = await this.readStoreCount("before bulkStore");
+        const storedEntries = await this.store.bulkStore(entries);
+        if (!Array.isArray(storedEntries)) {
+            this.debugLog("memory-pro: smart-extractor: skipping bulkStore persistence validation: bulkStore() did not return stored entries");
+            return;
+        }
+        if (storedEntries.length !== entries.length) {
+            this.log(`memory-pro: smart-extractor: bulkStore validation warning: queued ${entries.length} create(s) but bulkStore accepted ${storedEntries.length}`);
+        }
+        if (storedEntries.length === 0) {
+            return;
+        }
+        const afterCount = await this.readStoreCount("after bulkStore");
+        if (beforeCount === null || afterCount === null) {
+            return;
+        }
+        const observedDelta = afterCount - beforeCount;
+        if (observedDelta >= storedEntries.length) {
+            return;
+        }
+        const missingIds = await this.findMissingStoredIds(storedEntries);
+        if (missingIds.length === 0) {
+            this.debugLog(`memory-pro: smart-extractor: bulkStore row-count delta ${observedDelta}/${storedEntries.length} but all returned IDs are readable; likely concurrent delete/compaction`);
+            return;
+        }
+        const sample = missingIds.slice(0, 3).map((id) => id.slice(0, 8)).join(", ");
+        this.log(`memory-pro: smart-extractor: bulkStore validation warning: expected row delta >= ${storedEntries.length}, observed ${observedDelta} (before=${beforeCount}, after=${afterCount}); missing returned IDs=${missingIds.length}${sample ? ` sample=${sample}` : ""}`);
+    }
+    async readStoreCount(context) {
+        const count = this.store.count;
+        if (typeof count !== "function") {
+            this.debugLog(`memory-pro: smart-extractor: skipping bulkStore row-count validation (${context}): count() unavailable`);
+            return null;
+        }
+        try {
+            const value = await count.call(this.store);
+            if (Number.isFinite(value)) {
+                return value;
+            }
+            this.debugLog(`memory-pro: smart-extractor: skipping bulkStore row-count validation (${context}): non-finite count ${String(value)}`);
+        }
+        catch (err) {
+            this.debugLog(`memory-pro: smart-extractor: skipping bulkStore row-count validation (${context}): ${String(err)}`);
+        }
+        return null;
+    }
+    async findMissingStoredIds(entries) {
+        const hasId = this.store.hasId;
+        if (typeof hasId !== "function") {
+            return entries.map((entry) => entry.id);
+        }
+        const missing = [];
+        for (const entry of entries) {
+            try {
+                if (!await hasId.call(this.store, entry.id)) {
+                    missing.push(entry.id);
+                }
+            }
+            catch {
+                missing.push(entry.id);
+            }
+        }
+        return missing;
+    }
     /**
      * Filter out texts that match cheap static noise patterns first, then
      * filter remaining texts that match noise prototypes by embedding similarity.

--- a/src/smart-extractor.ts
+++ b/src/smart-extractor.ts
@@ -441,7 +441,7 @@ export class SmartExtractor {
     }
 
     if (createEntries.length > 0) {
-      await this.store.bulkStore(createEntries);
+      await this.bulkStoreAndValidate(createEntries);
     }
 
     return stats;
@@ -450,6 +450,95 @@ export class SmartExtractor {
   // --------------------------------------------------------------------------
   // Embedding Noise Pre-Filter
   // --------------------------------------------------------------------------
+
+  private async bulkStoreAndValidate(entries: StoreEntry[]): Promise<void> {
+    const beforeCount = await this.readStoreCount("before bulkStore");
+    const storedEntries = await this.store.bulkStore(entries);
+
+    if (!Array.isArray(storedEntries)) {
+      this.debugLog(
+        "memory-pro: smart-extractor: skipping bulkStore persistence validation: bulkStore() did not return stored entries",
+      );
+      return;
+    }
+
+    if (storedEntries.length !== entries.length) {
+      this.log(
+        `memory-pro: smart-extractor: bulkStore validation warning: queued ${entries.length} create(s) but bulkStore accepted ${storedEntries.length}`,
+      );
+    }
+
+    if (storedEntries.length === 0) {
+      return;
+    }
+
+    const afterCount = await this.readStoreCount("after bulkStore");
+    if (beforeCount === null || afterCount === null) {
+      return;
+    }
+
+    const observedDelta = afterCount - beforeCount;
+    if (observedDelta >= storedEntries.length) {
+      return;
+    }
+
+    const missingIds = await this.findMissingStoredIds(storedEntries);
+    if (missingIds.length === 0) {
+      this.debugLog(
+        `memory-pro: smart-extractor: bulkStore row-count delta ${observedDelta}/${storedEntries.length} but all returned IDs are readable; likely concurrent delete/compaction`,
+      );
+      return;
+    }
+
+    const sample = missingIds.slice(0, 3).map((id) => id.slice(0, 8)).join(", ");
+    this.log(
+      `memory-pro: smart-extractor: bulkStore validation warning: expected row delta >= ${storedEntries.length}, observed ${observedDelta} (before=${beforeCount}, after=${afterCount}); missing returned IDs=${missingIds.length}${sample ? ` sample=${sample}` : ""}`,
+    );
+  }
+
+  private async readStoreCount(context: string): Promise<number | null> {
+    const count = (this.store as unknown as { count?: () => Promise<number> }).count;
+    if (typeof count !== "function") {
+      this.debugLog(
+        `memory-pro: smart-extractor: skipping bulkStore row-count validation (${context}): count() unavailable`,
+      );
+      return null;
+    }
+
+    try {
+      const value = await count.call(this.store);
+      if (Number.isFinite(value)) {
+        return value;
+      }
+      this.debugLog(
+        `memory-pro: smart-extractor: skipping bulkStore row-count validation (${context}): non-finite count ${String(value)}`,
+      );
+    } catch (err) {
+      this.debugLog(
+        `memory-pro: smart-extractor: skipping bulkStore row-count validation (${context}): ${String(err)}`,
+      );
+    }
+    return null;
+  }
+
+  private async findMissingStoredIds(entries: import("./store.js").MemoryEntry[]): Promise<string[]> {
+    const hasId = (this.store as unknown as { hasId?: (id: string) => Promise<boolean> }).hasId;
+    if (typeof hasId !== "function") {
+      return entries.map((entry) => entry.id);
+    }
+
+    const missing: string[] = [];
+    for (const entry of entries) {
+      try {
+        if (!await hasId.call(this.store, entry.id)) {
+          missing.push(entry.id);
+        }
+      } catch {
+        missing.push(entry.id);
+      }
+    }
+    return missing;
+  }
 
   /**
    * Filter out texts that match cheap static noise patterns first, then

--- a/test/smart-extractor-bulk-store-validation.test.mjs
+++ b/test/smart-extractor-bulk-store-validation.test.mjs
@@ -1,0 +1,163 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const { SmartExtractor } = jiti("../src/smart-extractor.ts");
+
+function makeCandidates(count) {
+  const candidates = [
+    {
+      category: "preferences",
+      abstract: "Tea preference: oolong tea",
+      overview: "## Preference\n- Likes oolong tea",
+      content: "The user likes oolong tea.",
+    },
+    {
+      category: "entities",
+      abstract: "Workspace location: Seattle office",
+      overview: "## Entity\n- Seattle office",
+      content: "The user works from the Seattle office.",
+    },
+  ];
+  return candidates.slice(0, count);
+}
+
+function makeExtractor({
+  candidateCount = 1,
+  countValues = [],
+  bulkStoreImpl,
+  hasIdImpl,
+}) {
+  const logs = [];
+  const debugLogs = [];
+  const counts = [...countValues];
+  const store = {
+    async vectorSearch() {
+      return [];
+    },
+    async store() {},
+    async bulkStore(entries) {
+      return bulkStoreImpl
+        ? bulkStoreImpl(entries)
+        : entries.map((entry, index) => ({
+            ...entry,
+            id: `stored-${index + 1}`,
+            timestamp: Date.now(),
+          }));
+    },
+    async count() {
+      return counts.shift() ?? 0;
+    },
+    async hasId(id) {
+      return hasIdImpl ? hasIdImpl(id) : true;
+    },
+  };
+
+  const embedder = {
+    async embed() {
+      return [1, 0, 0];
+    },
+    async embedBatch(texts) {
+      return texts.map((_, index) =>
+        index % 2 === 0 ? [1, 0, 0] : [0, 1, 0],
+      );
+    },
+  };
+
+  const llm = {
+    async completeJson(_prompt, mode) {
+      if (mode === "extract-candidates") {
+        return { memories: makeCandidates(candidateCount) };
+      }
+      throw new Error(`unexpected mode: ${mode}`);
+    },
+  };
+
+  return {
+    extractor: new SmartExtractor(store, embedder, llm, {
+      user: "User",
+      extractMinMessages: 1,
+      extractMaxChars: 8000,
+      defaultScope: "global",
+      log(msg) {
+        logs.push(msg);
+      },
+      debugLog(msg) {
+        debugLogs.push(msg);
+      },
+    }),
+    logs,
+    debugLogs,
+  };
+}
+
+describe("SmartExtractor bulkStore persistence validation", () => {
+  it("logs when bulkStore accepts fewer entries than the extractor queued", async () => {
+    const { extractor, logs } = makeExtractor({
+      candidateCount: 1,
+      countValues: [0],
+      bulkStoreImpl: async () => [],
+    });
+
+    const stats = await extractor.extractAndPersist(
+      "The user likes oolong tea.",
+      "session-filtered",
+      { scope: "global" },
+    );
+
+    assert.equal(stats.created, 1);
+    assert.ok(
+      logs.some((msg) => msg.includes("queued 1 create(s) but bulkStore accepted 0")),
+      `expected queued-vs-accepted warning, got logs: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it("logs when row count does not increase and returned IDs are missing", async () => {
+    const { extractor, logs } = makeExtractor({
+      candidateCount: 2,
+      countValues: [10, 10],
+      hasIdImpl: async (id) => id !== "stored-2",
+    });
+
+    const stats = await extractor.extractAndPersist(
+      "The user likes oolong tea and works from the Seattle office.",
+      "session-partial",
+      { scope: "global" },
+    );
+
+    assert.equal(stats.created, 2);
+    assert.ok(
+      logs.some((msg) =>
+        msg.includes("expected row delta >= 2") &&
+        msg.includes("observed 0") &&
+        msg.includes("missing returned IDs=1")
+      ),
+      `expected row-count validation warning, got logs: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it("suppresses the warning when row-count delta is short but returned IDs are readable", async () => {
+    const { extractor, logs, debugLogs } = makeExtractor({
+      candidateCount: 2,
+      countValues: [10, 10],
+      hasIdImpl: async () => true,
+    });
+
+    await extractor.extractAndPersist(
+      "The user likes oolong tea and works from the Seattle office.",
+      "session-concurrent-delete",
+      { scope: "global" },
+    );
+
+    assert.equal(
+      logs.some((msg) => msg.includes("bulkStore validation warning")),
+      false,
+      `did not expect validation warning, got logs: ${JSON.stringify(logs)}`,
+    );
+    assert.ok(
+      debugLogs.some((msg) => msg.includes("likely concurrent delete/compaction")),
+      `expected concurrent-delete debug note, got debug logs: ${JSON.stringify(debugLogs)}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- wrap smart-extractor final `bulkStore` with before/after count validation
- warn when accepted entries or returned IDs indicate partial persistence
- keep public `ExtractionStats` unchanged

Fixes #693

## Tests
- `node --test test/smart-extractor-bulk-store-validation.test.mjs`
- `node --test test/smart-extractor-scope-filter.test.mjs`
- `node test/smart-extractor-branches.mjs`
- `npm run build`