### PR TITLE
fix: send Voyage-compatible embedding payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ Query → BM25 FTS ─────┘
 <details>
 <summary><strong>Embedding Providers</strong></summary>
 
-Works with **any OpenAI-compatible embedding API**:
+Works with **OpenAI-compatible embedding APIs**, including provider-specific payload adapters for services such as Jina and Voyage:
 
 | Provider | Model | Base URL | Dimensions |
 | --- | --- | --- | --- |
@@ -527,6 +527,8 @@ Works with **any OpenAI-compatible embedding API**:
 | **Voyage** | `voyage-4-lite` / `voyage-4` | `https://api.voyageai.com/v1` | 1024 / 1024 |
 | **Google Gemini** | `gemini-embedding-001` | `https://generativelanguage.googleapis.com/v1beta/openai/` | 3072 |
 | **Ollama** (local) | `nomic-embed-text` | `http://localhost:11434/v1` | provider-specific |
+
+Voyage embedding requests use Voyage's `model` + `input` payload shape. When `requestDimensions` is configured it is sent as `output_dimension`; OpenAI-only fields such as `encoding_format` are omitted.
 
 </details>
 

--- a/dist/src/embedder.js
+++ b/dist/src/embedder.js
@@ -240,6 +240,7 @@ function getEmbeddingCapabilities(profile) {
                     "retrieval.query": "query",
                     "retrieval.passage": "document",
                     "query": "query",
+                    "passage": "document",
                     "document": "document",
                 },
                 dimensionsField: "output_dimension",
@@ -371,7 +372,9 @@ export class Embedder {
     _taskQuery;
     _taskPassage;
     _normalized;
+    _providerProfile;
     _capabilities;
+    _apiKeys;
     /** Optional requested dimensions to pass through to the embedding provider (OpenAI-compatible). */
     _requestDimensions;
     /** When true, omit the dimensions parameter even if _requestDimensions is set. */
@@ -382,6 +385,7 @@ export class Embedder {
         // Normalize apiKey to array and resolve environment variables
         const apiKeys = Array.isArray(config.apiKey) ? config.apiKey : [config.apiKey];
         const resolvedKeys = apiKeys.map(k => resolveEnvVars(k));
+        this._apiKeys = resolvedKeys;
         this._model = config.model;
         this._baseURL = config.baseURL;
         this._taskQuery = config.taskQuery;
@@ -392,6 +396,7 @@ export class Embedder {
         // Enable auto-chunking by default for better handling of long documents
         this._autoChunk = config.chunking !== false;
         const profile = detectEmbeddingProviderProfile(this._baseURL, this._model);
+        this._providerProfile = profile;
         this._capabilities = getEmbeddingCapabilities(profile);
         const clientTimeoutMs = Number.isFinite(config.clientTimeoutMs) && config.clientTimeoutMs > 0
             ? Math.floor(config.clientTimeoutMs)
@@ -438,6 +443,12 @@ export class Embedder {
         this._clientIndex = (this._clientIndex + 1) % this.clients.length;
         return client;
     }
+    /** Return the next raw API key in the same round-robin order as clients. */
+    nextApiKey() {
+        const key = this._apiKeys[this._clientIndex % this._apiKeys.length];
+        this._clientIndex = (this._clientIndex + 1) % this._apiKeys.length;
+        return key;
+    }
     /** Check whether an error is a rate-limit / quota-exceeded / overload error. */
     isRateLimitError(error) {
         if (!error || typeof error !== "object")
@@ -471,6 +482,14 @@ export class Embedder {
         if (!this._baseURL)
             return false;
         return /localhost:11434|127\.0\.0\.1:11434|\/ollama\b/i.test(this._baseURL);
+    }
+    /**
+     * Voyage's embeddings endpoint rejects OpenAI SDK-injected request fields such
+     * as encoding_format. Use native fetch for Voyage so buildPayload() remains
+     * the exact serialized request body.
+     */
+    isVoyageProvider() {
+        return this._providerProfile === "voyage-compatible";
     }
     /**
      * Call embeddings.create using native fetch (bypasses OpenAI SDK).
@@ -549,6 +568,27 @@ export class Embedder {
         // convert to OpenAI-compatible shape { data: [{ embedding: number[] }] }
         return { data: [{ embedding: data.embedding }] };
     }
+    async embedWithVoyageFetch(payload, apiKey, signal) {
+        if (!this._baseURL) {
+            throw new Error("Voyage embedding provider requires embedding.baseURL, e.g. https://api.voyageai.com/v1");
+        }
+        const base = this._baseURL.replace(/\/$/, "");
+        const endpoint = base.endsWith("/embeddings") ? base : `${base}/embeddings`;
+        const response = await fetch(endpoint, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify(payload),
+            signal,
+        });
+        if (!response.ok) {
+            const body = await response.text().catch(() => "");
+            throw new Error(`Voyage embedding failed: ${response.status} ${response.statusText} ${body.slice(0, 200)}`);
+        }
+        return response.json();
+    }
     /**
      * Call embeddings.create with automatic key rotation on rate-limit errors.
      * Tries each key in the pool at most once before giving up.
@@ -575,8 +615,12 @@ export class Embedder {
         const maxAttempts = this.clients.length;
         let lastError;
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
-            const client = this.nextClient();
             try {
+                if (this.isVoyageProvider()) {
+                    const key = this.nextApiKey();
+                    return await this.embedWithVoyageFetch(payload, key, signal);
+                }
+                const client = this.nextClient();
                 // Pass signal to OpenAI SDK if provided (SDK v6+ supports this)
                 return await client.embeddings.create(payload, signal ? { signal } : undefined);
             }

--- a/dist/src/embedder.js
+++ b/dist/src/embedder.js
@@ -81,6 +81,17 @@ class EmbeddingCache {
         };
     }
 }
+class EmbeddingHttpError extends Error {
+    status;
+    statusCode;
+    constructor(provider, status, statusText, body) {
+        const detail = body.trim().slice(0, 200);
+        super(`${provider} embedding failed: ${status} ${statusText}${detail ? ` ${detail}` : ""}`);
+        this.name = "EmbeddingHttpError";
+        this.status = status;
+        this.statusCode = status;
+    }
+}
 // Known embedding model dimensions
 const EMBEDDING_DIMENSIONS = {
     "text-embedding-3-small": 1536,
@@ -129,10 +140,11 @@ function getErrorStatus(error) {
     if (typeof err.statusCode === "number")
         return err.statusCode;
     if (err.error && typeof err.error === "object") {
-        if (typeof err.error.status === "number")
-            return err.error.status;
-        if (typeof err.error.statusCode === "number")
-            return err.error.statusCode;
+        const nested = err.error;
+        if (typeof nested.status === "number")
+            return nested.status;
+        if (typeof nested.statusCode === "number")
+            return nested.statusCode;
     }
     return undefined;
 }
@@ -142,8 +154,10 @@ function getErrorCode(error) {
     const err = error;
     if (typeof err.code === "string")
         return err.code;
-    if (err.error && typeof err.error === "object" && typeof err.error.code === "string") {
-        return err.error.code;
+    if (err.error && typeof err.error === "object") {
+        const nested = err.error;
+        if (typeof nested.code === "string")
+            return nested.code;
     }
     return undefined;
 }
@@ -375,6 +389,7 @@ export class Embedder {
     _providerProfile;
     _capabilities;
     _apiKeys;
+    _clientTimeoutMs;
     /** Optional requested dimensions to pass through to the embedding provider (OpenAI-compatible). */
     _requestDimensions;
     /** When true, omit the dimensions parameter even if _requestDimensions is set. */
@@ -401,6 +416,7 @@ export class Embedder {
         const clientTimeoutMs = Number.isFinite(config.clientTimeoutMs) && config.clientTimeoutMs > 0
             ? Math.floor(config.clientTimeoutMs)
             : DEFAULT_EMBED_CLIENT_TIMEOUT_MS;
+        this._clientTimeoutMs = clientTimeoutMs;
         // Warn if configured fields will be silently ignored by this provider profile
         if (config.normalized !== undefined && !this._capabilities.normalized) {
             console.debug(`[memory-lancedb-pro] embedding.normalized is set but provider profile "${profile}" does not support it — value will be ignored`);
@@ -463,9 +479,10 @@ export class Embedder {
         // Nested error object (some providers)
         const nested = err.error;
         if (nested && typeof nested === "object") {
-            if (nested.type === "rate_limit_exceeded" || nested.type === "insufficient_quota")
+            const nestedError = nested;
+            if (nestedError.type === "rate_limit_exceeded" || nestedError.type === "insufficient_quota")
                 return true;
-            if (nested.code === "rate_limit_exceeded" || nested.code === "insufficient_quota")
+            if (nestedError.code === "rate_limit_exceeded" || nestedError.code === "insufficient_quota")
                 return true;
         }
         // Fallback: message text matching
@@ -491,6 +508,30 @@ export class Embedder {
     isVoyageProvider() {
         return this._providerProfile === "voyage-compatible";
     }
+    async fetchWithClientTimeout(input, init, options) {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs);
+        let unsubscribe;
+        if (options.signal) {
+            if (options.signal.aborted) {
+                clearTimeout(timeoutId);
+                throw new DOMException("The operation was aborted.", "AbortError");
+            }
+            const handler = () => controller.abort();
+            options.signal.addEventListener("abort", handler, { once: true });
+            unsubscribe = () => options.signal?.removeEventListener("abort", handler);
+        }
+        try {
+            return await fetch(input, {
+                ...init,
+                signal: controller.signal,
+            });
+        }
+        finally {
+            clearTimeout(timeoutId);
+            unsubscribe?.();
+        }
+    }
     /**
      * Call embeddings.create using native fetch (bypasses OpenAI SDK).
      * Used exclusively for Ollama endpoints where AbortController must work
@@ -515,7 +556,7 @@ export class Embedder {
         // If a model doesn't support that endpoint, failure will be silent from the user's perspective.
         // This is acceptable because most Ollama embedding models support /v1/embeddings.
         if (Array.isArray(payload.input)) {
-            const response = await fetch(base + "/v1/embeddings", {
+            const response = await this.fetchWithClientTimeout(base + "/v1/embeddings", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -528,11 +569,13 @@ export class Embedder {
                     // from buildPayload() are intentionally not included. Ollama embedding models
                     // do not support these parameters, so omitting them is correct.
                 }),
+            }, {
                 signal,
+                timeoutMs: this._clientTimeoutMs,
             });
             if (!response.ok) {
                 const body = await response.text().catch(() => "");
-                throw new Error(`Ollama batch embedding failed: ${response.status} ${response.statusText} ??${body.slice(0, 200)}`);
+                throw new EmbeddingHttpError("Ollama batch", response.status, response.statusText, body);
             }
             const data = await response.json();
             // Validate response count and non-empty embeddings
@@ -547,7 +590,7 @@ export class Embedder {
             return data;
         }
         // Single request: use /api/embeddings + prompt (PR #621 fix)
-        const response = await fetch(base + "/api/embeddings", {
+        const response = await this.fetchWithClientTimeout(base + "/api/embeddings", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
@@ -557,11 +600,13 @@ export class Embedder {
                 model: payload.model,
                 prompt: payload.input,
             }),
+        }, {
             signal,
+            timeoutMs: this._clientTimeoutMs,
         });
         if (!response.ok) {
             const body = await response.text().catch(() => "");
-            throw new Error(`Ollama embedding failed: ${response.status} ${response.statusText} ??${body.slice(0, 200)}`);
+            throw new EmbeddingHttpError("Ollama", response.status, response.statusText, body);
         }
         const data = await response.json();
         // Ollama /api/embeddings returns { embedding: number[] },
@@ -574,18 +619,20 @@ export class Embedder {
         }
         const base = this._baseURL.replace(/\/$/, "");
         const endpoint = base.endsWith("/embeddings") ? base : `${base}/embeddings`;
-        const response = await fetch(endpoint, {
+        const response = await this.fetchWithClientTimeout(endpoint, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
                 "Authorization": `Bearer ${apiKey}`,
             },
             body: JSON.stringify(payload),
+        }, {
             signal,
+            timeoutMs: this._clientTimeoutMs,
         });
         if (!response.ok) {
             const body = await response.text().catch(() => "");
-            throw new Error(`Voyage embedding failed: ${response.status} ${response.statusText} ${body.slice(0, 200)}`);
+            throw new EmbeddingHttpError("Voyage", response.status, response.statusText, body);
         }
         return response.json();
     }

--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -157,6 +157,43 @@ interface EmbeddingCapabilities {
   dimensionsField: string | null;
 }
 
+type EmbeddingRequestPayload = {
+  model: string;
+  input: string | string[];
+  encoding_format?: "float";
+  normalized?: boolean;
+  task?: string;
+  input_type?: string;
+  dimensions?: number;
+  output_dimension?: number;
+};
+
+type ProviderEmbeddingResponse = {
+  data: Array<{
+    embedding?: number[];
+  }>;
+};
+
+type NativeFetchOptions = {
+  signal?: AbortSignal;
+  timeoutMs: number;
+};
+
+type OpenAIEmbeddingCreatePayload = Parameters<OpenAI["embeddings"]["create"]>[0];
+
+class EmbeddingHttpError extends Error {
+  public readonly status: number;
+  public readonly statusCode: number;
+
+  constructor(provider: string, status: number, statusText: string, body: string) {
+    const detail = body.trim().slice(0, 200);
+    super(`${provider} embedding failed: ${status} ${statusText}${detail ? ` ${detail}` : ""}`);
+    this.name = "EmbeddingHttpError";
+    this.status = status;
+    this.statusCode = status;
+  }
+}
+
 // Known embedding model dimensions
 const EMBEDDING_DIMENSIONS: Record<string, number> = {
   "text-embedding-3-small": 1536,
@@ -205,22 +242,24 @@ function getErrorMessage(error: unknown): string {
 
 function getErrorStatus(error: unknown): number | undefined {
   if (!error || typeof error !== "object") return undefined;
-  const err = error as Record<string, any>;
+  const err = error as Record<string, unknown>;
   if (typeof err.status === "number") return err.status;
   if (typeof err.statusCode === "number") return err.statusCode;
   if (err.error && typeof err.error === "object") {
-    if (typeof err.error.status === "number") return err.error.status;
-    if (typeof err.error.statusCode === "number") return err.error.statusCode;
+    const nested = err.error as Record<string, unknown>;
+    if (typeof nested.status === "number") return nested.status;
+    if (typeof nested.statusCode === "number") return nested.statusCode;
   }
   return undefined;
 }
 
 function getErrorCode(error: unknown): string | undefined {
   if (!error || typeof error !== "object") return undefined;
-  const err = error as Record<string, any>;
+  const err = error as Record<string, unknown>;
   if (typeof err.code === "string") return err.code;
-  if (err.error && typeof err.error === "object" && typeof err.error.code === "string") {
-    return err.error.code;
+  if (err.error && typeof err.error === "object") {
+    const nested = err.error as Record<string, unknown>;
+    if (typeof nested.code === "string") return nested.code;
   }
   return undefined;
 }
@@ -480,6 +519,7 @@ export class Embedder {
   private readonly _providerProfile: EmbeddingProviderProfile;
   private readonly _capabilities: EmbeddingCapabilities;
   private readonly _apiKeys: string[];
+  private readonly _clientTimeoutMs: number;
 
   /** Optional requested dimensions to pass through to the embedding provider (OpenAI-compatible). */
   private readonly _requestDimensions?: number;
@@ -509,6 +549,7 @@ export class Embedder {
     const clientTimeoutMs = Number.isFinite(config.clientTimeoutMs) && config.clientTimeoutMs! > 0
       ? Math.floor(config.clientTimeoutMs!)
       : DEFAULT_EMBED_CLIENT_TIMEOUT_MS;
+    this._clientTimeoutMs = clientTimeoutMs;
 
     // Warn if configured fields will be silently ignored by this provider profile
     if (config.normalized !== undefined && !this._capabilities.normalized) {
@@ -579,7 +620,7 @@ export class Embedder {
   private isRateLimitError(error: unknown): boolean {
     if (!error || typeof error !== "object") return false;
 
-    const err = error as Record<string, any>;
+    const err = error as Record<string, unknown>;
 
     // HTTP status: 429 (rate limit) or 503 (service overload)
     if (err.status === 429 || err.status === 503) return true;
@@ -590,8 +631,9 @@ export class Embedder {
     // Nested error object (some providers)
     const nested = err.error;
     if (nested && typeof nested === "object") {
-      if (nested.type === "rate_limit_exceeded" || nested.type === "insufficient_quota") return true;
-      if (nested.code === "rate_limit_exceeded" || nested.code === "insufficient_quota") return true;
+      const nestedError = nested as Record<string, unknown>;
+      if (nestedError.type === "rate_limit_exceeded" || nestedError.type === "insufficient_quota") return true;
+      if (nestedError.code === "rate_limit_exceeded" || nestedError.code === "insufficient_quota") return true;
     }
 
     // Fallback: message text matching
@@ -619,6 +661,37 @@ export class Embedder {
     return this._providerProfile === "voyage-compatible";
   }
 
+  private async fetchWithClientTimeout(
+    input: string,
+    init: RequestInit,
+    options: NativeFetchOptions,
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs);
+    let unsubscribe: (() => void) | undefined;
+
+    if (options.signal) {
+      if (options.signal.aborted) {
+        clearTimeout(timeoutId);
+        throw new DOMException("The operation was aborted.", "AbortError");
+      }
+
+      const handler = () => controller.abort();
+      options.signal.addEventListener("abort", handler, { once: true });
+      unsubscribe = () => options.signal?.removeEventListener("abort", handler);
+    }
+
+    try {
+      return await fetch(input, {
+        ...init,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+      unsubscribe?.();
+    }
+  }
+
   /**
    * Call embeddings.create using native fetch (bypasses OpenAI SDK).
    * Used exclusively for Ollama endpoints where AbortController must work
@@ -632,7 +705,7 @@ export class Embedder {
    * See: https://github.com/CortexReach/memory-lancedb-pro/issues/620
    * Fix: https://github.com/CortexReach/memory-lancedb-pro/issues/629
    */
-  private async embedWithNativeFetch(payload: any, signal?: AbortSignal): Promise<any> {
+  private async embedWithNativeFetch(payload: EmbeddingRequestPayload, signal?: AbortSignal): Promise<ProviderEmbeddingResponse> {
     if (!this._baseURL) {
       throw new Error("embedWithNativeFetch requires a baseURL");
     }
@@ -645,7 +718,7 @@ export class Embedder {
     // If a model doesn't support that endpoint, failure will be silent from the user's perspective.
     // This is acceptable because most Ollama embedding models support /v1/embeddings.
     if (Array.isArray(payload.input)) {
-      const response = await fetch(base + "/v1/embeddings", {
+      const response = await this.fetchWithClientTimeout(base + "/v1/embeddings", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -658,23 +731,23 @@ export class Embedder {
           // from buildPayload() are intentionally not included. Ollama embedding models
           // do not support these parameters, so omitting them is correct.
         }),
+      }, {
         signal,
+        timeoutMs: this._clientTimeoutMs,
       });
 
       if (!response.ok) {
         const body = await response.text().catch(() => "");
-        throw new Error(
-          `Ollama batch embedding failed: ${response.status} ${response.statusText} ??${body.slice(0, 200)}`
-        );
+        throw new EmbeddingHttpError("Ollama batch", response.status, response.statusText, body);
       }
 
-      const data = await response.json() as any;
+      const data = await response.json() as ProviderEmbeddingResponse;
 
       // Validate response count and non-empty embeddings
       if (
         !Array.isArray(data?.data) ||
         data.data.length !== payload.input.length ||
-        data.data.some((item: any) => {
+        data.data.some((item) => {
           const embedding = item?.embedding;
           return !Array.isArray(embedding) || embedding.length === 0;
         })
@@ -688,7 +761,7 @@ export class Embedder {
     }
 
     // Single request: use /api/embeddings + prompt (PR #621 fix)
-    const response = await fetch(base + "/api/embeddings", {
+    const response = await this.fetchWithClientTimeout(base + "/api/embeddings", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -698,24 +771,24 @@ export class Embedder {
         model: payload.model,
         prompt: payload.input,
       }),
+    }, {
       signal,
+      timeoutMs: this._clientTimeoutMs,
     });
 
     if (!response.ok) {
       const body = await response.text().catch(() => "");
-      throw new Error(
-        `Ollama embedding failed: ${response.status} ${response.statusText} ??${body.slice(0, 200)}`
-      );
+      throw new EmbeddingHttpError("Ollama", response.status, response.statusText, body);
     }
 
-    const data = await response.json() as any;
+    const data = await response.json() as { embedding?: number[] };
 
     // Ollama /api/embeddings returns { embedding: number[] },
     // convert to OpenAI-compatible shape { data: [{ embedding: number[] }] }
     return { data: [{ embedding: data.embedding }] };
   }
 
-  private async embedWithVoyageFetch(payload: any, apiKey: string, signal?: AbortSignal): Promise<any> {
+  private async embedWithVoyageFetch(payload: EmbeddingRequestPayload, apiKey: string, signal?: AbortSignal): Promise<ProviderEmbeddingResponse> {
     if (!this._baseURL) {
       throw new Error(
         "Voyage embedding provider requires embedding.baseURL, e.g. https://api.voyageai.com/v1"
@@ -724,24 +797,24 @@ export class Embedder {
 
     const base = this._baseURL.replace(/\/$/, "");
     const endpoint = base.endsWith("/embeddings") ? base : `${base}/embeddings`;
-    const response = await fetch(endpoint, {
+    const response = await this.fetchWithClientTimeout(endpoint, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${apiKey}`,
       },
       body: JSON.stringify(payload),
+    }, {
       signal,
+      timeoutMs: this._clientTimeoutMs,
     });
 
     if (!response.ok) {
       const body = await response.text().catch(() => "");
-      throw new Error(
-        `Voyage embedding failed: ${response.status} ${response.statusText} ${body.slice(0, 200)}`
-      );
+      throw new EmbeddingHttpError("Voyage", response.status, response.statusText, body);
     }
 
-    return response.json();
+    return response.json() as Promise<ProviderEmbeddingResponse>;
   }
 
   /**
@@ -753,7 +826,7 @@ export class Embedder {
    * because AbortController does not reliably abort Ollama's HTTP connections
    * through the SDK's HTTP client on Node.js.
    */
-  private async embedWithRetry(payload: any, signal?: AbortSignal): Promise<any> {
+  private async embedWithRetry(payload: EmbeddingRequestPayload, signal?: AbortSignal): Promise<ProviderEmbeddingResponse> {
     // Use native fetch for Ollama to ensure proper AbortController support
     if (this.isOllamaProvider()) {
       try {
@@ -779,7 +852,10 @@ export class Embedder {
 
         const client = this.nextClient();
         // Pass signal to OpenAI SDK if provided (SDK v6+ supports this)
-        return await client.embeddings.create(payload, signal ? { signal } : undefined);
+        return await client.embeddings.create(
+          payload as OpenAIEmbeddingCreatePayload,
+          signal ? { signal } : undefined,
+        );
       } catch (error) {
         // If aborted, re-throw immediately
         if (error instanceof Error && error.name === 'AbortError') {
@@ -899,8 +975,8 @@ export class Embedder {
     }
   }
 
-  private buildPayload(input: string | string[], task?: string): any {
-    const payload: any = {
+  private buildPayload(input: string | string[], task?: string): EmbeddingRequestPayload {
+    const payload: EmbeddingRequestPayload = {
       model: this.model,
       input,
     };

--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -312,6 +312,7 @@ function getEmbeddingCapabilities(profile: EmbeddingProviderProfile): EmbeddingC
           "retrieval.query": "query",
           "retrieval.passage": "document",
           "query": "query",
+          "passage": "document",
           "document": "document",
         },
         dimensionsField: "output_dimension",
@@ -476,7 +477,9 @@ export class Embedder {
   private readonly _taskQuery?: string;
   private readonly _taskPassage?: string;
   private readonly _normalized?: boolean;
+  private readonly _providerProfile: EmbeddingProviderProfile;
   private readonly _capabilities: EmbeddingCapabilities;
+  private readonly _apiKeys: string[];
 
   /** Optional requested dimensions to pass through to the embedding provider (OpenAI-compatible). */
   private readonly _requestDimensions?: number;
@@ -489,6 +492,7 @@ export class Embedder {
     // Normalize apiKey to array and resolve environment variables
     const apiKeys = Array.isArray(config.apiKey) ? config.apiKey : [config.apiKey];
     const resolvedKeys = apiKeys.map(k => resolveEnvVars(k));
+    this._apiKeys = resolvedKeys;
 
     this._model = config.model;
     this._baseURL = config.baseURL;
@@ -500,6 +504,7 @@ export class Embedder {
     // Enable auto-chunking by default for better handling of long documents
     this._autoChunk = config.chunking !== false;
     const profile = detectEmbeddingProviderProfile(this._baseURL, this._model);
+    this._providerProfile = profile;
     this._capabilities = getEmbeddingCapabilities(profile);
     const clientTimeoutMs = Number.isFinite(config.clientTimeoutMs) && config.clientTimeoutMs! > 0
       ? Math.floor(config.clientTimeoutMs!)
@@ -563,6 +568,13 @@ export class Embedder {
     return client;
   }
 
+  /** Return the next raw API key in the same round-robin order as clients. */
+  private nextApiKey(): string {
+    const key = this._apiKeys[this._clientIndex % this._apiKeys.length];
+    this._clientIndex = (this._clientIndex + 1) % this._apiKeys.length;
+    return key;
+  }
+
   /** Check whether an error is a rate-limit / quota-exceeded / overload error. */
   private isRateLimitError(error: unknown): boolean {
     if (!error || typeof error !== "object") return false;
@@ -596,6 +608,15 @@ export class Embedder {
   private isOllamaProvider(): boolean {
     if (!this._baseURL) return false;
     return /localhost:11434|127\.0\.0\.1:11434|\/ollama\b/i.test(this._baseURL);
+  }
+
+  /**
+   * Voyage's embeddings endpoint rejects OpenAI SDK-injected request fields such
+   * as encoding_format. Use native fetch for Voyage so buildPayload() remains
+   * the exact serialized request body.
+   */
+  private isVoyageProvider(): boolean {
+    return this._providerProfile === "voyage-compatible";
   }
 
   /**
@@ -694,6 +715,35 @@ export class Embedder {
     return { data: [{ embedding: data.embedding }] };
   }
 
+  private async embedWithVoyageFetch(payload: any, apiKey: string, signal?: AbortSignal): Promise<any> {
+    if (!this._baseURL) {
+      throw new Error(
+        "Voyage embedding provider requires embedding.baseURL, e.g. https://api.voyageai.com/v1"
+      );
+    }
+
+    const base = this._baseURL.replace(/\/$/, "");
+    const endpoint = base.endsWith("/embeddings") ? base : `${base}/embeddings`;
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(payload),
+      signal,
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `Voyage embedding failed: ${response.status} ${response.statusText} ${body.slice(0, 200)}`
+      );
+    }
+
+    return response.json();
+  }
+
   /**
    * Call embeddings.create with automatic key rotation on rate-limit errors.
    * Tries each key in the pool at most once before giving up.
@@ -721,8 +771,13 @@ export class Embedder {
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const client = this.nextClient();
       try {
+        if (this.isVoyageProvider()) {
+          const key = this.nextApiKey();
+          return await this.embedWithVoyageFetch(payload, key, signal);
+        }
+
+        const client = this.nextClient();
         // Pass signal to OpenAI SDK if provided (SDK v6+ supports this)
         return await client.embeddings.create(payload, signal ? { signal } : undefined);
       } catch (error) {

--- a/test/embedder-error-hints.test.mjs
+++ b/test/embedder-error-hints.test.mjs
@@ -271,6 +271,64 @@ async function run() {
     },
   );
 
+  // Voyage native fetch must preserve the configured client timeout for batch
+  // calls, since batch embeddings are intentionally not wrapped by the global
+  // per-text timeout.
+  await withEmbeddingCaptureServer(
+    async () => {
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      return { body: createEmbeddingResponse(1024) };
+    },
+    async ({ baseURL }) => {
+      const embedder = new Embedder({
+        provider: "openai-compatible",
+        apiKey: "test-key",
+        model: "voyage-4",
+        baseURL,
+        clientTimeoutMs: 25,
+      });
+
+      await expectReject(
+        () => embedder.embedBatchPassage(["timeout voyage"]),
+        /aborted|abort/i,
+      );
+    },
+  );
+
+  // Voyage native fetch should use the same retry/key-rotation behavior as the
+  // SDK path when providers respond with overload/rate-limit statuses.
+  {
+    const authorizations = [];
+    await withEmbeddingCaptureServer(
+      (payload, req) => {
+        authorizations.push(req.headers.authorization);
+        if (authorizations.length === 1) {
+          return {
+            status: 503,
+            body: { error: { message: "provider overloaded" } },
+          };
+        }
+
+        assert.deepEqual(payload.input, ["rotate voyage"]);
+        return { body: createEmbeddingResponse(1024, 0.3) };
+      },
+      async ({ baseURL }) => {
+        const embedder = new Embedder({
+          provider: "openai-compatible",
+          apiKey: ["voyage-key-a", "voyage-key-b"],
+          model: "voyage-4",
+          baseURL,
+        });
+
+        const embeddings = await embedder.embedBatchPassage(["rotate voyage"]);
+        assert.equal(embeddings.length, 1);
+        assert.equal(embeddings[0].length, 1024);
+      },
+    );
+
+    assert.deepEqual(authorizations, ["Bearer voyage-key-a", "Bearer voyage-key-b"]);
+  }
+
   // End-to-end HTTP payload verification for generic-openai-compatible profile.
   // Unlike the mock tests above, this spins up a real HTTP server and verifies
   // the actual request body sent by the OpenAI SDK.

--- a/test/embedder-error-hints.test.mjs
+++ b/test/embedder-error-hints.test.mjs
@@ -100,25 +100,47 @@ async function expectReject(promiseFactory, pattern) {
   }
 }
 
+async function expectVoyagePayload(config, callEmbedder, assertPayload, dimensions = 1024) {
+  await withEmbeddingCaptureServer(
+    (payload) => {
+      assertPayload(payload);
+      const inputs = Array.isArray(payload.input) ? payload.input : [payload.input];
+      return {
+        body: {
+          data: inputs.map((_, index) => ({
+            object: "embedding",
+            index,
+            embedding: new Array(dimensions).fill(0.2),
+          })),
+        },
+      };
+    },
+    async ({ baseURL }) => {
+      const embedder = new Embedder({
+        provider: "openai-compatible",
+        apiKey: "test-key",
+        ...config,
+        baseURL,
+      });
+      await callEmbedder(embedder);
+    },
+  );
+}
+
 async function run() {
   assert.equal(getVectorDimensions("voyage-4-lite"), 1024);
   assert.equal(getVectorDimensions("voyage-3-large"), 1024);
   assert.equal(getVectorDimensions("bge-m3"), 1024);
   assert.equal(getVectorDimensions("BAAI/bge-m3"), 1024);
 
-  const voyageEmbedder = new Embedder({
-    provider: "openai-compatible",
-    apiKey: "test-key",
-    model: "voyage-3-lite",
-    baseURL: "https://api.voyageai.com/v1",
-    dimensions: 1024,
-  });
-  installMockEmbeddingClient(voyageEmbedder, async (payload) => {
-    assert.notEqual(payload.encoding_format, "float");
-    assert.equal(payload.dimensions, undefined);
-    return createEmbeddingResponse(1024);
-  });
-  await voyageEmbedder.embedPassage("hello");
+  await expectVoyagePayload(
+    { model: "voyage-3-lite", dimensions: 1024 },
+    (embedder) => embedder.embedPassage("hello"),
+    (payload) => {
+      assert.equal(payload.encoding_format, undefined, "voyage should not send encoding_format");
+      assert.equal(payload.dimensions, undefined, "voyage should not send dimensions");
+    },
+  );
 
   const jinaEmbedder = new Embedder({
     provider: "openai-compatible",
@@ -153,59 +175,101 @@ async function run() {
 
   // voyage-4 should be detected as voyage-compatible via model name prefix,
   // even when baseURL is NOT api.voyageai.com (e.g. behind a proxy).
-  const voyageProxyEmbedder = new Embedder({
-    provider: "openai-compatible",
-    apiKey: "test-key",
-    model: "voyage-4",
-    baseURL: "https://proxy.example.invalid/v1",
-    dimensions: 1024,
-  });
-  installMockEmbeddingClient(voyageProxyEmbedder, async (payload) => {
-    assert.notEqual(payload.encoding_format, "float", "voyage-4 should not send encoding_format");
-    assert.equal(payload.dimensions, undefined, "voyage-4 should not send dimensions");
-    return createEmbeddingResponse(1024);
-  });
-  await voyageProxyEmbedder.embedPassage("hello");
+  await expectVoyagePayload(
+    { model: "voyage-4", dimensions: 1024 },
+    (embedder) => embedder.embedPassage("hello"),
+    (payload) => {
+      assert.equal(payload.encoding_format, undefined, "voyage-4 should not send encoding_format");
+      assert.equal(payload.dimensions, undefined, "voyage-4 should not send dimensions");
+    },
+  );
 
   // Voyage: taskPassage "retrieval.passage" → input_type "document"
   //         taskQuery  "retrieval.query"   → input_type "query"
-  const voyageTaskEmbedder = new Embedder({
-    provider: "openai-compatible",
-    apiKey: "test-key",
-    model: "voyage-3-lite",
-    baseURL: "https://api.voyageai.com/v1",
-    dimensions: 1024,
-    taskPassage: "retrieval.passage",
-    taskQuery: "retrieval.query",
-  });
-  installMockEmbeddingClient(voyageTaskEmbedder, async (payload) => {
-    assert.equal(payload.input_type, "document", "voyage taskPassage should map to input_type=document");
-    assert.equal(payload.task, undefined, "voyage should not send task field");
-    return createEmbeddingResponse(1024);
-  });
-  await voyageTaskEmbedder.embedPassage("hello");
+  await expectVoyagePayload(
+    {
+      model: "voyage-3-lite",
+      dimensions: 1024,
+      taskPassage: "retrieval.passage",
+      taskQuery: "retrieval.query",
+    },
+    (embedder) => embedder.embedPassage("hello"),
+    (payload) => {
+      assert.equal(payload.input_type, "document", "voyage taskPassage should map to input_type=document");
+      assert.equal(payload.task, undefined, "voyage should not send task field");
+    },
+  );
 
-  installMockEmbeddingClient(voyageTaskEmbedder, async (payload) => {
-    assert.equal(payload.input_type, "query", "voyage taskQuery should map to input_type=query");
-    return createEmbeddingResponse(1024);
-  });
-  await voyageTaskEmbedder.embedQuery("hello");
+  await expectVoyagePayload(
+    {
+      model: "voyage-3-lite",
+      dimensions: 1024,
+      taskPassage: "retrieval.passage",
+      taskQuery: "retrieval.query",
+    },
+    (embedder) => embedder.embedQuery("hello"),
+    (payload) => {
+      assert.equal(payload.input_type, "query", "voyage taskQuery should map to input_type=query");
+    },
+  );
+
+  await expectVoyagePayload(
+    { model: "voyage-4", dimensions: 1024, taskPassage: "passage" },
+    (embedder) => embedder.embedPassage("hello"),
+    (payload) => {
+      assert.equal(payload.input_type, "document", "voyage taskPassage=passage should map to input_type=document");
+    },
+  );
 
   // Voyage: configured dimensions should be sent as output_dimension, not dimensions.
   // voyage-4-lite is a recommended Voyage model that supports output_dimension.
-  const voyageDimEmbedder = new Embedder({
-    provider: "openai-compatible",
-    apiKey: "test-key",
-    model: "voyage-4-lite",
-    baseURL: "https://api.voyageai.com/v1",
-    requestDimensions: 512,
-  });
-  installMockEmbeddingClient(voyageDimEmbedder, async (payload) => {
-    assert.equal(payload.output_dimension, 512, "voyage should send output_dimension");
-    assert.equal(payload.dimensions, undefined, "voyage should not send dimensions");
-    return createEmbeddingResponse(512);
-  });
-  await voyageDimEmbedder.embedPassage("hello");
+  await expectVoyagePayload(
+    { model: "voyage-4-lite", requestDimensions: 512 },
+    (embedder) => embedder.embedPassage("hello"),
+    (payload) => {
+      assert.equal(payload.output_dimension, 512, "voyage should send output_dimension");
+      assert.equal(payload.dimensions, undefined, "voyage should not send dimensions");
+    },
+    512,
+  );
+
+  // End-to-end HTTP payload verification for Voyage-compatible models through
+  // the native Voyage path. The local server uses a proxy-like baseURL, so this
+  // exercises model-prefix detection while capturing the serialized body.
+  await withEmbeddingCaptureServer(
+    (payload) => {
+      assert.equal(payload.model, "voyage-4-large");
+      assert.deepEqual(payload.input, ["hello voyage"]);
+      assert.equal(payload.input_type, "document", "voyage passage task should be sent as document");
+      assert.equal(payload.output_dimension, 512, "voyage should send output_dimension");
+      assert.equal(payload.encoding_format, undefined, "voyage should not send OpenAI encoding_format");
+      assert.equal(payload.dimensions, undefined, "voyage should not send OpenAI dimensions");
+      assert.equal(payload.task, undefined, "voyage should not send Jina task field");
+      assert.equal(payload.normalized, undefined, "voyage should not send Jina normalized field");
+      return {
+        body: {
+          data: payload.input.map((_, index) => ({
+            object: "embedding",
+            index,
+            embedding: new Array(512).fill(0.2),
+          })),
+        },
+      };
+    },
+    async ({ baseURL }) => {
+      const embedder = new Embedder({
+        provider: "openai-compatible",
+        apiKey: "test-key",
+        model: "voyage-4-large",
+        baseURL,
+        requestDimensions: 512,
+        taskPassage: "retrieval.passage",
+      });
+      const embeddings = await embedder.embedBatchPassage(["hello voyage"]);
+      assert.equal(embeddings.length, 1);
+      assert.equal(embeddings[0].length, 512);
+    },
+  );
 
   // End-to-end HTTP payload verification for generic-openai-compatible profile.
   // Unlike the mock tests above, this spins up a real HTTP server and verifies


### PR DESCRIPTION
## Summary
- use native fetch for Voyage embedding requests so OpenAI-only fields are not injected
- map Voyage task and dimension options to input_type and output_dimension
- add mocked payload coverage and document the provider-specific behavior

Fixes #379

## Tests
- `node test/embedder-error-hints.test.mjs`
- `npm run build`