### PR TITLE
fix: preserve searchable memory metadata

### DIFF
--- a/dist/src/memory-compactor.js
+++ b/dist/src/memory-compactor.js
@@ -19,6 +19,7 @@
  *        - metadata:   marked { compacted: true, sourceCount: N }
  *   4. Delete source entries, store merged entry.
  */
+import { buildSmartMetadata, parseSmartMetadata, reverseMapLegacyCategory, stringifySmartMetadata, } from "./smart-metadata.js";
 // ============================================================================
 // Math helpers
 // ============================================================================
@@ -115,7 +116,7 @@ export function buildMergedEntry(members) {
     const seen = new Set();
     const lines = [];
     for (const m of members) {
-        for (const line of m.text.split("\n")) {
+        for (const line of getFullSearchableContent(m).split("\n")) {
             const trimmed = line.trim();
             if (trimmed && !seen.has(trimmed.toLowerCase())) {
                 seen.add(trimmed.toLowerCase());
@@ -142,12 +143,80 @@ export function buildMergedEntry(members) {
     // --- scope: use the first (all should match) ---
     const scope = members[0].scope;
     // --- metadata ---
-    const metadata = JSON.stringify({
+    const compactedAt = Date.now();
+    const metadata = stringifySmartMetadata(buildSmartMetadata({
+        text,
+        category,
+        importance,
+        timestamp: compactedAt,
+        metadata: "{}",
+    }, {
+        l0_abstract: buildCompactedAbstract(members, text),
+        l1_overview: buildCompactedOverview(members, text),
+        l2_content: text,
+        memory_category: reverseMapLegacyCategory(category, text),
+        tier: strongestTier(members),
+        access_count: maxAccessCount(members),
+        confidence: maxConfidence(members),
+        last_accessed_at: Math.max(...members.map((m) => m.timestamp), compactedAt),
         compacted: true,
         sourceCount: members.length,
-        compactedAt: Date.now(),
-    });
+        compactedAt,
+    }));
     return { text, importance, category, scope, metadata };
+}
+function metadataFor(entry) {
+    return parseSmartMetadata(entry.metadata, entry);
+}
+function getFullSearchableContent(entry) {
+    return metadataFor(entry).l2_content || entry.text;
+}
+function stripBulletPrefix(text) {
+    return text.replace(/^\s*[-*]\s+/, "").trim();
+}
+function dedupeNonEmpty(values) {
+    const seen = new Set();
+    const deduped = [];
+    for (const value of values) {
+        const trimmed = stripBulletPrefix(value);
+        if (!trimmed)
+            continue;
+        const key = trimmed.toLowerCase();
+        if (seen.has(key))
+            continue;
+        seen.add(key);
+        deduped.push(trimmed);
+    }
+    return deduped;
+}
+function buildCompactedAbstract(members, fallbackText) {
+    const highestImportance = [...members].sort((a, b) => b.importance - a.importance)[0];
+    const candidate = highestImportance ? metadataFor(highestImportance).l0_abstract : "";
+    const fallback = fallbackText.match(/^[^.!?。！？\n]+[.!?。！？]?/)?.[0] || fallbackText;
+    return (candidate || fallback).slice(0, 180).trim();
+}
+function buildCompactedOverview(members, fallbackText) {
+    const summaries = dedupeNonEmpty(members.map((member) => metadataFor(member).l0_abstract)).slice(0, 8);
+    if (summaries.length > 0) {
+        return summaries.map((summary) => `- ${summary}`).join("\n");
+    }
+    return `- ${buildCompactedAbstract(members, fallbackText)}`;
+}
+function strongestTier(members) {
+    const rank = {
+        peripheral: 0,
+        working: 1,
+        core: 2,
+    };
+    return members
+        .map((member) => metadataFor(member).tier)
+        .sort((a, b) => rank[b] - rank[a])[0] ?? "working";
+}
+function maxAccessCount(members) {
+    return Math.max(0, ...members.map((member) => metadataFor(member).access_count));
+}
+function maxConfidence(members) {
+    return Math.max(0.7, ...members.map((member) => metadataFor(member).confidence));
 }
 const MAX_CLUSTER_COMPACTION_CONCURRENCY = 3;
 const MAX_CLUSTER_DELETE_CONCURRENCY = 8;

--- a/dist/src/memory-upgrader.js
+++ b/dist/src/memory-upgrader.js
@@ -258,6 +258,11 @@ export class MemoryUpgrader {
         else {
             enriched = simpleEnrich(entry.text, newCategory);
         }
+        const fullSearchableText = enriched.l2_content.trim() || entry.text;
+        enriched = {
+            ...enriched,
+            l2_content: fullSearchableText,
+        };
         // Step 3: Build enriched metadata
         const existingMeta = entry.metadata ? (() => {
             try {
@@ -283,9 +288,10 @@ export class MemoryUpgrader {
         return {
             entry,
             updates: {
-                // Keep the existing upgrader behavior in this PR: the primary text
-                // column is updated to L0, while L2 remains in smart metadata.
-                text: enriched.l0_abstract,
+                // Keep the full searchable layer in the primary text column. Search also
+                // scores L0/L1/L2 metadata, so replacing text with L0 would discard recall
+                // terms that only appear in the original content.
+                text: fullSearchableText,
                 metadata: stringifySmartMetadata(newMetadata),
             },
         };

--- a/src/memory-compactor.ts
+++ b/src/memory-compactor.ts
@@ -21,6 +21,13 @@
  */
 
 import type { MemoryEntry } from "./store.js";
+import {
+  buildSmartMetadata,
+  parseSmartMetadata,
+  reverseMapLegacyCategory,
+  stringifySmartMetadata,
+  type SmartMemoryMetadata,
+} from "./smart-metadata.js";
 
 // ============================================================================
 // Types
@@ -189,7 +196,7 @@ export function buildMergedEntry(
   const seen = new Set<string>();
   const lines: string[] = [];
   for (const m of members) {
-    for (const line of m.text.split("\n")) {
+    for (const line of getFullSearchableContent(m).split("\n")) {
       const trimmed = line.trim();
       if (trimmed && !seen.has(trimmed.toLowerCase())) {
         seen.add(trimmed.toLowerCase());
@@ -223,13 +230,93 @@ export function buildMergedEntry(
   const scope = members[0].scope;
 
   // --- metadata ---
-  const metadata = JSON.stringify({
-    compacted: true,
-    sourceCount: members.length,
-    compactedAt: Date.now(),
-  });
+  const compactedAt = Date.now();
+  const metadata = stringifySmartMetadata(buildSmartMetadata(
+    {
+      text,
+      category,
+      importance,
+      timestamp: compactedAt,
+      metadata: "{}",
+    },
+    {
+      l0_abstract: buildCompactedAbstract(members, text),
+      l1_overview: buildCompactedOverview(members, text),
+      l2_content: text,
+      memory_category: reverseMapLegacyCategory(category, text),
+      tier: strongestTier(members),
+      access_count: maxAccessCount(members),
+      confidence: maxConfidence(members),
+      last_accessed_at: Math.max(...members.map((m) => m.timestamp), compactedAt),
+      compacted: true,
+      sourceCount: members.length,
+      compactedAt,
+    } as Partial<SmartMemoryMetadata> & Record<string, unknown>,
+  ));
 
   return { text, importance, category, scope, metadata };
+}
+
+function metadataFor(entry: CompactionEntry): SmartMemoryMetadata {
+  return parseSmartMetadata(entry.metadata, entry);
+}
+
+function getFullSearchableContent(entry: CompactionEntry): string {
+  return metadataFor(entry).l2_content || entry.text;
+}
+
+function stripBulletPrefix(text: string): string {
+  return text.replace(/^\s*[-*]\s+/, "").trim();
+}
+
+function dedupeNonEmpty(values: string[]): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const value of values) {
+    const trimmed = stripBulletPrefix(value);
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(trimmed);
+  }
+  return deduped;
+}
+
+function buildCompactedAbstract(members: CompactionEntry[], fallbackText: string): string {
+  const highestImportance = [...members].sort((a, b) => b.importance - a.importance)[0];
+  const candidate = highestImportance ? metadataFor(highestImportance).l0_abstract : "";
+  const fallback = fallbackText.match(/^[^.!?。！？\n]+[.!?。！？]?/)?.[0] || fallbackText;
+  return (candidate || fallback).slice(0, 180).trim();
+}
+
+function buildCompactedOverview(members: CompactionEntry[], fallbackText: string): string {
+  const summaries = dedupeNonEmpty(
+    members.map((member) => metadataFor(member).l0_abstract),
+  ).slice(0, 8);
+  if (summaries.length > 0) {
+    return summaries.map((summary) => `- ${summary}`).join("\n");
+  }
+  return `- ${buildCompactedAbstract(members, fallbackText)}`;
+}
+
+function strongestTier(members: CompactionEntry[]): SmartMemoryMetadata["tier"] {
+  const rank: Record<SmartMemoryMetadata["tier"], number> = {
+    peripheral: 0,
+    working: 1,
+    core: 2,
+  };
+  return members
+    .map((member) => metadataFor(member).tier)
+    .sort((a, b) => rank[b] - rank[a])[0] ?? "working";
+}
+
+function maxAccessCount(members: CompactionEntry[]): number {
+  return Math.max(0, ...members.map((member) => metadataFor(member).access_count));
+}
+
+function maxConfidence(members: CompactionEntry[]): number {
+  return Math.max(0.7, ...members.map((member) => metadataFor(member).confidence));
 }
 
 // ============================================================================

--- a/src/memory-upgrader.ts
+++ b/src/memory-upgrader.ts
@@ -387,6 +387,12 @@ export class MemoryUpgrader {
       enriched = simpleEnrich(entry.text, newCategory);
     }
 
+    const fullSearchableText = enriched.l2_content.trim() || entry.text;
+    enriched = {
+      ...enriched,
+      l2_content: fullSearchableText,
+    };
+
     // Step 3: Build enriched metadata
     const existingMeta = entry.metadata ? (() => {
       try { return JSON.parse(entry.metadata!); } catch { return {}; }
@@ -412,9 +418,10 @@ export class MemoryUpgrader {
     return {
       entry,
       updates: {
-        // Keep the existing upgrader behavior in this PR: the primary text
-        // column is updated to L0, while L2 remains in smart metadata.
-        text: enriched.l0_abstract,
+        // Keep the full searchable layer in the primary text column. Search also
+        // scores L0/L1/L2 metadata, so replacing text with L0 would discard recall
+        // terms that only appear in the original content.
+        text: fullSearchableText,
         metadata: stringifySmartMetadata(newMetadata as any),
       },
     };

--- a/test/memory-compactor.test.mjs
+++ b/test/memory-compactor.test.mjs
@@ -10,6 +10,7 @@ const {
   buildMergedEntry,
   runCompaction,
 } = jiti("../src/memory-compactor.ts");
+const { parseSmartMetadata, stringifySmartMetadata, buildSmartMetadata } = jiti("../src/smart-metadata.ts");
 
 // ============================================================================
 // Helpers
@@ -220,6 +221,64 @@ describe("buildMergedEntry", () => {
     assert.equal(meta.compacted, true);
     assert.equal(meta.sourceCount, 3);
     assert.ok(typeof meta.compactedAt === "number");
+  });
+
+  it("builds searchable L0/L1/L2 metadata from source full content", () => {
+    const a = entry({
+      text: "OpenClaw incident 786 retrieval structure.",
+      metadata: stringifySmartMetadata(buildSmartMetadata(
+        {
+          text: "OpenClaw incident 786 retrieval structure.",
+          category: "fact",
+          importance: 0.8,
+          timestamp: Date.now(),
+          metadata: "{}",
+        },
+        {
+          l0_abstract: "OpenClaw incident 786 retrieval structure.",
+          l1_overview: "- Preserve retrieval structure",
+          l2_content: "OpenClaw incident 786 keeps rare-token CalypsoTicket-786 in full memory content.",
+          memory_category: "cases",
+          tier: "core",
+          access_count: 4,
+          confidence: 0.91,
+        },
+      )),
+    });
+    const b = entry({
+      text: "OpenClaw issue 786 compacted metadata.",
+      metadata: stringifySmartMetadata(buildSmartMetadata(
+        {
+          text: "OpenClaw issue 786 compacted metadata.",
+          category: "fact",
+          importance: 0.7,
+          timestamp: Date.now(),
+          metadata: "{}",
+        },
+        {
+          l0_abstract: "Compacted entries keep L0 L1 L2 metadata.",
+          l1_overview: "- Carry useful metadata after compaction",
+          l2_content: "Compacted issue 786 entries keep searchable LayerTwoOnlyNeedle metadata.",
+          memory_category: "cases",
+          tier: "working",
+          access_count: 2,
+          confidence: 0.82,
+        },
+      )),
+    });
+
+    const merged = buildMergedEntry([a, b]);
+    const meta = parseSmartMetadata(merged.metadata, merged);
+
+    assert.ok(merged.text.includes("CalypsoTicket-786"));
+    assert.ok(merged.text.includes("LayerTwoOnlyNeedle"));
+    assert.equal(meta.l2_content, merged.text);
+    assert.match(meta.l1_overview, /OpenClaw incident 786 retrieval structure/);
+    assert.equal(meta.memory_category, "cases");
+    assert.equal(meta.tier, "core");
+    assert.equal(meta.access_count, 4);
+    assert.equal(meta.compacted, true);
+    assert.equal(meta.sourceCount, 2);
   });
 });
 

--- a/test/memory-upgrader-diagnostics.test.mjs
+++ b/test/memory-upgrader-diagnostics.test.mjs
@@ -15,6 +15,7 @@ const { createMemoryUpgrader } = jiti("../src/memory-upgrader.ts");
 
 async function runTest() {
   await testLegacyUpgradeFallbackDiagnostic();
+  await testUpgradeKeepsFullTextWhenLlmReturnsConciseL0();
   await testReflectionRowsAreNotLegacy();
   await testBatchPreparationCompletesBeforeWrites();
   console.log("memory-upgrader diagnostics test passed");
@@ -68,6 +69,55 @@ async function testLegacyUpgradeFallbackDiagnostic() {
   );
   assert.equal(typeof updates[0].patch.text, "string");
   assert.ok(updates[0].patch.metadata.includes("upgraded_at"));
+}
+
+async function testUpgradeKeepsFullTextWhenLlmReturnsConciseL0() {
+  const updates = [];
+  const legacyEntry = {
+    id: "legacy-structured-1",
+    text: "OpenClaw incident 786: keep rare-token CalypsoTicket-786 in searchable memory content.",
+    category: "fact",
+    scope: "test",
+    importance: 0.8,
+    timestamp: Date.now(),
+    metadata: "{}",
+  };
+
+  const store = {
+    async list() {
+      return [legacyEntry];
+    },
+    async update(id, patch) {
+      updates.push({ id, patch });
+      return true;
+    },
+  };
+
+  const llm = {
+    async completeJson() {
+      return {
+        l0_abstract: "OpenClaw incident 786 retrieval structure.",
+        l1_overview: "- Preserve the full searchable layer",
+        l2_content: legacyEntry.text,
+        resolved_category: "cases",
+      };
+    },
+    getLastError() {
+      return null;
+    },
+  };
+
+  const upgrader = createMemoryUpgrader(store, llm, { log: () => {} });
+  const result = await upgrader.upgrade({ batchSize: 1 });
+
+  assert.equal(result.upgraded, 1);
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].patch.text, legacyEntry.text);
+
+  const meta = JSON.parse(updates[0].patch.metadata);
+  assert.equal(meta.l0_abstract, "OpenClaw incident 786 retrieval structure.");
+  assert.equal(meta.l2_content, legacyEntry.text);
+  assert.equal(meta.memory_category, "cases");
 }
 
 async function testReflectionRowsAreNotLegacy() {

--- a/test/store-lexical-metadata-search.test.mjs
+++ b/test/store-lexical-metadata-search.test.mjs
@@ -1,0 +1,68 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const { MemoryStore } = jiti("../src/store.ts");
+const { buildSmartMetadata, stringifySmartMetadata } = jiti("../src/smart-metadata.ts");
+
+function makeTable(rows) {
+  return {
+    async listIndices() {
+      return [];
+    },
+    query() {
+      const builder = {
+        where() {
+          return builder;
+        },
+        select() {
+          return builder;
+        },
+        async toArray() {
+          return rows;
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+describe("MemoryStore lexical metadata search", () => {
+  it("matches recall terms that are only present in L2 metadata", async () => {
+    const row = {
+      id: "memory-search-l2",
+      text: "Concise abstract without the rare token.",
+      vector: [0.1, 0.2, 0.3],
+      category: "fact",
+      scope: "global",
+      importance: 0.8,
+      timestamp: Date.now(),
+      metadata: stringifySmartMetadata(buildSmartMetadata(
+        {
+          text: "Concise abstract without the rare token.",
+          category: "fact",
+          importance: 0.8,
+          timestamp: Date.now(),
+          metadata: "{}",
+        },
+        {
+          l0_abstract: "Concise abstract without the rare token.",
+          l1_overview: "- Search should inspect smart metadata",
+          l2_content: "Full retained content includes CalypsoTicket-786 for lexical recall.",
+          memory_category: "cases",
+        },
+      )),
+    };
+
+    const store = new MemoryStore({ dbPath: "/unused", vectorDim: 3 });
+    store.table = makeTable([row]);
+
+    const results = await store.bm25Search("CalypsoTicket-786", 5);
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].entry.id, "memory-search-l2");
+    assert.equal(results[0].entry.text, row.text);
+    assert.ok(results[0].score > 0);
+  });
+});


### PR DESCRIPTION
## Summary
- keep upgraded memories searchable by preserving full L2 content in the primary text column
- build compacted memories from source L2 content when available
- write compacted L0/L1/L2 smart metadata for lexical recall

Fixes #786

## Tests
- `node test/memory-upgrader-diagnostics.test.mjs`
- `node --test test/memory-compactor.test.mjs`
- `node --test test/store-lexical-metadata-search.test.mjs`
- `npm run build`