### PR TITLE
fix: prefix Qwen3 query embeddings

### DIFF
--- a/dist/src/embedder.js
+++ b/dist/src/embedder.js
@@ -338,6 +338,7 @@ const EMBED_TIMEOUT_MS = 10_000;
 const DEFAULT_EMBED_CLIENT_TIMEOUT_MS = 30_000;
 /** Bounded startup health probe timeout; normal embeddings keep the larger client timeout. */
 const EMBED_HEALTH_CHECK_TIMEOUT_MS = 7_500;
+const DEFAULT_QWEN3_QUERY_TASK = "Given a memory search query, retrieve relevant stored knowledge entries that match the query";
 /**
  * Strictly decreasing character limit for forced truncation.
  * Each recursion level MUST reduce input by this factor to guarantee progress.
@@ -400,7 +401,7 @@ export class Embedder {
         if (config.normalized !== undefined && !this._capabilities.normalized) {
             console.debug(`[memory-lancedb-pro] embedding.normalized is set but provider profile "${profile}" does not support it — value will be ignored`);
         }
-        if ((config.taskQuery || config.taskPassage) && !this._capabilities.taskField) {
+        if ((config.taskPassage || (config.taskQuery && !this.isQwen3EmbeddingModel())) && !this._capabilities.taskField) {
             console.debug(`[memory-lancedb-pro] embedding.taskQuery/taskPassage is set but provider profile "${profile}" does not support task hints — values will be ignored`);
         }
         // Create a client pool — one OpenAI client per key
@@ -647,7 +648,7 @@ export class Embedder {
     // Task-aware API
     // --------------------------------------------------------------------------
     async embedQuery(text, signal) {
-        return this.withTimeout((sig) => this.embedSingle(text, this._taskQuery, 0, sig), "embedQuery", signal);
+        return this.withTimeout((sig) => this.embedSingle(this.wrapQueryText(text), this._taskQuery, 0, sig), "embedQuery", signal);
     }
     async embedPassage(text, signal) {
         return this.withTimeout((sig) => this.embedSingle(text, this._taskPassage, 0, sig), "embedPassage", signal);
@@ -657,7 +658,7 @@ export class Embedder {
     // EMBED_TIMEOUT_MS regardless of how many texts succeed. Individual text embedding
     // within the batch is protected by the SDK's own timeout handling.
     async embedBatchQuery(texts, signal) {
-        return this.embedMany(texts, this._taskQuery, signal);
+        return this.embedMany(texts.map((text) => this.wrapQueryText(text)), this._taskQuery, signal);
     }
     async embedBatchPassage(texts, signal) {
         return this.embedMany(texts, this._taskPassage, signal);
@@ -665,6 +666,18 @@ export class Embedder {
     // --------------------------------------------------------------------------
     // Internals
     // --------------------------------------------------------------------------
+    isQwen3EmbeddingModel() {
+        return /qwen3[-_]embedding/i.test(this._model);
+    }
+    wrapQueryText(text) {
+        if (!this.isQwen3EmbeddingModel() || !text || text.trim().length === 0) {
+            return text;
+        }
+        const task = this._taskQuery && this._taskQuery.trim().length > 0
+            ? this._taskQuery
+            : DEFAULT_QWEN3_QUERY_TASK;
+        return `Instruct: ${task}\nQuery:${text}`;
+    }
     validateEmbedding(embedding) {
         if (!Array.isArray(embedding)) {
             throw new Error(`Embedding is not an array (got ${typeof embedding})`);

--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -429,6 +429,9 @@ const DEFAULT_EMBED_CLIENT_TIMEOUT_MS = 30_000;
 /** Bounded startup health probe timeout; normal embeddings keep the larger client timeout. */
 const EMBED_HEALTH_CHECK_TIMEOUT_MS = 7_500;
 
+const DEFAULT_QWEN3_QUERY_TASK =
+  "Given a memory search query, retrieve relevant stored knowledge entries that match the query";
+
 /**
  * Strictly decreasing character limit for forced truncation.
  * Each recursion level MUST reduce input by this factor to guarantee progress.
@@ -511,7 +514,7 @@ export class Embedder {
         `[memory-lancedb-pro] embedding.normalized is set but provider profile "${profile}" does not support it — value will be ignored`
       );
     }
-    if ((config.taskQuery || config.taskPassage) && !this._capabilities.taskField) {
+    if ((config.taskPassage || (config.taskQuery && !this.isQwen3EmbeddingModel())) && !this._capabilities.taskField) {
       console.debug(
         `[memory-lancedb-pro] embedding.taskQuery/taskPassage is set but provider profile "${profile}" does not support task hints — values will be ignored`
       );
@@ -810,7 +813,7 @@ export class Embedder {
   // --------------------------------------------------------------------------
 
   async embedQuery(text: string, signal?: AbortSignal): Promise<number[]> {
-    return this.withTimeout((sig) => this.embedSingle(text, this._taskQuery, 0, sig), "embedQuery", signal);
+    return this.withTimeout((sig) => this.embedSingle(this.wrapQueryText(text), this._taskQuery, 0, sig), "embedQuery", signal);
   }
 
   async embedPassage(text: string, signal?: AbortSignal): Promise<number[]> {
@@ -822,7 +825,7 @@ export class Embedder {
   // EMBED_TIMEOUT_MS regardless of how many texts succeed. Individual text embedding
   // within the batch is protected by the SDK's own timeout handling.
   async embedBatchQuery(texts: string[], signal?: AbortSignal): Promise<number[][]> {
-    return this.embedMany(texts, this._taskQuery, signal);
+    return this.embedMany(texts.map((text) => this.wrapQueryText(text)), this._taskQuery, signal);
   }
 
   async embedBatchPassage(texts: string[], signal?: AbortSignal): Promise<number[][]> {
@@ -832,6 +835,21 @@ export class Embedder {
   // --------------------------------------------------------------------------
   // Internals
   // --------------------------------------------------------------------------
+
+  private isQwen3EmbeddingModel(): boolean {
+    return /qwen3[-_]embedding/i.test(this._model);
+  }
+
+  private wrapQueryText(text: string): string {
+    if (!this.isQwen3EmbeddingModel() || !text || text.trim().length === 0) {
+      return text;
+    }
+
+    const task = this._taskQuery && this._taskQuery.trim().length > 0
+      ? this._taskQuery
+      : DEFAULT_QWEN3_QUERY_TASK;
+    return `Instruct: ${task}\nQuery:${text}`;
+  }
 
   private validateEmbedding(embedding: number[]): void {
     if (!Array.isArray(embedding)) {

--- a/test/embedder-error-hints.test.mjs
+++ b/test/embedder-error-hints.test.mjs
@@ -151,6 +151,56 @@ async function run() {
   });
   await genericEmbedder.embedPassage("hello");
 
+  const qwen3DefaultQueryTask =
+    "Given a memory search query, retrieve relevant stored knowledge entries that match the query";
+  const qwen3Embedder = new Embedder({
+    provider: "openai-compatible",
+    apiKey: "test-key",
+    model: "/models/Qwen3-Embedding-8B",
+    baseURL: "https://vllm.example.invalid/v1",
+    dimensions: 4096,
+  });
+
+  installMockEmbeddingClient(qwen3Embedder, async (payload) => {
+    assert.equal(
+      payload.input,
+      `Instruct: ${qwen3DefaultQueryTask}\nQuery:PlayerAction`,
+      "Qwen3 query embeddings should use the recommended query instruction prefix",
+    );
+    assert.equal(payload.task, undefined, "generic Qwen3 endpoints should not receive a task payload field");
+    return createEmbeddingResponse(4096);
+  });
+  await qwen3Embedder.embedQuery("PlayerAction");
+
+  installMockEmbeddingClient(qwen3Embedder, async (payload) => {
+    assert.equal(payload.input, "PlayerAction schema", "Qwen3 passage embeddings should remain raw");
+    return createEmbeddingResponse(4096);
+  });
+  await qwen3Embedder.embedPassage("PlayerAction schema");
+
+  const qwen3CustomTaskEmbedder = new Embedder({
+    provider: "openai-compatible",
+    apiKey: "test-key",
+    model: "Qwen3_Embedding_8B",
+    baseURL: "https://vllm.example.invalid/v1",
+    dimensions: 4096,
+    taskQuery: "Retrieve relevant project memories.",
+  });
+  installMockEmbeddingClient(qwen3CustomTaskEmbedder, async (payload) => {
+    assert.deepEqual(payload.input, [
+      "Instruct: Retrieve relevant project memories.\nQuery:PlayerAction",
+      "Instruct: Retrieve relevant project memories.\nQuery:DimPlayerAction",
+    ]);
+    assert.equal(payload.task, undefined, "taskQuery should be used as prefix text, not sent as a generic task field");
+    return {
+      data: [
+        { object: "embedding", index: 0, embedding: new Array(4096).fill(0.1) },
+        { object: "embedding", index: 1, embedding: new Array(4096).fill(0.2) },
+      ],
+    };
+  });
+  await qwen3CustomTaskEmbedder.embedBatchQuery(["PlayerAction", "DimPlayerAction"]);
+
   // voyage-4 should be detected as voyage-compatible via model name prefix,
   // even when baseURL is NOT api.voyageai.com (e.g. behind a proxy).
   const voyageProxyEmbedder = new Embedder({


### PR DESCRIPTION
## Summary
- wrap Qwen3 query embeddings with the recommended query instruction prefix
- reuse `embedding.taskQuery` as the instruction text when configured
- leave passage embeddings and non-Qwen providers unchanged

Fixes #573

## Tests
- `node test/embedder-error-hints.test.mjs`
- `npm run build`