### PR TITLE
fix: require explicit self-improvement opt-in

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2019,7 +2019,7 @@ const memoryLanceDBProPlugin = {
             selfImprovementMaxEntries: config.selfImprovement?.maxEntries,
         }, {
             enableManagementTools: config.enableManagementTools,
-            enableSelfImprovementTools: config.selfImprovement?.enabled !== false,
+            enableSelfImprovementTools: config.selfImprovement?.enabled === true,
         });
         // Auto-compaction at gateway_start (if enabled, respects cooldown)
         if (config.memoryCompaction?.enabled) {
@@ -2912,7 +2912,7 @@ const memoryLanceDBProPlugin = {
         // ========================================================================
         // Integrated Self-Improvement (inheritance + derived)
         // ========================================================================
-        if (config.selfImprovement?.enabled !== false) {
+        if (config.selfImprovement?.enabled === true) {
             const pendingSelfImprovementResetReminderBySession = new Set();
             const getSelfImprovementSessionKey = (event, ctx) => {
                 const candidates = [
@@ -3412,7 +3412,7 @@ const memoryLanceDBProPlugin = {
                     const reflectionGovernanceCandidates = reflectionGenerated.usedFallback
                         ? []
                         : extractReflectionLearningGovernanceCandidates(reflectionText);
-                    if (config.selfImprovement?.enabled !== false && reflectionGovernanceCandidates.length > 0) {
+                    if (config.selfImprovement?.enabled === true && reflectionGovernanceCandidates.length > 0) {
                         for (const candidate of reflectionGovernanceCandidates) {
                             const appendResult = await appendSelfImprovementEntry({
                                 baseDir: workspaceDir,
@@ -4010,19 +4010,13 @@ export function parsePluginConfig(value) {
         sessionStrategy,
         selfImprovement: typeof cfg.selfImprovement === "object" && cfg.selfImprovement !== null
             ? {
-                enabled: cfg.selfImprovement.enabled !== false,
+                enabled: cfg.selfImprovement.enabled === true,
                 beforeResetNote: cfg.selfImprovement.beforeResetNote !== false,
                 skipSubagentBootstrap: cfg.selfImprovement.skipSubagentBootstrap !== false,
                 ensureLearningFiles: cfg.selfImprovement.ensureLearningFiles !== false,
                 maxEntries: parsePositiveInt(cfg.selfImprovement.maxEntries) ?? 500,
             }
-            : {
-                enabled: true,
-                beforeResetNote: true,
-                skipSubagentBootstrap: true,
-                ensureLearningFiles: true,
-                maxEntries: 500,
-            },
+            : undefined,
         canonicalCorpus: parseCanonicalCorpusConfig(cfg.canonicalCorpus),
         memoryReflection: memoryReflectionRaw
             ? {

--- a/index.ts
+++ b/index.ts
@@ -2662,7 +2662,7 @@ const memoryLanceDBProPlugin = {
       },
       {
         enableManagementTools: config.enableManagementTools,
-        enableSelfImprovementTools: config.selfImprovement?.enabled !== false,
+        enableSelfImprovementTools: config.selfImprovement?.enabled === true,
       }
     );
 
@@ -3764,7 +3764,7 @@ const memoryLanceDBProPlugin = {
     // Integrated Self-Improvement (inheritance + derived)
     // ========================================================================
 
-    if (config.selfImprovement?.enabled !== false) {
+    if (config.selfImprovement?.enabled === true) {
       const pendingSelfImprovementResetReminderBySession = new Set<string>();
       const getSelfImprovementSessionKey = (event: any, ctx?: any): string => {
         const candidates = [
@@ -4318,7 +4318,7 @@ const memoryLanceDBProPlugin = {
           const reflectionGovernanceCandidates = reflectionGenerated.usedFallback
             ? []
             : extractReflectionLearningGovernanceCandidates(reflectionText);
-          if (config.selfImprovement?.enabled !== false && reflectionGovernanceCandidates.length > 0) {
+          if (config.selfImprovement?.enabled === true && reflectionGovernanceCandidates.length > 0) {
             for (const candidate of reflectionGovernanceCandidates) {
               const appendResult = await appendSelfImprovementEntry({
                 baseDir: workspaceDir,
@@ -5030,19 +5030,13 @@ export function parsePluginConfig(value: unknown): PluginConfig {
     sessionStrategy,
     selfImprovement: typeof cfg.selfImprovement === "object" && cfg.selfImprovement !== null
       ? {
-        enabled: (cfg.selfImprovement as Record<string, unknown>).enabled !== false,
+        enabled: (cfg.selfImprovement as Record<string, unknown>).enabled === true,
         beforeResetNote: (cfg.selfImprovement as Record<string, unknown>).beforeResetNote !== false,
         skipSubagentBootstrap: (cfg.selfImprovement as Record<string, unknown>).skipSubagentBootstrap !== false,
         ensureLearningFiles: (cfg.selfImprovement as Record<string, unknown>).ensureLearningFiles !== false,
         maxEntries: parsePositiveInt((cfg.selfImprovement as Record<string, unknown>).maxEntries) ?? 500,
       }
-      : {
-        enabled: true,
-        beforeResetNote: true,
-        skipSubagentBootstrap: true,
-        ensureLearningFiles: true,
-        maxEntries: 500,
-      },
+      : undefined,
     canonicalCorpus: parseCanonicalCorpusConfig(cfg.canonicalCorpus),
     memoryReflection: memoryReflectionRaw
       ? {

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -286,7 +286,7 @@ try {
   );
   assert.equal(services.length, 1, "plugin should register its background service");
   assert.equal(typeof api.hooks.agent_end, "function", "autoCapture should remain enabled by default");
-  assert.equal(typeof api.hooks["command:new"], "function", "selfImprovement command:new hook should be registered by default (#391)");
+  assert.equal(api.hooks["command:new"], undefined, "selfImprovement command:new hook should stay disabled without selfImprovement config (#405)");
   await assert.doesNotReject(
     services[0].stop(),
     "service stop should not throw when no access tracker is configured",
@@ -307,11 +307,10 @@ try {
   });
   resetRegistration();
   plugin.register(sessionDefaultApi);
-  // selfImprovement registers command:new by default (#391), independent of sessionMemory config
   assert.equal(
-    typeof sessionDefaultApi.hooks["command:new"],
-    "function",
-    "command:new hook should be registered (selfImprovement default-on since #391)",
+    sessionDefaultApi.hooks["command:new"],
+    undefined,
+    "sessionMemory config should not implicitly enable selfImprovement command:new hook (#405)",
   );
 
   const sessionEnabledApi = createMockApi({
@@ -334,11 +333,35 @@ try {
     "function",
     "sessionMemory.enabled=true should register the async before_reset hook",
   );
-  // selfImprovement registers command:new by default (#391), independent of sessionMemory config
   assert.equal(
-    typeof sessionEnabledApi.hooks["command:new"],
+    sessionEnabledApi.hooks["command:new"],
+    undefined,
+    "sessionMemory.enabled=true should not implicitly enable selfImprovement command:new hook (#405)",
+  );
+
+  const selfImprovementEnabledApi = createMockApi({
+    dbPath: path.join(workDir, "db-self-improvement-enabled"),
+    autoCapture: false,
+    autoRecall: false,
+    sessionStrategy: "none",
+    selfImprovement: {
+      enabled: true,
+      ensureLearningFiles: false,
+    },
+    embedding: {
+      provider: "openai-compatible",
+      apiKey: "dummy",
+      model: "text-embedding-3-small",
+      baseURL: "http://127.0.0.1:9/v1",
+      dimensions: 1536,
+    },
+  });
+  resetRegistration();
+  plugin.register(selfImprovementEnabledApi);
+  assert.equal(
+    typeof selfImprovementEnabledApi.hooks["command:new"],
     "function",
-    "command:new hook should be registered (selfImprovement default-on since #391)",
+    "selfImprovement.enabled=true should register command:new hook (#405)",
   );
 
   const longText = `${"Long embedding payload. ".repeat(420)}tail`;

--- a/test/session-summary-before-reset.test.mjs
+++ b/test/session-summary-before-reset.test.mjs
@@ -106,8 +106,7 @@ describe("systemSessionMemory before_reset", { concurrency: false }, () => {
     memoryLanceDBProPlugin.register(api);
 
     assert.equal(typeof api.hooks.before_reset, "function");
-    // selfImprovement registers command:new by default (#391)
-    assert.equal(typeof api.hooks["command:new"], "function");
+    assert.equal(api.hooks["command:new"], undefined, "selfImprovement command:new hook should require explicit config (#405)");
 
     await api.hooks.before_reset(
       {


### PR DESCRIPTION
## Summary
- keep self-improvement disabled unless `selfImprovement.enabled` is explicitly true
- prevent self-improvement hooks and tools from registering from unrelated session memory config
- update regression coverage for default-disabled and explicit-enabled behavior

Fixes #405

## Tests
- `node test/plugin-manifest-regression.mjs`
- `node --test test/session-summary-before-reset.test.mjs`
- `node --test test/self-improvement-reset-note.test.mjs`
- `npm run build`