### PR TITLE
fix: abort auto-recall retrieval on timeout

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1746,13 +1746,30 @@ const memoryLanceDBProPlugin = {
             throw err;
         }
         const { config, resolvedDbPath, vectorDim, store, embedder, retriever, canonicalCorpusIndexer, scopeManager, migrator, smartExtractor, decayEngine, tierManager, extractionRateLimiter, reflectionErrorStateBySession, reflectionDerivedBySession, reflectionDerivedSuppressionBySession, reflectionByAgentCache, recallHistory, turnCounter, autoCaptureSeenTextCount, autoCapturePendingIngressTexts, autoCaptureRecentTexts, } = singleton;
-        async function sleep(ms) {
-            await new Promise(resolve => setTimeout(resolve, ms));
+        async function sleep(ms, signal) {
+            if (signal?.aborted) {
+                throw signal.reason ?? new Error("aborted");
+            }
+            await new Promise((resolve, reject) => {
+                const timeoutId = setTimeout(() => {
+                    cleanup();
+                    resolve();
+                }, ms);
+                const onAbort = () => {
+                    cleanup();
+                    reject(signal?.reason ?? new Error("aborted"));
+                };
+                const cleanup = () => {
+                    clearTimeout(timeoutId);
+                    signal?.removeEventListener("abort", onAbort);
+                };
+                signal?.addEventListener("abort", onAbort, { once: true });
+            });
         }
         async function retrieveWithRetry(params) {
             let results = await retriever.retrieve(params);
             if (results.length === 0) {
-                await sleep(75);
+                await sleep(75, params.signal);
                 results = await retriever.retrieve(params);
             }
             return results;
@@ -2213,6 +2230,7 @@ const memoryLanceDBProPlugin = {
                         limit: retrieveLimit,
                         scopeFilter: accessibleScopes,
                         source: "auto-recall",
+                        signal: autoRecallAbortController.signal,
                     }), config.workspaceBoundary);
                     if (shouldDropLateAutoRecall("post-retrieve"))
                         return;
@@ -2426,13 +2444,24 @@ const memoryLanceDBProPlugin = {
                         ephemeral: true,
                     };
                 };
+                const autoRecallAbortController = new AbortController();
                 let timeoutId;
                 try {
+                    const recallPromise = recallWork().then((r) => {
+                        clearTimeout(timeoutId);
+                        return r;
+                    }).catch((err) => {
+                        if (autoRecallTimedOut && autoRecallAbortController.signal.aborted) {
+                            return undefined;
+                        }
+                        throw err;
+                    });
                     const result = await Promise.race([
-                        recallWork().then((r) => { clearTimeout(timeoutId); return r; }),
+                        recallPromise,
                         new Promise((resolve) => {
                             timeoutId = setTimeout(() => {
                                 autoRecallTimedOut = true;
+                                autoRecallAbortController.abort(new Error(`auto-recall timed out after ${AUTO_RECALL_TIMEOUT_MS}ms`));
                                 api.logger.warn(`memory-lancedb-pro: auto-recall timed out after ${AUTO_RECALL_TIMEOUT_MS}ms; skipping memory injection to avoid stalling agent startup`);
                                 resolve(undefined);
                             }, AUTO_RECALL_TIMEOUT_MS);

--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -337,7 +337,7 @@ export class MemoryRetriever {
         return this.store.hasFtsSupport;
     }
     async retrieve(context) {
-        const { query, limit, scopeFilter, category, source } = context;
+        const { query, limit, scopeFilter, category, source, signal } = context;
         const safeLimit = clampInt(limit, 1, 20);
         this.lastDiagnostics = null;
         const diagnostics = {
@@ -380,10 +380,10 @@ export class MemoryRetriever {
                 results = await this.bm25OnlyRetrieval(query, tagTokens, safeLimit, scopeFilter, category, trace, diagnostics);
             }
             else if (this.config.mode === "vector" || !hasFtsSupport) {
-                results = await this.vectorOnlyRetrieval(query, safeLimit, scopeFilter, category, trace, diagnostics);
+                results = await this.vectorOnlyRetrieval(query, safeLimit, scopeFilter, category, trace, diagnostics, signal);
             }
             else {
-                results = await this.hybridRetrieval(query, safeLimit, scopeFilter, category, trace, source, diagnostics);
+                results = await this.hybridRetrieval(query, safeLimit, scopeFilter, category, trace, source, diagnostics, signal);
             }
             diagnostics.finalResultCount = results.length;
             diagnostics.dropSummary = buildDropSummary(diagnostics);
@@ -453,11 +453,11 @@ export class MemoryRetriever {
         const matches = query.match(regex);
         return matches || [];
     }
-    async vectorOnlyRetrieval(query, limit, scopeFilter, category, trace, diagnostics) {
+    async vectorOnlyRetrieval(query, limit, scopeFilter, category, trace, diagnostics, signal) {
         let failureStage = "vector.embedQuery";
         try {
             const candidatePoolSize = Math.max(this.config.candidatePoolSize, limit * 2);
-            const queryVector = await this.embedder.embedQuery(query);
+            const queryVector = await this.embedder.embedQuery(query, signal);
             failureStage = "vector.vectorSearch";
             const results = await this.store.vectorSearch(queryVector, candidatePoolSize, this.config.minScore, scopeFilter, { excludeInactive: true });
             const filtered = category
@@ -606,11 +606,11 @@ export class MemoryRetriever {
             diagnostics.stageCounts.afterDiversity = deduplicated.length;
         return finalResults;
     }
-    async hybridRetrieval(query, limit, scopeFilter, category, trace, source, diagnostics) {
+    async hybridRetrieval(query, limit, scopeFilter, category, trace, source, diagnostics, signal) {
         let failureStage = "hybrid.embedQuery";
         try {
             const candidatePoolSize = Math.max(this.config.candidatePoolSize, limit * 2);
-            const queryVector = await this.embedder.embedQuery(query);
+            const queryVector = await this.embedder.embedQuery(query, signal);
             const bm25Query = this.buildBM25Query(query, source);
             if (diagnostics) {
                 diagnostics.bm25Query = bm25Query;

--- a/index.ts
+++ b/index.ts
@@ -2317,8 +2317,25 @@ const memoryLanceDBProPlugin = {
     } = singleton;
 
 
-    async function sleep(ms: number): Promise<void> {
-      await new Promise(resolve => setTimeout(resolve, ms));
+    async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+      if (signal?.aborted) {
+        throw signal.reason ?? new Error("aborted");
+      }
+      await new Promise<void>((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          cleanup();
+          resolve();
+        }, ms);
+        const onAbort = () => {
+          cleanup();
+          reject(signal?.reason ?? new Error("aborted"));
+        };
+        const cleanup = () => {
+          clearTimeout(timeoutId);
+          signal?.removeEventListener("abort", onAbort);
+        };
+        signal?.addEventListener("abort", onAbort, { once: true });
+      });
     }
 
     async function retrieveWithRetry(params: {
@@ -2327,10 +2344,11 @@ const memoryLanceDBProPlugin = {
       scopeFilter?: string[];
       category?: string;
       source?: "manual" | "auto-recall" | "cli";
+      signal?: AbortSignal;
     }) {
       let results = await retriever.retrieve(params);
       if (results.length === 0) {
-        await sleep(75);
+        await sleep(75, params.signal);
         results = await retriever.retrieve(params);
       }
       return results;
@@ -2889,6 +2907,7 @@ const memoryLanceDBProPlugin = {
             limit: retrieveLimit,
             scopeFilter: accessibleScopes,
             source: "auto-recall",
+            signal: autoRecallAbortController.signal,
           }), config.workspaceBoundary);
 
           if (shouldDropLateAutoRecall("post-retrieve")) return;
@@ -3147,13 +3166,26 @@ const memoryLanceDBProPlugin = {
           };
         };
 
+        const autoRecallAbortController = new AbortController();
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         try {
+          const recallPromise = recallWork().then((r) => {
+            clearTimeout(timeoutId);
+            return r;
+          }).catch((err) => {
+            if (autoRecallTimedOut && autoRecallAbortController.signal.aborted) {
+              return undefined;
+            }
+            throw err;
+          });
           const result = await Promise.race([
-            recallWork().then((r) => { clearTimeout(timeoutId); return r; }),
+            recallPromise,
             new Promise<undefined>((resolve) => {
               timeoutId = setTimeout(() => {
                 autoRecallTimedOut = true;
+                autoRecallAbortController.abort(new Error(
+                  `auto-recall timed out after ${AUTO_RECALL_TIMEOUT_MS}ms`,
+                ));
                 api.logger.warn(
                   `memory-lancedb-pro: auto-recall timed out after ${AUTO_RECALL_TIMEOUT_MS}ms; skipping memory injection to avoid stalling agent startup`,
                 );

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -105,6 +105,8 @@ export interface RetrievalContext {
   category?: string;
   /** Retrieval source: "manual" for user-triggered, "auto-recall" for system-initiated, "cli" for CLI commands. */
   source?: "manual" | "auto-recall" | "cli";
+  /** Optional cancellation signal for callers with an outer timeout budget. */
+  signal?: AbortSignal;
 }
 
 export interface RetrievalResult extends MemorySearchResult {
@@ -583,7 +585,7 @@ export class MemoryRetriever {
   }
 
   async retrieve(context: RetrievalContext): Promise<RetrievalResult[]> {
-    const { query, limit, scopeFilter, category, source } = context;
+    const { query, limit, scopeFilter, category, source, signal } = context;
     const safeLimit = clampInt(limit, 1, 20);
     this.lastDiagnostics = null;
     const diagnostics: RetrievalDiagnostics = {
@@ -642,6 +644,7 @@ export class MemoryRetriever {
           category,
           trace,
           diagnostics,
+          signal,
         );
       } else {
         results = await this.hybridRetrieval(
@@ -652,6 +655,7 @@ export class MemoryRetriever {
           trace,
           source,
           diagnostics,
+          signal,
         );
       }
 
@@ -747,11 +751,12 @@ export class MemoryRetriever {
     category?: string,
     trace?: TraceCollector,
     diagnostics?: RetrievalDiagnostics,
+    signal?: AbortSignal,
   ): Promise<RetrievalResult[]> {
     let failureStage: RetrievalDiagnostics["failureStage"] = "vector.embedQuery";
     try {
       const candidatePoolSize = Math.max(this.config.candidatePoolSize, limit * 2);
-      const queryVector = await this.embedder.embedQuery(query);
+      const queryVector = await this.embedder.embedQuery(query, signal);
       failureStage = "vector.vectorSearch";
       const results = await this.store.vectorSearch(
         queryVector,
@@ -937,11 +942,12 @@ export class MemoryRetriever {
     trace?: TraceCollector,
     source?: RetrievalContext["source"],
     diagnostics?: RetrievalDiagnostics,
+    signal?: AbortSignal,
   ): Promise<RetrievalResult[]> {
     let failureStage: RetrievalDiagnostics["failureStage"] = "hybrid.embedQuery";
     try {
       const candidatePoolSize = Math.max(this.config.candidatePoolSize, limit * 2);
-      const queryVector = await this.embedder.embedQuery(query);
+      const queryVector = await this.embedder.embedQuery(query, signal);
       const bm25Query = this.buildBM25Query(query, source);
       if (diagnostics) {
         diagnostics.bm25Query = bm25Query;

--- a/test/auto-recall-timeout.test.mjs
+++ b/test/auto-recall-timeout.test.mjs
@@ -227,6 +227,81 @@ describe("auto-recall timeout", () => {
     );
   });
 
+  it("aborts in-flight retrieval when auto-recall times out", async () => {
+    const logs = { info: [], warn: [], debug: [] };
+    let retrieveCalls = 0;
+    let retrievalSignal;
+
+    activeCreateRetriever = function mockCreateRetriever() {
+      return {
+        async retrieve(context) {
+          retrieveCalls++;
+          retrievalSignal = context.signal;
+          assert.ok(retrievalSignal, "auto-recall should pass a retrieval AbortSignal");
+          await new Promise((resolve) => {
+            if (retrievalSignal.aborted) {
+              resolve();
+              return;
+            }
+            retrievalSignal.addEventListener("abort", resolve, { once: true });
+          });
+          return [];
+        },
+        getConfig() {
+          return { mode: "hybrid" };
+        },
+        setAccessTracker() {},
+        setStatsCollector() {},
+      };
+    };
+    activeCreateEmbedder = function mockCreateEmbedder() {
+      return {
+        async embedQuery() {
+          return new Float32Array(384).fill(0);
+        },
+        async embedPassage() {
+          return new Float32Array(384).fill(0);
+        },
+      };
+    };
+
+    const harness = createPluginApiHarness({
+      resolveRoot: workspaceDir,
+      logs,
+      pluginConfig: {
+        dbPath: path.join(workspaceDir, "db"),
+        embedding: { apiKey: "test-api-key" },
+        smartExtraction: false,
+        autoCapture: false,
+        autoRecall: true,
+        autoRecallMinLength: 1,
+        autoRecallTimeoutMs: 1,
+        selfImprovement: { enabled: false, beforeResetNote: false, ensureLearningFiles: false },
+      },
+    });
+
+    memoryLanceDBProPlugin.register(harness.api);
+
+    const autoRecallHook = getAutoRecallHook(harness.eventHandlers);
+    const output = await autoRecallHook(
+      { prompt: "Please recall what I mentioned before about this task." },
+      { sessionId: "auto-timeout-abort", sessionKey: "agent:main:session:auto-timeout-abort", agentId: "main" },
+    );
+
+    assert.equal(output, undefined);
+    assert.equal(retrieveCalls, 1, "aborted retrieval should not retry after timeout");
+    assert.equal(retrievalSignal?.aborted, true, "auto-recall timeout should abort retrieval");
+    assert.ok(
+      logs.warn.some((line) => line.includes("auto-recall timed out after 1ms")),
+      "expected timeout warning",
+    );
+    assert.equal(
+      logs.warn.some((line) => line.includes("recall failed")),
+      false,
+      "expected timeout abort to be consumed without a second noisy warning",
+    );
+  });
+
   it("returns context before auto-recall metadata patch settles", async () => {
     const logs = { info: [], warn: [], debug: [] };
     const patchResolvers = [];


### PR DESCRIPTION
## Summary
- abort in-flight auto-recall retrieval work when the outer timeout fires
- thread AbortSignal through retrieveWithRetry and retriever vector/hybrid embedding paths
- suppress expected post-timeout abort noise while keeping the existing timeout warning

Fixes #643

## Tests
- `node --test test/auto-recall-timeout.test.mjs`
- `node test/retriever-rerank-regression.mjs`
- `npm run build`