### PR TITLE
fix: batch memory upgrader writes

### DIFF
--- a/dist/src/memory-upgrader.js
+++ b/dist/src/memory-upgrader.js
@@ -6,11 +6,11 @@
  * to enable unified memory lifecycle management (decay, tier promotion,
  * smart dedup).
  *
- * Pipeline per memory:
+ * Pipeline per batch:
  *   1. Detect legacy format (missing `memory_category` in metadata)
- *   2. Reverse-map 5-category → 6-category
- *   3. Generate L0/L1/L2 via LLM (or fallback to simple rules)
- *   4. Write enriched metadata back via store.update()
+ *   2. Reverse-map 5-category → 6-category and generate L0/L1/L2
+ *   3. Prepare update patches without holding the DB write lock
+ *   4. Write prepared patches in a batch where the store supports it
  */
 import { buildSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
 const CURRENT_REFLECTION_METADATA_TYPES = new Set([
@@ -201,17 +201,18 @@ export class MemoryUpgrader {
         for (let i = 0; i < toProcess.length; i += batchSize) {
             const batch = toProcess.slice(i, i + batchSize);
             this.log(`memory-upgrader: processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(toProcess.length / batchSize)} (${batch.length} memories)`);
+            const prepared = [];
             for (const entry of batch) {
                 try {
-                    await this.upgradeEntry(entry, noLlm);
-                    result.upgraded++;
+                    prepared.push(await this.prepareUpgradeEntry(entry, noLlm));
                 }
                 catch (err) {
-                    const errMsg = `Failed to upgrade ${entry.id}: ${String(err)}`;
+                    const errMsg = `Failed to prepare upgrade ${entry.id}: ${String(err)}`;
                     result.errors.push(errMsg);
                     this.log(`memory-upgrader: ERROR — ${errMsg}`);
                 }
             }
+            await this.writePreparedBatch(prepared, result, options.scopeFilter ?? this.options.scopeFilter);
             // Progress report
             this.log(`memory-upgrader: progress — ${result.upgraded} upgraded, ${result.errors.length} errors`);
         }
@@ -219,9 +220,9 @@ export class MemoryUpgrader {
         return result;
     }
     /**
-     * Upgrade a single legacy memory entry.
+     * Prepare a single legacy memory entry without writing to the store.
      */
-    async upgradeEntry(entry, noLlm) {
+    async prepareUpgradeEntry(entry, noLlm) {
         // Step 1: Reverse-map category
         let newCategory = reverseMapCategory(entry.category, entry.text);
         // Step 2: Generate L0/L1/L2
@@ -279,12 +280,63 @@ export class MemoryUpgrader {
             upgraded_from: entry.category,
             upgraded_at: Date.now(),
         };
-        // Step 4: Update the memory entry
-        await this.store.update(entry.id, {
-            // Update text to L0 abstract for better search indexing
-            text: enriched.l0_abstract,
-            metadata: stringifySmartMetadata(newMetadata),
-        });
+        return {
+            entry,
+            updates: {
+                // Keep the existing upgrader behavior in this PR: the primary text
+                // column is updated to L0, while L2 remains in smart metadata.
+                text: enriched.l0_abstract,
+                metadata: stringifySmartMetadata(newMetadata),
+            },
+        };
+    }
+    /**
+     * Persist a prepared batch with one store-level batch call when available.
+     */
+    async writePreparedBatch(prepared, result, scopeFilter) {
+        if (prepared.length === 0)
+            return;
+        const store = this.store;
+        if (typeof store.bulkUpdateExact === "function") {
+            let writeResults;
+            try {
+                writeResults = await store.bulkUpdateExact(prepared.map(({ entry, updates }) => ({ id: entry.id, updates })), scopeFilter);
+            }
+            catch (err) {
+                for (const { entry } of prepared) {
+                    const errMsg = `Failed to write upgrade ${entry.id}: ${String(err)}`;
+                    result.errors.push(errMsg);
+                    this.log(`memory-upgrader: ERROR — ${errMsg}`);
+                }
+                return;
+            }
+            for (let index = 0; index < writeResults.length; index++) {
+                const writeResult = writeResults[index];
+                const fallbackEntry = prepared[index]?.entry;
+                if (writeResult.entry) {
+                    result.upgraded++;
+                }
+                else {
+                    const id = writeResult.id ?? fallbackEntry?.id ?? "unknown";
+                    const detail = writeResult.error ? `: ${writeResult.error}` : "";
+                    const errMsg = `Failed to write upgrade ${id}${detail}`;
+                    result.errors.push(errMsg);
+                    this.log(`memory-upgrader: ERROR — ${errMsg}`);
+                }
+            }
+            return;
+        }
+        for (const { entry, updates } of prepared) {
+            try {
+                await this.store.update(entry.id, updates, scopeFilter);
+                result.upgraded++;
+            }
+            catch (err) {
+                const errMsg = `Failed to write upgrade ${entry.id}: ${String(err)}`;
+                result.errors.push(errMsg);
+                this.log(`memory-upgrader: ERROR — ${errMsg}`);
+            }
+        }
     }
 }
 // ============================================================================

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -1505,6 +1505,180 @@ export class MemoryStore {
             categoryCounts,
         };
     }
+    /**
+     * Update multiple already-resolved memory IDs under one write lock.
+     *
+     * This intentionally accepts exact IDs only. Interactive callers that rely on
+     * short-prefix resolution should keep using update(), while bulk maintenance
+     * jobs can avoid repeated file-lock churn once they already have full row IDs.
+     */
+    async bulkUpdateExact(updates, scopeFilter) {
+        await this.ensureInitialized();
+        if (updates.length === 0)
+            return [];
+        if (isExplicitDenyAllScopeFilter(scopeFilter)) {
+            return updates.map(({ id }) => ({
+                id,
+                entry: null,
+                error: `Memory ${id} is outside accessible scopes`,
+            }));
+        }
+        return this.runWithFileLock(() => this.runSerializedUpdate(async () => {
+            const results = new Map();
+            const pending = [];
+            const seenIds = new Set();
+            updates.forEach((candidate, inputIndex) => {
+                const id = candidate.id;
+                if (typeof id !== "string" || id.length === 0) {
+                    results.set(inputIndex, {
+                        id: String(id),
+                        entry: null,
+                        error: `Invalid memory ID format: ${String(id)}`,
+                    });
+                    return;
+                }
+                if (seenIds.has(id)) {
+                    results.set(inputIndex, {
+                        id,
+                        entry: null,
+                        error: `Duplicate memory ID in bulk update: ${id}`,
+                    });
+                    return;
+                }
+                seenIds.add(id);
+                pending.push({ inputIndex, id, updates: candidate.updates });
+            });
+            for (let i = 0; i < pending.length; i += MemoryStore.MAX_BATCH_SIZE) {
+                const chunk = pending.slice(i, i + MemoryStore.MAX_BATCH_SIZE);
+                const whereClause = chunk
+                    .map(({ id }) => `id = '${escapeSqlLiteral(id)}'`)
+                    .join(" OR ");
+                const rows = whereClause.length > 0
+                    ? await this.table.query().where(`(${whereClause})`).toArray()
+                    : [];
+                const rowsById = new Map();
+                for (const row of rows) {
+                    rowsById.set(row.id, row);
+                }
+                const originals = [];
+                const updatedEntries = [];
+                const updatedInputIndices = [];
+                for (const candidate of chunk) {
+                    const row = rowsById.get(candidate.id);
+                    if (!row) {
+                        results.set(candidate.inputIndex, { id: candidate.id, entry: null });
+                        continue;
+                    }
+                    const rowScope = row.scope ?? "global";
+                    if (scopeFilter &&
+                        scopeFilter.length > 0 &&
+                        !scopeFilter.includes(rowScope)) {
+                        results.set(candidate.inputIndex, {
+                            id: candidate.id,
+                            entry: null,
+                            error: `Memory ${candidate.id} is outside accessible scopes`,
+                        });
+                        continue;
+                    }
+                    const original = {
+                        id: row.id,
+                        text: row.text,
+                        vector: Array.from(row.vector),
+                        category: row.category,
+                        scope: rowScope,
+                        importance: Number(row.importance),
+                        timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
+                        metadata: row.metadata || "{}",
+                    };
+                    const updated = {
+                        ...original,
+                        text: candidate.updates.text ?? original.text,
+                        vector: candidate.updates.vector ?? original.vector,
+                        category: candidate.updates.category ?? original.category,
+                        scope: rowScope,
+                        importance: candidate.updates.importance ?? original.importance,
+                        timestamp: original.timestamp,
+                        metadata: candidate.updates.metadata ?? original.metadata,
+                    };
+                    originals.push(original);
+                    updatedEntries.push(updated);
+                    updatedInputIndices.push(candidate.inputIndex);
+                }
+                if (updatedEntries.length === 0) {
+                    continue;
+                }
+                const deleteWhereClause = updatedEntries
+                    .map(({ id }) => `id = '${escapeSqlLiteral(id)}'`)
+                    .join(" OR ");
+                let deleted = false;
+                try {
+                    await this.table.delete(`(${deleteWhereClause})`);
+                    deleted = true;
+                    await this.table.add(updatedEntries);
+                    for (let index = 0; index < updatedEntries.length; index++) {
+                        results.set(updatedInputIndices[index], {
+                            id: updatedEntries[index].id,
+                            entry: updatedEntries[index],
+                        });
+                    }
+                }
+                catch (writeError) {
+                    const writeMessage = writeError instanceof Error ? writeError.message : String(writeError);
+                    if (!deleted) {
+                        for (let index = 0; index < updatedEntries.length; index++) {
+                            results.set(updatedInputIndices[index], {
+                                id: updatedEntries[index].id,
+                                entry: null,
+                                error: `Failed to bulk update memory ${updatedEntries[index].id}: delete failed before replacement write. ` +
+                                    `Write error: ${writeMessage}`,
+                            });
+                        }
+                        continue;
+                    }
+                    const existingAfterFailure = await this.table.query()
+                        .where(`(${deleteWhereClause})`)
+                        .toArray()
+                        .catch(() => []);
+                    const preservedIds = new Set(existingAfterFailure.map((row) => row.id));
+                    const originalsToRestore = originals.filter((entry) => !preservedIds.has(entry.id));
+                    try {
+                        if (originalsToRestore.length > 0) {
+                            await this.table.add(originalsToRestore);
+                        }
+                    }
+                    catch (rollbackError) {
+                        const rollbackMessage = rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+                        for (let index = 0; index < updatedEntries.length; index++) {
+                            results.set(updatedInputIndices[index], {
+                                id: updatedEntries[index].id,
+                                entry: null,
+                                error: `Failed to bulk update memory ${updatedEntries[index].id}: write failed and rollback also failed. ` +
+                                    `Write error: ${writeMessage}. Rollback error: ${rollbackMessage}`,
+                            });
+                        }
+                        continue;
+                    }
+                    for (let index = 0; index < updatedEntries.length; index++) {
+                        const preserved = preservedIds.has(updatedEntries[index].id);
+                        results.set(updatedInputIndices[index], {
+                            id: updatedEntries[index].id,
+                            entry: null,
+                            error: `Failed to bulk update memory ${updatedEntries[index].id}: ` +
+                                (preserved
+                                    ? "write failed after delete, but an existing row was preserved. "
+                                    : "write failed, original row restored. ") +
+                                `Write error: ${writeMessage}`,
+                        });
+                    }
+                }
+            }
+            return updates.map((candidate, inputIndex) => results.get(inputIndex) ?? {
+                id: candidate.id,
+                entry: null,
+                error: `Memory ${candidate.id} was not processed`,
+            });
+        }));
+    }
     async update(id, updates, scopeFilter) {
         await this.ensureInitialized();
         if (isExplicitDenyAllScopeFilter(scopeFilter)) {

--- a/src/memory-upgrader.ts
+++ b/src/memory-upgrader.ts
@@ -6,14 +6,14 @@
  * to enable unified memory lifecycle management (decay, tier promotion,
  * smart dedup).
  *
- * Pipeline per memory:
+ * Pipeline per batch:
  *   1. Detect legacy format (missing `memory_category` in metadata)
- *   2. Reverse-map 5-category → 6-category
- *   3. Generate L0/L1/L2 via LLM (or fallback to simple rules)
- *   4. Write enriched metadata back via store.update()
+ *   2. Reverse-map 5-category → 6-category and generate L0/L1/L2
+ *   3. Prepare update patches without holding the DB write lock
+ *   4. Write prepared patches in a batch where the store supports it
  */
 
-import type { MemoryStore, MemoryEntry } from "./store.js";
+import type { MemoryStore, MemoryEntry, MemoryUpdatePatch, MemoryBulkUpdateResult } from "./store.js";
 import type { LlmClient } from "./llm-client.js";
 import type { MemoryCategory } from "./memory-categories.js";
 import type { MemoryTier } from "./memory-categories.js";
@@ -60,6 +60,19 @@ interface EnrichedMetadata {
   last_accessed_at: number;
   upgraded_from: string; // original 5-category
   upgraded_at: number;   // timestamp of upgrade
+}
+
+interface PreparedUpgrade {
+  entry: MemoryEntry;
+  updates: MemoryUpdatePatch;
+}
+
+interface BulkUpdateCapableStore {
+  bulkUpdateExact?: (
+    updates: Array<{ id: string; updates: MemoryUpdatePatch }>,
+    scopeFilter?: string[],
+  ) => Promise<MemoryBulkUpdateResult[]>;
+  update: MemoryStore["update"];
 }
 
 const CURRENT_REFLECTION_METADATA_TYPES = new Set([
@@ -292,16 +305,22 @@ export class MemoryUpgrader {
         `memory-upgrader: processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(toProcess.length / batchSize)} (${batch.length} memories)`,
       );
 
+      const prepared: PreparedUpgrade[] = [];
       for (const entry of batch) {
         try {
-          await this.upgradeEntry(entry, noLlm);
-          result.upgraded++;
+          prepared.push(await this.prepareUpgradeEntry(entry, noLlm));
         } catch (err) {
-          const errMsg = `Failed to upgrade ${entry.id}: ${String(err)}`;
+          const errMsg = `Failed to prepare upgrade ${entry.id}: ${String(err)}`;
           result.errors.push(errMsg);
           this.log(`memory-upgrader: ERROR — ${errMsg}`);
         }
       }
+
+      await this.writePreparedBatch(
+        prepared,
+        result,
+        options.scopeFilter ?? this.options.scopeFilter,
+      );
 
       // Progress report
       this.log(
@@ -316,12 +335,12 @@ export class MemoryUpgrader {
   }
 
   /**
-   * Upgrade a single legacy memory entry.
+   * Prepare a single legacy memory entry without writing to the store.
    */
-  private async upgradeEntry(
+  private async prepareUpgradeEntry(
     entry: MemoryEntry,
     noLlm: boolean,
-  ): Promise<void> {
+  ): Promise<PreparedUpgrade> {
     // Step 1: Reverse-map category
     let newCategory = reverseMapCategory(entry.category, entry.text);
 
@@ -390,12 +409,70 @@ export class MemoryUpgrader {
       upgraded_at: Date.now(),
     };
 
-    // Step 4: Update the memory entry
-    await this.store.update(entry.id, {
-      // Update text to L0 abstract for better search indexing
-      text: enriched.l0_abstract,
-      metadata: stringifySmartMetadata(newMetadata as any),
-    });
+    return {
+      entry,
+      updates: {
+        // Keep the existing upgrader behavior in this PR: the primary text
+        // column is updated to L0, while L2 remains in smart metadata.
+        text: enriched.l0_abstract,
+        metadata: stringifySmartMetadata(newMetadata as any),
+      },
+    };
+  }
+
+  /**
+   * Persist a prepared batch with one store-level batch call when available.
+   */
+  private async writePreparedBatch(
+    prepared: PreparedUpgrade[],
+    result: UpgradeResult,
+    scopeFilter?: string[],
+  ): Promise<void> {
+    if (prepared.length === 0) return;
+
+    const store = this.store as BulkUpdateCapableStore;
+    if (typeof store.bulkUpdateExact === "function") {
+      let writeResults: MemoryBulkUpdateResult[];
+      try {
+        writeResults = await store.bulkUpdateExact(
+          prepared.map(({ entry, updates }) => ({ id: entry.id, updates })),
+          scopeFilter,
+        );
+      } catch (err) {
+        for (const { entry } of prepared) {
+          const errMsg = `Failed to write upgrade ${entry.id}: ${String(err)}`;
+          result.errors.push(errMsg);
+          this.log(`memory-upgrader: ERROR — ${errMsg}`);
+        }
+        return;
+      }
+
+      for (let index = 0; index < writeResults.length; index++) {
+        const writeResult = writeResults[index];
+        const fallbackEntry = prepared[index]?.entry;
+        if (writeResult.entry) {
+          result.upgraded++;
+        } else {
+          const id = writeResult.id ?? fallbackEntry?.id ?? "unknown";
+          const detail = writeResult.error ? `: ${writeResult.error}` : "";
+          const errMsg = `Failed to write upgrade ${id}${detail}`;
+          result.errors.push(errMsg);
+          this.log(`memory-upgrader: ERROR — ${errMsg}`);
+        }
+      }
+      return;
+    }
+
+    for (const { entry, updates } of prepared) {
+      try {
+        await this.store.update(entry.id, updates, scopeFilter);
+        result.upgraded++;
+      } catch (err) {
+        const errMsg = `Failed to write upgrade ${entry.id}: ${String(err)}`;
+        result.errors.push(errMsg);
+        this.log(`memory-upgrader: ERROR — ${errMsg}`);
+      }
+    }
   }
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -59,6 +59,20 @@ export interface MetadataPatch {
   [key: string]: unknown;
 }
 
+export interface MemoryUpdatePatch {
+  text?: string;
+  vector?: number[];
+  importance?: number;
+  category?: MemoryEntry["category"];
+  metadata?: string;
+}
+
+export interface MemoryBulkUpdateResult {
+  id: string;
+  entry: MemoryEntry | null;
+  error?: string;
+}
+
 // ============================================================================
 // LanceDB Dynamic Import
 // ============================================================================
@@ -1816,15 +1830,209 @@ export class MemoryStore {
     };
   }
 
+  /**
+   * Update multiple already-resolved memory IDs under one write lock.
+   *
+   * This intentionally accepts exact IDs only. Interactive callers that rely on
+   * short-prefix resolution should keep using update(), while bulk maintenance
+   * jobs can avoid repeated file-lock churn once they already have full row IDs.
+   */
+  async bulkUpdateExact(
+    updates: Array<{ id: string; updates: MemoryUpdatePatch }>,
+    scopeFilter?: string[],
+  ): Promise<MemoryBulkUpdateResult[]> {
+    await this.ensureInitialized();
+
+    if (updates.length === 0) return [];
+
+    if (isExplicitDenyAllScopeFilter(scopeFilter)) {
+      return updates.map(({ id }) => ({
+        id,
+        entry: null,
+        error: `Memory ${id} is outside accessible scopes`,
+      }));
+    }
+
+    return this.runWithFileLock(() => this.runSerializedUpdate(async () => {
+      const results = new Map<number, MemoryBulkUpdateResult>();
+      const pending: Array<{ inputIndex: number; id: string; updates: MemoryUpdatePatch }> = [];
+      const seenIds = new Set<string>();
+
+      updates.forEach((candidate, inputIndex) => {
+        const id = candidate.id;
+        if (typeof id !== "string" || id.length === 0) {
+          results.set(inputIndex, {
+            id: String(id),
+            entry: null,
+            error: `Invalid memory ID format: ${String(id)}`,
+          });
+          return;
+        }
+        if (seenIds.has(id)) {
+          results.set(inputIndex, {
+            id,
+            entry: null,
+            error: `Duplicate memory ID in bulk update: ${id}`,
+          });
+          return;
+        }
+        seenIds.add(id);
+        pending.push({ inputIndex, id, updates: candidate.updates });
+      });
+
+      for (let i = 0; i < pending.length; i += MemoryStore.MAX_BATCH_SIZE) {
+        const chunk = pending.slice(i, i + MemoryStore.MAX_BATCH_SIZE);
+        const whereClause = chunk
+          .map(({ id }) => `id = '${escapeSqlLiteral(id)}'`)
+          .join(" OR ");
+        const rows = whereClause.length > 0
+          ? await this.table!.query().where(`(${whereClause})`).toArray()
+          : [];
+        const rowsById = new Map<string, any>();
+        for (const row of rows) {
+          rowsById.set(row.id as string, row);
+        }
+
+        const originals: MemoryEntry[] = [];
+        const updatedEntries: MemoryEntry[] = [];
+        const updatedInputIndices: number[] = [];
+
+        for (const candidate of chunk) {
+          const row = rowsById.get(candidate.id);
+          if (!row) {
+            results.set(candidate.inputIndex, { id: candidate.id, entry: null });
+            continue;
+          }
+
+          const rowScope = (row.scope as string | undefined) ?? "global";
+          if (
+            scopeFilter &&
+            scopeFilter.length > 0 &&
+            !scopeFilter.includes(rowScope)
+          ) {
+            results.set(candidate.inputIndex, {
+              id: candidate.id,
+              entry: null,
+              error: `Memory ${candidate.id} is outside accessible scopes`,
+            });
+            continue;
+          }
+
+          const original: MemoryEntry = {
+            id: row.id as string,
+            text: row.text as string,
+            vector: Array.from(row.vector as Iterable<number>),
+            category: row.category as MemoryEntry["category"],
+            scope: rowScope,
+            importance: Number(row.importance),
+            timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
+            metadata: (row.metadata as string) || "{}",
+          };
+          const updated: MemoryEntry = {
+            ...original,
+            text: candidate.updates.text ?? original.text,
+            vector: candidate.updates.vector ?? original.vector,
+            category: candidate.updates.category ?? original.category,
+            scope: rowScope,
+            importance: candidate.updates.importance ?? original.importance,
+            timestamp: original.timestamp,
+            metadata: candidate.updates.metadata ?? original.metadata,
+          };
+
+          originals.push(original);
+          updatedEntries.push(updated);
+          updatedInputIndices.push(candidate.inputIndex);
+        }
+
+        if (updatedEntries.length === 0) {
+          continue;
+        }
+
+        const deleteWhereClause = updatedEntries
+          .map(({ id }) => `id = '${escapeSqlLiteral(id)}'`)
+          .join(" OR ");
+        let deleted = false;
+        try {
+          await this.table!.delete(`(${deleteWhereClause})`);
+          deleted = true;
+          await this.table!.add(updatedEntries);
+          for (let index = 0; index < updatedEntries.length; index++) {
+            results.set(updatedInputIndices[index], {
+              id: updatedEntries[index].id,
+              entry: updatedEntries[index],
+            });
+          }
+        } catch (writeError) {
+          const writeMessage = writeError instanceof Error ? writeError.message : String(writeError);
+          if (!deleted) {
+            for (let index = 0; index < updatedEntries.length; index++) {
+              results.set(updatedInputIndices[index], {
+                id: updatedEntries[index].id,
+                entry: null,
+                error:
+                  `Failed to bulk update memory ${updatedEntries[index].id}: delete failed before replacement write. ` +
+                  `Write error: ${writeMessage}`,
+              });
+            }
+            continue;
+          }
+
+          const existingAfterFailure = await this.table!.query()
+            .where(`(${deleteWhereClause})`)
+            .toArray()
+            .catch(() => []);
+          const preservedIds = new Set(
+            existingAfterFailure.map((row: any) => row.id as string),
+          );
+          const originalsToRestore = originals.filter((entry) => !preservedIds.has(entry.id));
+
+          try {
+            if (originalsToRestore.length > 0) {
+              await this.table!.add(originalsToRestore);
+            }
+          } catch (rollbackError) {
+            const rollbackMessage = rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+            for (let index = 0; index < updatedEntries.length; index++) {
+              results.set(updatedInputIndices[index], {
+                id: updatedEntries[index].id,
+                entry: null,
+                error:
+                  `Failed to bulk update memory ${updatedEntries[index].id}: write failed and rollback also failed. ` +
+                  `Write error: ${writeMessage}. Rollback error: ${rollbackMessage}`,
+              });
+            }
+            continue;
+          }
+
+          for (let index = 0; index < updatedEntries.length; index++) {
+            const preserved = preservedIds.has(updatedEntries[index].id);
+            results.set(updatedInputIndices[index], {
+              id: updatedEntries[index].id,
+              entry: null,
+              error:
+                `Failed to bulk update memory ${updatedEntries[index].id}: ` +
+                (preserved
+                  ? "write failed after delete, but an existing row was preserved. "
+                  : "write failed, original row restored. ") +
+                `Write error: ${writeMessage}`,
+            });
+          }
+        }
+      }
+
+      return updates.map((candidate, inputIndex) =>
+        results.get(inputIndex) ?? {
+          id: candidate.id,
+          entry: null,
+          error: `Memory ${candidate.id} was not processed`,
+        },
+      );
+    }));
+  }
+
   async update(
     id: string,
-    updates: {
-      text?: string;
-      vector?: number[];
-      importance?: number;
-      category?: MemoryEntry["category"];
-      metadata?: string;
-    },
+    updates: MemoryUpdatePatch,
     scopeFilter?: string[],
   ): Promise<MemoryEntry | null> {
     await this.ensureInitialized();

--- a/test/memory-upgrader-diagnostics.test.mjs
+++ b/test/memory-upgrader-diagnostics.test.mjs
@@ -16,6 +16,7 @@ const { createMemoryUpgrader } = jiti("../src/memory-upgrader.ts");
 async function runTest() {
   await testLegacyUpgradeFallbackDiagnostic();
   await testReflectionRowsAreNotLegacy();
+  await testBatchPreparationCompletesBeforeWrites();
   console.log("memory-upgrader diagnostics test passed");
 }
 
@@ -133,6 +134,75 @@ async function testReflectionRowsAreNotLegacy() {
   assert.equal(dryRun.totalLegacy, 0);
   assert.equal(dryRun.skipped, 3);
   assert.equal(updates.length, 0);
+}
+
+async function testBatchPreparationCompletesBeforeWrites() {
+  const logs = [];
+  let llmCalls = 0;
+  const legacyRows = [
+    {
+      id: "legacy-batch-1",
+      text: "Legacy memory about reducing updater lock contention.",
+      category: "fact",
+      scope: "test",
+      importance: 0.8,
+      timestamp: Date.now(),
+      metadata: "{}",
+    },
+    {
+      id: "legacy-batch-2",
+      text: "Legacy memory about keeping DB writes short.",
+      category: "decision",
+      scope: "test",
+      importance: 0.7,
+      timestamp: Date.now(),
+      metadata: "{}",
+    },
+  ];
+
+  const store = {
+    async list() {
+      return legacyRows;
+    },
+    async bulkUpdateExact(updates) {
+      assert.equal(llmCalls, 2, "all enrichment should finish before the batch write");
+      assert.equal(updates.length, 2);
+      return updates.map(({ id, updates: patch }) => ({
+        id,
+        entry: { ...legacyRows.find((row) => row.id === id), ...patch },
+      }));
+    },
+    async update() {
+      throw new Error("single-entry update should not be used when bulkUpdateExact exists");
+    },
+  };
+
+  const llm = {
+    async completeJson() {
+      llmCalls += 1;
+      return {
+        l0_abstract: `Batch summary ${llmCalls}`,
+        l1_overview: `- Batch summary ${llmCalls}`,
+        l2_content: legacyRows[llmCalls - 1].text,
+        resolved_category: "cases",
+      };
+    },
+    getLastError() {
+      return null;
+    },
+  };
+
+  const upgrader = createMemoryUpgrader(store, llm, {
+    log: (msg) => logs.push(msg),
+  });
+
+  const result = await upgrader.upgrade({ batchSize: 2 });
+
+  assert.equal(result.totalLegacy, 2);
+  assert.equal(result.upgraded, 2);
+  assert.equal(result.errors.length, 0);
+  assert.equal(llmCalls, 2);
+  assert.ok(logs.some((msg) => msg.includes("processing batch 1/1")));
 }
 
 runTest().catch((err) => {

--- a/test/store-write-queue.test.mjs
+++ b/test/store-write-queue.test.mjs
@@ -26,6 +26,16 @@ function makeEntry(i) {
   };
 }
 
+function assertVectorClose(actual, expected) {
+  assert.equal(actual?.length, expected.length);
+  for (let index = 0; index < expected.length; index++) {
+    assert.ok(
+      Math.abs(actual[index] - expected[index]) < 1e-6,
+      `vector[${index}] expected ${expected[index]}, got ${actual[index]}`,
+    );
+  }
+}
+
 describe("MemoryStore write queue", () => {
   it("serializes concurrent writes within the same store instance", async () => {
     const { store, dir } = makeStore();
@@ -111,6 +121,34 @@ describe("MemoryStore write queue", () => {
       const fetchedC = await store.getById(c.id);
       assert.ok(fetchedC);
       assert.strictEqual(fetchedC.text, "memory-3");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("bulkUpdateExact updates multiple exact IDs while preserving vectors", async () => {
+    const { store, dir } = makeStore();
+    try {
+      const a = await store.store(makeEntry(1));
+      const b = await store.store(makeEntry(2));
+
+      const results = await store.bulkUpdateExact([
+        { id: a.id, updates: { text: "memory-1-upgraded", metadata: "{\"upgraded\":true}" } },
+        { id: b.id, updates: { text: "memory-2-upgraded", importance: 0.95 } },
+      ]);
+
+      assert.strictEqual(results.length, 2);
+      assert.ok(results.every((result) => result.entry), "all exact updates should succeed");
+
+      const fetchedA = await store.getById(a.id);
+      const fetchedB = await store.getById(b.id);
+
+      assertVectorClose(fetchedA?.vector, a.vector);
+      assertVectorClose(fetchedB?.vector, b.vector);
+      assert.strictEqual(fetchedA?.text, "memory-1-upgraded");
+      assert.strictEqual(fetchedA?.metadata, "{\"upgraded\":true}");
+      assert.strictEqual(fetchedB?.text, "memory-2-upgraded");
+      assert.strictEqual(fetchedB?.importance, 0.95);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- split memory upgrade work into prepare/enrich and write phases
- add `bulkUpdateExact` so upgrader batches exact-ID updates under one write lock
- keep prefix/interactive update behavior on the existing `update` path

Fixes #632

## Tests
- `node test/memory-upgrader-diagnostics.test.mjs`
- `node --test test/store-write-queue.test.mjs`
- `npm run build`