### PR TITLE
fix: avoid sync fs in write lock path

### DIFF
--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -3,8 +3,8 @@
  */
 import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
-import { existsSync, accessSync, constants, mkdirSync, realpathSync, lstatSync, statSync, unlinkSync, rmdirSync, writeFileSync, } from "node:fs";
-import { access as accessAsync, lstat as lstatAsync, mkdir as mkdirAsync, realpath as realpathAsync, } from "node:fs/promises";
+import { existsSync, accessSync, constants, mkdirSync, realpathSync, lstatSync, unlinkSync, writeFileSync, } from "node:fs";
+import { access as accessAsync, lstat as lstatAsync, mkdir as mkdirAsync, realpath as realpathAsync, rmdir as rmdirAsync, stat as statAsync, unlink as unlinkAsync, writeFile as writeFileAsync, } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
@@ -391,17 +391,19 @@ export class MemoryStore {
         const lockPath = join(this.config.dbPath, ".memory-write.lock");
         const lockArtifactPath = `${lockPath}.lock`;
         const ensureLockTargetExists = async () => {
-            if (!existsSync(lockPath)) {
-                try {
-                    mkdirSync(dirname(lockPath), { recursive: true });
-                }
-                catch { }
-                try {
-                    const { writeFileSync } = await import("node:fs");
-                    writeFileSync(lockPath, "", { flag: "wx" });
-                }
-                catch { }
+            try {
+                await accessAsync(lockPath);
+                return;
             }
+            catch { }
+            try {
+                await mkdirAsync(dirname(lockPath), { recursive: true });
+            }
+            catch { }
+            try {
+                await writeFileAsync(lockPath, "", { flag: "wx" });
+            }
+            catch { }
         };
         await ensureLockTargetExists();
         // 【修復 #415】調整 retries：max wait 從 ~3100ms → ~151秒
@@ -414,26 +416,24 @@ export class MemoryStore {
         // Proactive cleanup of stale proper-lockfile artifacts（from PR #626）.
         // proper-lockfile locks the target by creating `${target}.lock`; the
         // target file itself is expected to persist and must not be treated stale.
-        if (existsSync(lockArtifactPath)) {
-            try {
-                const stat = statSync(lockArtifactPath);
-                const ageMs = Date.now() - stat.mtimeMs;
-                const staleThresholdMs = 5 * 60 * 1000;
-                if (ageMs > staleThresholdMs) {
-                    try {
-                        if (stat.isDirectory()) {
-                            rmdirSync(lockArtifactPath);
-                        }
-                        else {
-                            unlinkSync(lockArtifactPath);
-                        }
-                        console.warn(`[memory-lancedb-pro] cleared stale lock artifact: ${lockArtifactPath} ageMs=${ageMs}`);
+        try {
+            const stat = await statAsync(lockArtifactPath);
+            const ageMs = Date.now() - stat.mtimeMs;
+            const staleThresholdMs = 5 * 60 * 1000;
+            if (ageMs > staleThresholdMs) {
+                try {
+                    if (stat.isDirectory()) {
+                        await rmdirAsync(lockArtifactPath);
                     }
-                    catch { }
+                    else {
+                        await unlinkAsync(lockArtifactPath);
+                    }
+                    console.warn(`[memory-lancedb-pro] cleared stale lock artifact: ${lockArtifactPath} ageMs=${ageMs}`);
                 }
+                catch { }
             }
-            catch { }
         }
+        catch { }
         const acquireLock = async () => lockfile.lock(lockPath, {
             // 【修復 #670】realpath:false — 避免 proactive cleanup 刪除 stale lock artifact 後，
             // proper-lockfile v4 的 realpath() 在已刪除檔案上被呼叫，導致 ENOENT。

--- a/src/store.ts
+++ b/src/store.ts
@@ -12,9 +12,7 @@ import {
   mkdirSync,
   realpathSync,
   lstatSync,
-  statSync,
   unlinkSync,
-  rmdirSync,
   writeFileSync,
 } from "node:fs";
 import {
@@ -22,6 +20,10 @@ import {
   lstat as lstatAsync,
   mkdir as mkdirAsync,
   realpath as realpathAsync,
+  rmdir as rmdirAsync,
+  stat as statAsync,
+  unlink as unlinkAsync,
+  writeFile as writeFileAsync,
 } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -511,10 +513,13 @@ export class MemoryStore {
     const lockPath = join(this.config.dbPath, ".memory-write.lock");
     const lockArtifactPath = `${lockPath}.lock`;
     const ensureLockTargetExists = async () => {
-      if (!existsSync(lockPath)) {
-        try { mkdirSync(dirname(lockPath), { recursive: true }); } catch {}
-        try { const { writeFileSync } = await import("node:fs"); writeFileSync(lockPath, "", { flag: "wx" }); } catch {}
-      }
+      try {
+        await accessAsync(lockPath);
+        return;
+      } catch {}
+
+      try { await mkdirAsync(dirname(lockPath), { recursive: true }); } catch {}
+      try { await writeFileAsync(lockPath, "", { flag: "wx" }); } catch {}
     };
     await ensureLockTargetExists();
     // 【修復 #415】調整 retries：max wait 從 ~3100ms → ~151秒
@@ -528,23 +533,21 @@ export class MemoryStore {
     // Proactive cleanup of stale proper-lockfile artifacts（from PR #626）.
     // proper-lockfile locks the target by creating `${target}.lock`; the
     // target file itself is expected to persist and must not be treated stale.
-    if (existsSync(lockArtifactPath)) {
-      try {
-        const stat = statSync(lockArtifactPath);
-        const ageMs = Date.now() - stat.mtimeMs;
-        const staleThresholdMs = 5 * 60 * 1000;
-        if (ageMs > staleThresholdMs) {
-          try {
-            if (stat.isDirectory()) {
-              rmdirSync(lockArtifactPath);
-            } else {
-              unlinkSync(lockArtifactPath);
-            }
-            console.warn(`[memory-lancedb-pro] cleared stale lock artifact: ${lockArtifactPath} ageMs=${ageMs}`);
-          } catch {}
-        }
-      } catch {}
-    }
+    try {
+      const stat = await statAsync(lockArtifactPath);
+      const ageMs = Date.now() - stat.mtimeMs;
+      const staleThresholdMs = 5 * 60 * 1000;
+      if (ageMs > staleThresholdMs) {
+        try {
+          if (stat.isDirectory()) {
+            await rmdirAsync(lockArtifactPath);
+          } else {
+            await unlinkAsync(lockArtifactPath);
+          }
+          console.warn(`[memory-lancedb-pro] cleared stale lock artifact: ${lockArtifactPath} ageMs=${ageMs}`);
+        } catch {}
+      }
+    } catch {}
 
     const acquireLock = async () => lockfile.lock(lockPath, {
       // 【修復 #670】realpath:false — 避免 proactive cleanup 刪除 stale lock artifact 後，

--- a/test/cross-process-lock.test.mjs
+++ b/test/cross-process-lock.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, existsSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import jitiFactory from "jiti";
@@ -137,6 +137,35 @@ describe("Cross-process file lock", () => {
       assert.ok(
         !warnings.some((message) => message.includes("cleared stale lock")),
         "old lock target file should not emit stale-lock cleanup warnings",
+      );
+    } finally {
+      console.warn = originalWarn;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("cleans stale proper-lockfile artifact without deleting lock target", async () => {
+    const { store, dir } = makeStore();
+    const lockTarget = join(dir, ".memory-write.lock");
+    const lockArtifact = `${lockTarget}.lock`;
+    const oldTime = new Date(Date.now() - 10 * 60 * 1000);
+    const warnings = [];
+    const originalWarn = console.warn;
+
+    try {
+      mkdirSync(lockArtifact, { recursive: true });
+      utimesSync(lockArtifact, oldTime, oldTime);
+      console.warn = (...args) => {
+        warnings.push(args.join(" "));
+      };
+
+      await store.store(makeEntry(1));
+
+      assert.ok(existsSync(lockTarget), "persistent lock target file should remain");
+      assert.strictEqual(existsSync(lockArtifact), false, "stale lock artifact should be removed");
+      assert.ok(
+        warnings.some((message) => message.includes("cleared stale lock artifact")),
+        "stale lock artifact cleanup should emit a warning",
       );
     } finally {
       console.warn = originalWarn;

--- a/test/lock-recovery.test.mjs
+++ b/test/lock-recovery.test.mjs
@@ -126,7 +126,8 @@ describe("runWithFileLock recovery", () => {
       await store.store(makeEntry(1));
 
       const lockPath = join(dir, ".memory-write.lock");
-      assert.strictEqual(existsSync(lockPath), false);
+      assert.strictEqual(existsSync(lockPath), true);
+      assert.strictEqual(existsSync(`${lockPath}.lock`), false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- replace synchronous lock target setup and stale lock artifact cleanup with fs/promises
- keep the persistent `.memory-write.lock` target while only cleaning stale proper-lockfile artifacts
- add regression coverage for artifact cleanup and lock target preservation

Fixes #763

## Tests
- `node --test test/cross-process-lock.test.mjs`
- `node --test test/lock-release-on-error.test.mjs`
- `node --test test/lock-recovery.test.mjs`
- `node --test test/lock-stress-test.mjs`
- `npm run build`