### PR TITLE
fix: batch supersede creates through bulk store

### DIFF
--- a/dist/src/smart-extractor.js
+++ b/dist/src/smart-extractor.js
@@ -285,16 +285,23 @@ export class SmartExtractor {
             }
         }
         const createEntries = [];
+        const pendingSupersedeInvalidations = [];
         for (const { index, candidate } of processableCandidates) {
             try {
-                await this.processCandidate(candidate, conversationText, sessionKey, stats, targetScope, scopeFilter, precomputedVectors.get(index), createEntries);
+                await this.processCandidate(candidate, conversationText, sessionKey, stats, targetScope, scopeFilter, precomputedVectors.get(index), createEntries, pendingSupersedeInvalidations);
             }
             catch (err) {
                 this.log(`memory-pro: smart-extractor: failed to process candidate [${candidate.category}]: ${String(err)}`);
             }
         }
         if (createEntries.length > 0) {
-            await this.bulkStoreAndValidate(createEntries);
+            const createdEntries = await this.bulkStoreAndValidate(createEntries);
+            if (createdEntries) {
+                await this.applyPendingSupersedeInvalidations(createdEntries, pendingSupersedeInvalidations);
+            }
+            else if (pendingSupersedeInvalidations.length > 0) {
+                this.log("memory-pro: smart-extractor: supersede invalidation skipped because bulkStore() did not return created entries");
+            }
         }
         return stats;
     }
@@ -306,29 +313,30 @@ export class SmartExtractor {
         const storedEntries = await this.store.bulkStore(entries);
         if (!Array.isArray(storedEntries)) {
             this.debugLog("memory-pro: smart-extractor: skipping bulkStore persistence validation: bulkStore() did not return stored entries");
-            return;
+            return undefined;
         }
         if (storedEntries.length !== entries.length) {
             this.log(`memory-pro: smart-extractor: bulkStore validation warning: queued ${entries.length} create(s) but bulkStore accepted ${storedEntries.length}`);
         }
         if (storedEntries.length === 0) {
-            return;
+            return storedEntries;
         }
         const afterCount = await this.readStoreCount("after bulkStore");
         if (beforeCount === null || afterCount === null) {
-            return;
+            return storedEntries;
         }
         const observedDelta = afterCount - beforeCount;
         if (observedDelta >= storedEntries.length) {
-            return;
+            return storedEntries;
         }
         const missingIds = await this.findMissingStoredIds(storedEntries);
         if (missingIds.length === 0) {
             this.debugLog(`memory-pro: smart-extractor: bulkStore row-count delta ${observedDelta}/${storedEntries.length} but all returned IDs are readable; likely concurrent delete/compaction`);
-            return;
+            return storedEntries;
         }
         const sample = missingIds.slice(0, 3).map((id) => id.slice(0, 8)).join(", ");
         this.log(`memory-pro: smart-extractor: bulkStore validation warning: expected row delta >= ${storedEntries.length}, observed ${observedDelta} (before=${beforeCount}, after=${afterCount}); missing returned IDs=${missingIds.length}${sample ? ` sample=${sample}` : ""}`);
+        return storedEntries;
     }
     async readStoreCount(context) {
         const count = this.store.count;
@@ -529,7 +537,7 @@ export class SmartExtractor {
      *   When provided (from batch pre-embedding), skips the per-candidate embed
      *   call to reduce API round-trips.
      */
-    async processCandidate(candidate, conversationText, sessionKey, stats, targetScope, scopeFilter, precomputedVector, createEntries) {
+    async processCandidate(candidate, conversationText, sessionKey, stats, targetScope, scopeFilter, precomputedVector, createEntries, pendingSupersedeInvalidations) {
         // Profile always merges (skip dedup — admission control still applies)
         if (ALWAYS_MERGE_CATEGORIES.has(candidate.category)) {
             const profileResult = await this.handleProfileMerge(candidate, conversationText, sessionKey, targetScope, scopeFilter, undefined, createEntries);
@@ -594,7 +602,7 @@ export class SmartExtractor {
             case "supersede":
                 if (dedupResult.matchId &&
                     TEMPORAL_VERSIONED_CATEGORIES.has(candidate.category)) {
-                    await this.handleSupersede(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, admission?.audit, createEntries);
+                    await this.handleSupersede(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, admission?.audit, createEntries, pendingSupersedeInvalidations);
                     stats.created++;
                     stats.superseded = (stats.superseded ?? 0) + 1;
                 }
@@ -627,7 +635,7 @@ export class SmartExtractor {
                 if (dedupResult.matchId) {
                     if (TEMPORAL_VERSIONED_CATEGORIES.has(candidate.category) &&
                         dedupResult.contextLabel === "general") {
-                        await this.handleSupersede(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, admission?.audit, createEntries);
+                        await this.handleSupersede(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, admission?.audit, createEntries, pendingSupersedeInvalidations);
                         stats.created++;
                         stats.superseded = (stats.superseded ?? 0) + 1;
                     }
@@ -852,7 +860,7 @@ export class SmartExtractor {
      * Handle SUPERSEDE: preserve the old record as historical but mark it as no
      * longer current, then create the new active fact.
      */
-    async handleSupersede(candidate, vector, matchId, sessionKey, targetScope, scopeFilter, admissionAudit, createEntries) {
+    async handleSupersede(candidate, vector, matchId, sessionKey, targetScope, scopeFilter, admissionAudit, createEntries, pendingSupersedeInvalidations) {
         const existing = await this.store.getById(matchId, scopeFilter);
         if (!existing) {
             createEntries?.push(this.buildStoreEntry(candidate, vector || [], sessionKey, targetScope));
@@ -863,7 +871,7 @@ export class SmartExtractor {
         const factKey = existingMeta.fact_key ?? deriveFactKey(candidate.category, candidate.abstract);
         const storeCategory = this.mapToStoreCategory(candidate.category);
         const supersedeClassifyText = candidate.content || candidate.abstract;
-        const created = await this.store.store({
+        const entry = {
             text: candidate.abstract,
             vector,
             category: storeCategory,
@@ -897,18 +905,46 @@ export class SmartExtractor {
                 memory_temporal_type: classifyTemporal(supersedeClassifyText),
                 valid_until: inferExpiry(supersedeClassifyText),
             })),
-        });
+        };
+        if (createEntries && pendingSupersedeInvalidations) {
+            const entryIndex = createEntries.length;
+            createEntries.push(entry);
+            pendingSupersedeInvalidations.push({
+                entryIndex,
+                matchId,
+                existing,
+                factKey,
+                scopeFilter,
+            });
+            return;
+        }
+        const created = await this.store.store(entry);
+        await this.invalidateSupersededMemory(matchId, existing, factKey, created.id, scopeFilter);
+        this.log(`memory-pro: smart-extractor: superseded [${candidate.category}] ${matchId.slice(0, 8)} -> ${created.id.slice(0, 8)}`);
+    }
+    async applyPendingSupersedeInvalidations(createdEntries, pendingSupersedeInvalidations) {
+        for (const pending of pendingSupersedeInvalidations) {
+            const created = createdEntries[pending.entryIndex];
+            if (!created) {
+                this.log(`memory-pro: smart-extractor: supersede invalidation skipped for ${pending.matchId.slice(0, 8)} because batch create returned no matching entry`);
+                continue;
+            }
+            await this.invalidateSupersededMemory(pending.matchId, pending.existing, pending.factKey, created.id, pending.scopeFilter);
+            this.log(`memory-pro: smart-extractor: superseded ${pending.matchId.slice(0, 8)} -> ${created.id.slice(0, 8)}`);
+        }
+    }
+    async invalidateSupersededMemory(matchId, existing, factKey, createdId, scopeFilter) {
+        const existingMeta = parseSmartMetadata(existing.metadata, existing);
         const invalidatedMetadata = buildSmartMetadata(existing, {
             fact_key: factKey,
-            invalidated_at: now,
-            superseded_by: created.id,
+            invalidated_at: Date.now(),
+            superseded_by: createdId,
             relations: appendRelation(existingMeta.relations, {
                 type: "superseded_by",
-                targetId: created.id,
+                targetId: createdId,
             }),
         });
         await this.store.update(matchId, { metadata: stringifySmartMetadata(invalidatedMetadata) }, scopeFilter);
-        this.log(`memory-pro: smart-extractor: superseded [${candidate.category}] ${matchId.slice(0, 8)} -> ${created.id.slice(0, 8)}`);
     }
     // --------------------------------------------------------------------------
     // Context-Aware Handlers (support / contextualize / contradict)

--- a/src/smart-extractor.ts
+++ b/src/smart-extractor.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import type { MemoryStore, MemorySearchResult } from "./store.js";
+import type { MemoryStore, MemoryEntry, MemorySearchResult } from "./store.js";
 import type { Embedder } from "./embedder.js";
 import type { LlmClient } from "./llm-client.js";
 import {
@@ -53,6 +53,13 @@ import { inferAtomicBrandItemPreferenceSlot } from "./preference-slots.js";
 import { batchDedup } from "./batch-dedup.js";
 
 type StoreEntry = Omit<import("./store.js").MemoryEntry, "id" | "timestamp">;
+type PendingSupersedeInvalidation = {
+  entryIndex: number;
+  matchId: string;
+  existing: MemoryEntry;
+  factKey: string;
+  scopeFilter?: string[];
+};
 
 // ============================================================================
 // Envelope Metadata Stripping
@@ -419,7 +426,8 @@ export class SmartExtractor {
       }
     }
 
-    const createEntries: Omit<import("./store.js").MemoryEntry, "id" | "timestamp">[] = [];
+    const createEntries: StoreEntry[] = [];
+    const pendingSupersedeInvalidations: PendingSupersedeInvalidation[] = [];
 
     for (const { index, candidate } of processableCandidates) {
       try {
@@ -432,6 +440,7 @@ export class SmartExtractor {
           scopeFilter,
           precomputedVectors.get(index),
           createEntries,
+          pendingSupersedeInvalidations,
         );
       } catch (err) {
         this.log(
@@ -441,7 +450,17 @@ export class SmartExtractor {
     }
 
     if (createEntries.length > 0) {
-      await this.bulkStoreAndValidate(createEntries);
+      const createdEntries = await this.bulkStoreAndValidate(createEntries);
+      if (createdEntries) {
+        await this.applyPendingSupersedeInvalidations(
+          createdEntries,
+          pendingSupersedeInvalidations,
+        );
+      } else if (pendingSupersedeInvalidations.length > 0) {
+        this.log(
+          "memory-pro: smart-extractor: supersede invalidation skipped because bulkStore() did not return created entries",
+        );
+      }
     }
 
     return stats;
@@ -451,7 +470,7 @@ export class SmartExtractor {
   // Embedding Noise Pre-Filter
   // --------------------------------------------------------------------------
 
-  private async bulkStoreAndValidate(entries: StoreEntry[]): Promise<void> {
+  private async bulkStoreAndValidate(entries: StoreEntry[]): Promise<MemoryEntry[] | undefined> {
     const beforeCount = await this.readStoreCount("before bulkStore");
     const storedEntries = await this.store.bulkStore(entries);
 
@@ -459,7 +478,7 @@ export class SmartExtractor {
       this.debugLog(
         "memory-pro: smart-extractor: skipping bulkStore persistence validation: bulkStore() did not return stored entries",
       );
-      return;
+      return undefined;
     }
 
     if (storedEntries.length !== entries.length) {
@@ -469,17 +488,17 @@ export class SmartExtractor {
     }
 
     if (storedEntries.length === 0) {
-      return;
+      return storedEntries;
     }
 
     const afterCount = await this.readStoreCount("after bulkStore");
     if (beforeCount === null || afterCount === null) {
-      return;
+      return storedEntries;
     }
 
     const observedDelta = afterCount - beforeCount;
     if (observedDelta >= storedEntries.length) {
-      return;
+      return storedEntries;
     }
 
     const missingIds = await this.findMissingStoredIds(storedEntries);
@@ -487,13 +506,14 @@ export class SmartExtractor {
       this.debugLog(
         `memory-pro: smart-extractor: bulkStore row-count delta ${observedDelta}/${storedEntries.length} but all returned IDs are readable; likely concurrent delete/compaction`,
       );
-      return;
+      return storedEntries;
     }
 
     const sample = missingIds.slice(0, 3).map((id) => id.slice(0, 8)).join(", ");
     this.log(
       `memory-pro: smart-extractor: bulkStore validation warning: expected row delta >= ${storedEntries.length}, observed ${observedDelta} (before=${beforeCount}, after=${afterCount}); missing returned IDs=${missingIds.length}${sample ? ` sample=${sample}` : ""}`,
     );
+    return storedEntries;
   }
 
   private async readStoreCount(context: string): Promise<number | null> {
@@ -763,6 +783,7 @@ export class SmartExtractor {
     scopeFilter?: string[],
     precomputedVector?: number[],
     createEntries?: Omit<import("./store.js").MemoryEntry, "id" | "timestamp">[],
+    pendingSupersedeInvalidations?: PendingSupersedeInvalidation[],
   ): Promise<void> {
     // Profile always merges (skip dedup — admission control still applies)
     if (ALWAYS_MERGE_CATEGORIES.has(candidate.category)) {
@@ -873,6 +894,7 @@ export class SmartExtractor {
             scopeFilter,
             admission?.audit,
             createEntries,
+            pendingSupersedeInvalidations,
           );
           stats.created++;
           stats.superseded = (stats.superseded ?? 0) + 1;
@@ -917,6 +939,7 @@ export class SmartExtractor {
               scopeFilter,
               admission?.audit,
               createEntries,
+              pendingSupersedeInvalidations,
             );
             stats.created++;
             stats.superseded = (stats.superseded ?? 0) + 1;
@@ -1262,6 +1285,7 @@ export class SmartExtractor {
     scopeFilter?: string[],
     admissionAudit?: AdmissionAuditRecord,
     createEntries?: StoreEntry[],
+    pendingSupersedeInvalidations?: PendingSupersedeInvalidation[],
   ): Promise<void> {
     const existing = await this.store.getById(matchId, scopeFilter);
     if (!existing) {
@@ -1275,7 +1299,7 @@ export class SmartExtractor {
       existingMeta.fact_key ?? deriveFactKey(candidate.category, candidate.abstract);
     const storeCategory = this.mapToStoreCategory(candidate.category);
     const supersedeClassifyText = candidate.content || candidate.abstract;
-    const created = await this.store.store({
+    const entry: StoreEntry = {
       text: candidate.abstract,
       vector,
       category: storeCategory,
@@ -1314,15 +1338,75 @@ export class SmartExtractor {
           },
         ),
       ),
-    });
+    };
 
+    if (createEntries && pendingSupersedeInvalidations) {
+      const entryIndex = createEntries.length;
+      createEntries.push(entry);
+      pendingSupersedeInvalidations.push({
+        entryIndex,
+        matchId,
+        existing,
+        factKey,
+        scopeFilter,
+      });
+      return;
+    }
+
+    const created = await this.store.store(entry);
+    await this.invalidateSupersededMemory(
+      matchId,
+      existing,
+      factKey,
+      created.id,
+      scopeFilter,
+    );
+
+    this.log(
+      `memory-pro: smart-extractor: superseded [${candidate.category}] ${matchId.slice(0, 8)} -> ${created.id.slice(0, 8)}`,
+    );
+  }
+
+  private async applyPendingSupersedeInvalidations(
+    createdEntries: MemoryEntry[],
+    pendingSupersedeInvalidations: PendingSupersedeInvalidation[],
+  ): Promise<void> {
+    for (const pending of pendingSupersedeInvalidations) {
+      const created = createdEntries[pending.entryIndex];
+      if (!created) {
+        this.log(
+          `memory-pro: smart-extractor: supersede invalidation skipped for ${pending.matchId.slice(0, 8)} because batch create returned no matching entry`,
+        );
+        continue;
+      }
+      await this.invalidateSupersededMemory(
+        pending.matchId,
+        pending.existing,
+        pending.factKey,
+        created.id,
+        pending.scopeFilter,
+      );
+      this.log(
+        `memory-pro: smart-extractor: superseded ${pending.matchId.slice(0, 8)} -> ${created.id.slice(0, 8)}`,
+      );
+    }
+  }
+
+  private async invalidateSupersededMemory(
+    matchId: string,
+    existing: MemoryEntry,
+    factKey: string,
+    createdId: string,
+    scopeFilter?: string[],
+  ): Promise<void> {
+    const existingMeta = parseSmartMetadata(existing.metadata, existing);
     const invalidatedMetadata = buildSmartMetadata(existing, {
       fact_key: factKey,
-      invalidated_at: now,
-      superseded_by: created.id,
+      invalidated_at: Date.now(),
+      superseded_by: createdId,
       relations: appendRelation(existingMeta.relations, {
         type: "superseded_by",
-        targetId: created.id,
+        targetId: createdId,
       }),
     });
 
@@ -1330,10 +1414,6 @@ export class SmartExtractor {
       matchId,
       { metadata: stringifySmartMetadata(invalidatedMetadata) },
       scopeFilter,
-    );
-
-    this.log(
-      `memory-pro: smart-extractor: superseded [${candidate.category}] ${matchId.slice(0, 8)} -> ${created.id.slice(0, 8)}`,
     );
   }
 

--- a/test/smart-extractor-supersede-bulkstore.test.mjs
+++ b/test/smart-extractor-supersede-bulkstore.test.mjs
@@ -1,0 +1,151 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const { SmartExtractor } = jiti("../src/smart-extractor.ts");
+const {
+  buildSmartMetadata,
+  parseSmartMetadata,
+  stringifySmartMetadata,
+} = jiti("../src/smart-metadata.ts");
+
+function makeVector(seed) {
+  return Array.from({ length: 8 }, (_, index) => seed + index / 100);
+}
+
+function makeExistingPreference() {
+  const text = "Preferred drink is oolong tea";
+  return {
+    id: "old-pref-1",
+    text,
+    vector: makeVector(0.1),
+    category: "preference",
+    scope: "agent:test",
+    importance: 0.8,
+    timestamp: 1,
+    metadata: stringifySmartMetadata(
+      buildSmartMetadata(
+        { text, category: "preference", importance: 0.8 },
+        {
+          l0_abstract: text,
+          l1_overview: "The user prefers oolong tea.",
+          l2_content: text,
+          memory_category: "preferences",
+          tier: "working",
+          confidence: 0.8,
+          fact_key: "preferences:drink",
+        },
+      ),
+    ),
+  };
+}
+
+function makeExtractor(store) {
+  const candidate = {
+    category: "preferences",
+    abstract: "Preferred drink is coffee",
+    overview: "The user prefers coffee.",
+    content: "The user now prefers coffee as their daily drink.",
+  };
+
+  const embedder = {
+    async embed() {
+      return makeVector(0.2);
+    },
+    async embedBatch(texts) {
+      return texts.map(() => makeVector(0.2));
+    },
+  };
+
+  const llm = {
+    async completeJson(_prompt, mode) {
+      if (mode === "extract-candidates") {
+        return { memories: [candidate] };
+      }
+      if (mode === "dedup-decision") {
+        return {
+          decision: "supersede",
+          reason: "newer preference replaces older preference",
+          match_index: 1,
+        };
+      }
+      throw new Error(`unexpected mode: ${mode}`);
+    },
+  };
+
+  return new SmartExtractor(store, embedder, llm, {
+    user: "User",
+    extractMinMessages: 1,
+    extractMaxChars: 8000,
+    defaultScope: "agent:test",
+    log() {},
+    debugLog() {},
+  });
+}
+
+describe("SmartExtractor SUPERSEDE batch create path", () => {
+  it("queues the superseding entry for bulkStore and invalidates the old record after creation", async () => {
+    const existing = makeExistingPreference();
+    const calls = [];
+
+    const store = {
+      async vectorSearch(_vector, _limit, _minScore, scopeFilter, options) {
+        calls.push({ method: "vectorSearch", scopeFilter, options });
+        return [{ entry: existing, score: 0.98 }];
+      },
+      async getById(id, scopeFilter) {
+        calls.push({ method: "getById", id, scopeFilter });
+        return id === existing.id ? existing : null;
+      },
+      async store() {
+        calls.push({ method: "store" });
+        throw new Error("store.store() should not be called in batch context");
+      },
+      async bulkStore(entries) {
+        calls.push({ method: "bulkStore", entries });
+        return entries.map((entry, index) => ({
+          ...entry,
+          id: `new-pref-${index + 1}`,
+          timestamp: 2 + index,
+        }));
+      },
+      async update(id, patch, scopeFilter) {
+        calls.push({ method: "update", id, patch, scopeFilter });
+        if (id === existing.id && patch.metadata) {
+          existing.metadata = patch.metadata;
+        }
+        return existing;
+      },
+    };
+
+    const extractor = makeExtractor(store);
+    const stats = await extractor.extractAndPersist(
+      "The user says their preferred drink is now coffee.",
+      "session-676",
+      { scope: "agent:test" },
+    );
+
+    const storeCalls = calls.filter((call) => call.method === "store");
+    const bulkCalls = calls.filter((call) => call.method === "bulkStore");
+    const updateCalls = calls.filter((call) => call.method === "update");
+
+    assert.equal(storeCalls.length, 0, "SUPERSEDE existing-found must not call store.store() when batching");
+    assert.equal(bulkCalls.length, 1, "superseding entry should be written through the batch bulkStore path");
+    assert.equal(bulkCalls[0].entries.length, 1, "batch should contain the new superseding entry");
+    assert.equal(updateCalls.length, 1, "old record should still be invalidated");
+    assert.deepEqual(updateCalls[0].scopeFilter, ["agent:test"]);
+
+    const newMeta = parseSmartMetadata(bulkCalls[0].entries[0].metadata, bulkCalls[0].entries[0]);
+    assert.equal(newMeta.supersedes, existing.id);
+    assert.equal(newMeta.fact_key, "preferences:drink");
+
+    const oldMeta = parseSmartMetadata(existing.metadata, existing);
+    assert.equal(oldMeta.superseded_by, "new-pref-1");
+    assert.ok(oldMeta.invalidated_at, "old record should be marked invalidated");
+    assert.equal(oldMeta.fact_key, "preferences:drink");
+
+    assert.equal(stats.created, 1);
+    assert.equal(stats.superseded, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- queue superseding smart-extractor entries into the existing bulkStore batch path
- defer old-record invalidation until the created superseding entry ID is known
- keep the non-batch fallback path intact

Fixes #676

## Tests
- `node --test test/smart-extractor-supersede-bulkstore.test.mjs`
- `node --test test/smart-extractor-scope-filter.test.mjs`
- `npm run build`