### PR TITLE
fix: skip repeated empty command reflections

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -270,6 +270,8 @@ const DEFAULT_REFLECTION_SESSION_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_REFLECTION_MAX_TRACKED_SESSIONS = 200;
 const DEFAULT_REFLECTION_ERROR_SCAN_MAX_CHARS = 8_000;
 const DEFAULT_SERIAL_GUARD_COOLDOWN_MS = 120_000;
+const DEFAULT_REFLECTION_EMPTY_EVENT_GUARD_TTL_MS = 120_000;
+const DEFAULT_REFLECTION_EMPTY_EVENT_GUARD_MAX_ENTRIES = 200;
 // After /new or /reset, the just-closed session may have generated fresh
 // derived deltas. Keep those out of the immediately opened prompt window.
 const DEFAULT_REFLECTION_BOUNDARY_DERIVED_SUPPRESSION_MS = 120_000;
@@ -1523,6 +1525,45 @@ function getCommandActionName(action) {
 function isSessionBoundaryReflectionAction(action) {
     const name = getCommandActionName(action);
     return name === "new" || name === "reset";
+}
+const REFLECTION_EMPTY_EVENT_GUARD = Symbol.for("openclaw.memory-lancedb-pro.reflection-empty-event-guard");
+function getReflectionEmptyEventGuardMap() {
+    const g = globalThis;
+    if (!g[REFLECTION_EMPTY_EVENT_GUARD])
+        g[REFLECTION_EMPTY_EVENT_GUARD] = new Map();
+    return g[REFLECTION_EMPTY_EVENT_GUARD];
+}
+function pruneReflectionEmptyEventGuard(now = Date.now()) {
+    const guard = getReflectionEmptyEventGuardMap();
+    for (const [key, entry] of guard) {
+        if (now - entry.updatedAt > DEFAULT_REFLECTION_EMPTY_EVENT_GUARD_TTL_MS) {
+            guard.delete(key);
+        }
+    }
+    if (guard.size > DEFAULT_REFLECTION_EMPTY_EVENT_GUARD_MAX_ENTRIES) {
+        const newest = Array.from(guard.entries()).slice(-DEFAULT_REFLECTION_EMPTY_EVENT_GUARD_MAX_ENTRIES);
+        guard.clear();
+        for (const [key, entry] of newest)
+            guard.set(key, entry);
+    }
+}
+async function getReflectionEmptyEventGuardKey(params) {
+    let fileFingerprint = "file=(none)";
+    if (params.sessionFile) {
+        try {
+            const st = await stat(params.sessionFile);
+            fileFingerprint = `file=${params.sessionFile};size=${st.size};mtime=${Math.trunc(st.mtimeMs)}`;
+        }
+        catch (err) {
+            fileFingerprint = `file=${params.sessionFile};missing=${String(err?.code || err?.name || "unknown")}`;
+        }
+    }
+    return [
+        getCommandActionName(params.action) || "unknown",
+        params.sessionKey,
+        params.sessionId || "unknown",
+        fileFingerprint,
+    ].join("|");
 }
 let _singletonState = null;
 function _initPluginState(api) {
@@ -3241,6 +3282,13 @@ const memoryLanceDBProPlugin = {
                 }
                 if (_dedupHookEvent("reflection", event))
                     return;
+                const context = (event.context || {});
+                const cfg = context.cfg;
+                const sessionEntry = (context.previousSessionEntry || context.sessionEntry || {});
+                const currentSessionId = typeof sessionEntry.sessionId === "string" ? sessionEntry.sessionId : "unknown";
+                let currentSessionFile = typeof sessionEntry.sessionFile === "string" ? sessionEntry.sessionFile : undefined;
+                const sourceAgentId = parseAgentIdFromSessionKey(sessionKey) || "main";
+                const commandSource = typeof context.commandSource === "string" ? context.commandSource : "";
                 if (isSessionBoundaryReflectionAction(action)) {
                     const now = Date.now();
                     reflectionDerivedBySession.delete(sessionKey);
@@ -3250,6 +3298,55 @@ const memoryLanceDBProPlugin = {
                         reason: action,
                     });
                 }
+                if (!cfg) {
+                    api.logger.warn(`memory-reflection: command:${action} missing cfg in hook context; skip reflection`);
+                    return;
+                }
+                // Guard: skip reflection for invalid agentId formats (numeric chat_id, etc.)
+                if (isInvalidAgentIdFormat(sourceAgentId, config.declaredAgents)) {
+                    api.logger.debug?.(`memory-reflection: command hook skipped (invalid agentId=${sourceAgentId}, sessionKey=${sessionKey ?? "(none)"})`);
+                    return;
+                }
+                // Exclude agents/sessions listed in memoryReflection.excludeAgents (supports wildcards)
+                const excludePatterns = config.memoryReflection?.excludeAgents;
+                if (excludePatterns && isAgentOrSessionExcluded(sourceAgentId, sessionKey, excludePatterns)) {
+                    api.logger.debug?.(`memory-reflection: command hook skipped (excluded agent=${sourceAgentId}, sessionKey=${sessionKey ?? "(none)"})`);
+                    return;
+                }
+                let emptyEventGuardKey;
+                const isBoundaryAction = isSessionBoundaryReflectionAction(action);
+                if (isBoundaryAction) {
+                    pruneReflectionEmptyEventGuard();
+                    emptyEventGuardKey = await getReflectionEmptyEventGuardKey({
+                        action,
+                        sessionKey,
+                        sessionId: currentSessionId,
+                        sessionFile: currentSessionFile,
+                    });
+                    const guarded = getReflectionEmptyEventGuardMap().get(emptyEventGuardKey);
+                    if (guarded && Date.now() - guarded.updatedAt <= DEFAULT_REFLECTION_EMPTY_EVENT_GUARD_TTL_MS) {
+                        api.logger.info(`memory-reflection: command:${action} skipped repeated empty/unusable session; sessionKey=${sessionKey}; sessionId=${currentSessionId}; sessionFile=${currentSessionFile || "(none)"}; reason=${guarded.reason}`);
+                        return;
+                    }
+                }
+                const rememberEmptyReflectionEvent = async (reason) => {
+                    if (!isBoundaryAction)
+                        return;
+                    const guard = getReflectionEmptyEventGuardMap();
+                    const now = Date.now();
+                    const finalKey = await getReflectionEmptyEventGuardKey({
+                        action,
+                        sessionKey,
+                        sessionId: currentSessionId,
+                        sessionFile: currentSessionFile,
+                    });
+                    guard.set(finalKey, { updatedAt: now, reason });
+                    if (emptyEventGuardKey && emptyEventGuardKey === finalKey) {
+                        guard.set(emptyEventGuardKey, { updatedAt: now, reason });
+                    }
+                    pruneReflectionEmptyEventGuard(now);
+                    api.logger.info(`memory-reflection: command:${action} empty/unusable guard recorded; sessionKey=${sessionKey}; sessionId=${currentSessionId}; sessionFile=${currentSessionFile || "(none)"}; reason=${reason}`);
+                };
                 // Guard against re-entrant calls for the same session (e.g. file-write triggering another command:new)
                 // Uses global lock shared across all plugin instances to prevent loop amplification.
                 const globalLock = getGlobalReflectionLock();
@@ -3257,9 +3354,6 @@ const memoryLanceDBProPlugin = {
                     api.logger.info(`memory-reflection: skipping re-entrant call for sessionKey=${sessionKey}; already running (global guard)`);
                     return;
                 }
-                // Parse context before guards so cfg is available for serialCooldownMs
-                const context = (event.context || {});
-                const cfg = context.cfg;
                 // Serial loop guard: skip if a reflection for this sessionKey completed recently
                 if (sessionKey) {
                     const serialGuard = getSerialGuardMap();
@@ -3278,26 +3372,6 @@ const memoryLanceDBProPlugin = {
                 try {
                     pruneReflectionSessionState();
                     const workspaceDir = resolveWorkspaceDirFromContext(context);
-                    if (!cfg) {
-                        api.logger.warn(`memory-reflection: command:${action} missing cfg in hook context; skip reflection`);
-                        return;
-                    }
-                    const sessionEntry = (context.previousSessionEntry || context.sessionEntry || {});
-                    const currentSessionId = typeof sessionEntry.sessionId === "string" ? sessionEntry.sessionId : "unknown";
-                    let currentSessionFile = typeof sessionEntry.sessionFile === "string" ? sessionEntry.sessionFile : undefined;
-                    const sourceAgentId = parseAgentIdFromSessionKey(sessionKey) || "main";
-                    // Guard: skip reflection for invalid agentId formats (numeric chat_id, etc.)
-                    if (isInvalidAgentIdFormat(sourceAgentId, config.declaredAgents)) {
-                        api.logger.debug?.(`memory-reflection: command hook skipped (invalid agentId=${sourceAgentId}, sessionKey=${sessionKey ?? "(none)"})`);
-                        return;
-                    }
-                    // Exclude agents/sessions listed in memoryReflection.excludeAgents (supports wildcards)
-                    const excludePatterns = config.memoryReflection?.excludeAgents;
-                    if (excludePatterns && isAgentOrSessionExcluded(sourceAgentId, sessionKey, excludePatterns)) {
-                        api.logger.debug?.(`memory-reflection: command hook skipped (excluded agent=${sourceAgentId}, sessionKey=${sessionKey ?? "(none)"})`);
-                        return;
-                    }
-                    const commandSource = typeof context.commandSource === "string" ? context.commandSource : "";
                     api.logger.info(`memory-reflection: command:${action} hook start; sessionKey=${sessionKey || "(none)"}; source=${commandSource || "(unknown)"}; sessionId=${currentSessionId}; sessionFile=${currentSessionFile || "(none)"}`);
                     if (!currentSessionFile || currentSessionFile.includes(".reset.")) {
                         const searchDirs = resolveReflectionSessionSearchDirs({
@@ -3326,11 +3400,13 @@ const memoryLanceDBProPlugin = {
                             sourceAgentId,
                         });
                         api.logger.warn(`memory-reflection: command:${action} missing session file after recovery for session ${currentSessionId}; dirs=${searchDirs.join(" | ") || "(none)"}`);
+                        await rememberEmptyReflectionEvent("missing-session-file");
                         return;
                     }
                     const conversation = await readSessionConversationWithResetFallback(currentSessionFile, reflectionMessageCount);
                     if (!conversation) {
                         api.logger.warn(`memory-reflection: command:${action} conversation empty/unusable for session ${currentSessionId}; file=${currentSessionFile}`);
+                        await rememberEmptyReflectionEvent("empty-conversation");
                         return;
                     }
                     // Mark that reflection will actually run — cooldown is only recorded
@@ -4147,5 +4223,6 @@ export function resetRegistration() {
     _registeredApisMap.clear(); // dual-track: clear Map alongside WeakSet
     _singletonState = null;
     _hookEventDedup.clear();
+    getReflectionEmptyEventGuardMap().clear();
 }
 export default memoryLanceDBProPlugin;

--- a/index.ts
+++ b/index.ts
@@ -543,6 +543,8 @@ const DEFAULT_REFLECTION_SESSION_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_REFLECTION_MAX_TRACKED_SESSIONS = 200;
 const DEFAULT_REFLECTION_ERROR_SCAN_MAX_CHARS = 8_000;
 const DEFAULT_SERIAL_GUARD_COOLDOWN_MS = 120_000;
+const DEFAULT_REFLECTION_EMPTY_EVENT_GUARD_TTL_MS = 120_000;
+const DEFAULT_REFLECTION_EMPTY_EVENT_GUARD_MAX_ENTRIES = 200;
 // After /new or /reset, the just-closed session may have generated fresh
 // derived deltas. Keep those out of the immediately opened prompt window.
 const DEFAULT_REFLECTION_BOUNDARY_DERIVED_SUPPRESSION_MS = 120_000;
@@ -568,6 +570,11 @@ type ReflectionErrorState = {
 type ReflectionDerivedSuppressionState = {
   updatedAt: number;
   until: number;
+  reason: string;
+};
+
+type ReflectionEmptyEventGuardEntry = {
+  updatedAt: number;
   reason: string;
 };
 
@@ -2004,6 +2011,52 @@ function getCommandActionName(action: unknown): string {
 function isSessionBoundaryReflectionAction(action: unknown): boolean {
   const name = getCommandActionName(action);
   return name === "new" || name === "reset";
+}
+
+const REFLECTION_EMPTY_EVENT_GUARD = Symbol.for("openclaw.memory-lancedb-pro.reflection-empty-event-guard");
+
+function getReflectionEmptyEventGuardMap(): Map<string, ReflectionEmptyEventGuardEntry> {
+  const g = globalThis as Record<symbol, unknown>;
+  if (!g[REFLECTION_EMPTY_EVENT_GUARD]) g[REFLECTION_EMPTY_EVENT_GUARD] = new Map<string, ReflectionEmptyEventGuardEntry>();
+  return g[REFLECTION_EMPTY_EVENT_GUARD] as Map<string, ReflectionEmptyEventGuardEntry>;
+}
+
+function pruneReflectionEmptyEventGuard(now = Date.now()): void {
+  const guard = getReflectionEmptyEventGuardMap();
+  for (const [key, entry] of guard) {
+    if (now - entry.updatedAt > DEFAULT_REFLECTION_EMPTY_EVENT_GUARD_TTL_MS) {
+      guard.delete(key);
+    }
+  }
+  if (guard.size > DEFAULT_REFLECTION_EMPTY_EVENT_GUARD_MAX_ENTRIES) {
+    const newest = Array.from(guard.entries()).slice(-DEFAULT_REFLECTION_EMPTY_EVENT_GUARD_MAX_ENTRIES);
+    guard.clear();
+    for (const [key, entry] of newest) guard.set(key, entry);
+  }
+}
+
+async function getReflectionEmptyEventGuardKey(params: {
+  action: string;
+  sessionKey: string;
+  sessionId: string;
+  sessionFile?: string;
+}): Promise<string> {
+  let fileFingerprint = "file=(none)";
+  if (params.sessionFile) {
+    try {
+      const st = await stat(params.sessionFile);
+      fileFingerprint = `file=${params.sessionFile};size=${st.size};mtime=${Math.trunc(st.mtimeMs)}`;
+    } catch (err: any) {
+      fileFingerprint = `file=${params.sessionFile};missing=${String(err?.code || err?.name || "unknown")}`;
+    }
+  }
+
+  return [
+    getCommandActionName(params.action) || "unknown",
+    params.sessionKey,
+    params.sessionId || "unknown",
+    fileFingerprint,
+  ].join("|");
 }
 
 // ============================================================================
@@ -4118,6 +4171,13 @@ const memoryLanceDBProPlugin = {
         }
 
         if (_dedupHookEvent("reflection", event)) return;
+        const context = (event.context || {}) as Record<string, unknown>;
+        const cfg = context.cfg;
+        const sessionEntry = (context.previousSessionEntry || context.sessionEntry || {}) as Record<string, unknown>;
+        const currentSessionId = typeof sessionEntry.sessionId === "string" ? sessionEntry.sessionId : "unknown";
+        let currentSessionFile = typeof sessionEntry.sessionFile === "string" ? sessionEntry.sessionFile : undefined;
+        const sourceAgentId = parseAgentIdFromSessionKey(sessionKey) || "main";
+        const commandSource = typeof context.commandSource === "string" ? context.commandSource : "";
         if (isSessionBoundaryReflectionAction(action)) {
           const now = Date.now();
           reflectionDerivedBySession.delete(sessionKey);
@@ -4127,6 +4187,65 @@ const memoryLanceDBProPlugin = {
             reason: action,
           });
         }
+        if (!cfg) {
+          api.logger.warn(`memory-reflection: command:${action} missing cfg in hook context; skip reflection`);
+          return;
+        }
+        // Guard: skip reflection for invalid agentId formats (numeric chat_id, etc.)
+        if (isInvalidAgentIdFormat(sourceAgentId, config.declaredAgents)) {
+          api.logger.debug?.(
+            `memory-reflection: command hook skipped (invalid agentId=${sourceAgentId}, sessionKey=${sessionKey ?? "(none)"})`,
+          );
+          return;
+        }
+        // Exclude agents/sessions listed in memoryReflection.excludeAgents (supports wildcards)
+        const excludePatterns = config.memoryReflection?.excludeAgents;
+        if (excludePatterns && isAgentOrSessionExcluded(sourceAgentId, sessionKey, excludePatterns)) {
+          api.logger.debug?.(
+            `memory-reflection: command hook skipped (excluded agent=${sourceAgentId}, sessionKey=${sessionKey ?? "(none)"})`,
+          );
+          return;
+        }
+
+        let emptyEventGuardKey: string | undefined;
+        const isBoundaryAction = isSessionBoundaryReflectionAction(action);
+        if (isBoundaryAction) {
+          pruneReflectionEmptyEventGuard();
+          emptyEventGuardKey = await getReflectionEmptyEventGuardKey({
+            action,
+            sessionKey,
+            sessionId: currentSessionId,
+            sessionFile: currentSessionFile,
+          });
+          const guarded = getReflectionEmptyEventGuardMap().get(emptyEventGuardKey);
+          if (guarded && Date.now() - guarded.updatedAt <= DEFAULT_REFLECTION_EMPTY_EVENT_GUARD_TTL_MS) {
+            api.logger.info(
+              `memory-reflection: command:${action} skipped repeated empty/unusable session; sessionKey=${sessionKey}; sessionId=${currentSessionId}; sessionFile=${currentSessionFile || "(none)"}; reason=${guarded.reason}`
+            );
+            return;
+          }
+        }
+
+        const rememberEmptyReflectionEvent = async (reason: string) => {
+          if (!isBoundaryAction) return;
+          const guard = getReflectionEmptyEventGuardMap();
+          const now = Date.now();
+          const finalKey = await getReflectionEmptyEventGuardKey({
+            action,
+            sessionKey,
+            sessionId: currentSessionId,
+            sessionFile: currentSessionFile,
+          });
+          guard.set(finalKey, { updatedAt: now, reason });
+          if (emptyEventGuardKey && emptyEventGuardKey === finalKey) {
+            guard.set(emptyEventGuardKey, { updatedAt: now, reason });
+          }
+          pruneReflectionEmptyEventGuard(now);
+          api.logger.info(
+            `memory-reflection: command:${action} empty/unusable guard recorded; sessionKey=${sessionKey}; sessionId=${currentSessionId}; sessionFile=${currentSessionFile || "(none)"}; reason=${reason}`
+          );
+        };
+
         // Guard against re-entrant calls for the same session (e.g. file-write triggering another command:new)
         // Uses global lock shared across all plugin instances to prevent loop amplification.
         const globalLock = getGlobalReflectionLock();
@@ -4134,9 +4253,6 @@ const memoryLanceDBProPlugin = {
           api.logger.info(`memory-reflection: skipping re-entrant call for sessionKey=${sessionKey}; already running (global guard)`);
           return;
         }
-        // Parse context before guards so cfg is available for serialCooldownMs
-        const context = (event.context || {}) as Record<string, unknown>;
-        const cfg = context.cfg;
         // Serial loop guard: skip if a reflection for this sessionKey completed recently
         if (sessionKey) {
           const serialGuard = getSerialGuardMap();
@@ -4154,32 +4270,6 @@ const memoryLanceDBProPlugin = {
         try {
           pruneReflectionSessionState();
           const workspaceDir = resolveWorkspaceDirFromContext(context);
-          if (!cfg) {
-            api.logger.warn(`memory-reflection: command:${action} missing cfg in hook context; skip reflection`);
-            return;
-          }
-
-          const sessionEntry = (context.previousSessionEntry || context.sessionEntry || {}) as Record<string, unknown>;
-          const currentSessionId = typeof sessionEntry.sessionId === "string" ? sessionEntry.sessionId : "unknown";
-          let currentSessionFile = typeof sessionEntry.sessionFile === "string" ? sessionEntry.sessionFile : undefined;
-          const sourceAgentId = parseAgentIdFromSessionKey(sessionKey) || "main";
-          // Guard: skip reflection for invalid agentId formats (numeric chat_id, etc.)
-          if (isInvalidAgentIdFormat(sourceAgentId, config.declaredAgents)) {
-            api.logger.debug?.(
-              `memory-reflection: command hook skipped (invalid agentId=${sourceAgentId}, sessionKey=${sessionKey ?? "(none)"})`,
-            );
-            return;
-          }
-          // Exclude agents/sessions listed in memoryReflection.excludeAgents (supports wildcards)
-          const excludePatterns = config.memoryReflection?.excludeAgents;
-          if (excludePatterns && isAgentOrSessionExcluded(sourceAgentId, sessionKey, excludePatterns)) {
-            api.logger.debug?.(
-              `memory-reflection: command hook skipped (excluded agent=${sourceAgentId}, sessionKey=${sessionKey ?? "(none)"})`,
-            );
-            return;
-          }
-
-          const commandSource = typeof context.commandSource === "string" ? context.commandSource : "";
           api.logger.info(
             `memory-reflection: command:${action} hook start; sessionKey=${sessionKey || "(none)"}; source=${commandSource || "(unknown)"}; sessionId=${currentSessionId}; sessionFile=${currentSessionFile || "(none)"}`
           );
@@ -4218,6 +4308,7 @@ const memoryLanceDBProPlugin = {
             api.logger.warn(
               `memory-reflection: command:${action} missing session file after recovery for session ${currentSessionId}; dirs=${searchDirs.join(" | ") || "(none)"}`
             );
+            await rememberEmptyReflectionEvent("missing-session-file");
             return;
           }
 
@@ -4226,6 +4317,7 @@ const memoryLanceDBProPlugin = {
             api.logger.warn(
               `memory-reflection: command:${action} conversation empty/unusable for session ${currentSessionId}; file=${currentSessionFile}`
             );
+            await rememberEmptyReflectionEvent("empty-conversation");
             return;
           }
 
@@ -5184,6 +5276,7 @@ export function resetRegistration() {
   _registeredApisMap.clear();  // dual-track: clear Map alongside WeakSet
   _singletonState = null;
   _hookEventDedup.clear();
+  getReflectionEmptyEventGuardMap().clear();
 }
 
 export default memoryLanceDBProPlugin;

--- a/test/command-reflection-guard.test.mjs
+++ b/test/command-reflection-guard.test.mjs
@@ -9,7 +9,7 @@
  */
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "os";
 import path from "path";
 import { fileURLToPath } from "node:url";
@@ -216,6 +216,98 @@ describe("runMemoryReflection — invalid agentId guard", () => {
       assert.ok(
         startLogs.length >= 0, // not asserting >0 since DB might not be initialized
         `expect no crash for valid agentId=main; got: ${JSON.stringify(startLogs)}`,
+      );
+    });
+  });
+
+  describe("Empty command boundary sessions", () => {
+    it("skips repeated empty command:new events for the same fresh session without suppressing a different old session", async () => {
+      const pluginConfig = makePluginConfig(workDir);
+      pluginConfig.memoryReflection.serialCooldownMs = 1;
+
+      const harness = createPluginApiHarness({
+        resolveRoot: workDir,
+        pluginConfig,
+      });
+      memoryLanceDBProPlugin.register(harness.api);
+
+      const hooks = harness.eventHandlers.get("command:new") || [];
+      const reflectionHook = hooks.find((hook) =>
+        hook.meta?.name === "memory-lancedb-pro.memory-reflection.command-new"
+      );
+      assert.ok(reflectionHook, "expected memory reflection command:new hook");
+
+      const emptySessionFile = path.join(workDir, "fresh-empty.jsonl");
+      writeFileSync(emptySessionFile, "", "utf-8");
+
+      const originalDateNow = Date.now;
+      let now = 1_800_000_000_000;
+      Date.now = () => now;
+      try {
+        for (const timestamp of [1000, 2000, 3000]) {
+          await reflectionHook.handler({
+            sessionKey: "agent:main:session:fresh",
+            timestamp,
+            action: "command:new",
+            context: {
+              cfg: pluginConfig,
+              workspaceDir: workDir,
+              sessionEntry: {
+                sessionId: "fresh-empty",
+                sessionFile: emptySessionFile,
+              },
+            },
+          }, { sessionKey: "agent:main:session:fresh", agentId: "main" });
+          now += 10;
+        }
+      } finally {
+        Date.now = originalDateNow;
+      }
+
+      const emptyLogs = harness.logs.filter(([, msg]) => msg.includes("conversation empty/unusable"));
+      assert.equal(emptyLogs.length, 1, `only the first empty event should read the session; got ${JSON.stringify(emptyLogs)}`);
+
+      const skippedLogs = harness.logs.filter(([, msg]) => msg.includes("skipped repeated empty/unusable session"));
+      assert.equal(skippedLogs.length, 2, `expected repeated empty events to hit the guard; got ${JSON.stringify(harness.logs)}`);
+
+      const oldSessionFile = path.join(workDir, "old-session.jsonl");
+      writeFileSync(
+        oldSessionFile,
+        [
+          JSON.stringify({ type: "message", message: { role: "user", content: "Please remember the old session." } }),
+          JSON.stringify({ type: "message", message: { role: "assistant", content: "I will reflect on the old session." } }),
+        ].join("\n") + "\n",
+        "utf-8",
+      );
+
+      const originalOpenClawCliBin = process.env.OPENCLAW_CLI_BIN;
+      process.env.OPENCLAW_CLI_BIN = "/usr/bin/false";
+      const originalDateNowSecond = Date.now;
+      now = 1_800_000_001_000;
+      Date.now = () => now;
+      try {
+        await reflectionHook.handler({
+          sessionKey: "agent:main:session:fresh",
+          timestamp: 4000,
+          action: "command:new",
+          context: {
+            cfg: pluginConfig,
+            workspaceDir: workDir,
+            previousSessionEntry: {
+              sessionId: "old-session",
+              sessionFile: oldSessionFile,
+            },
+          },
+        }, { sessionKey: "agent:main:session:fresh", agentId: "main" });
+      } finally {
+        Date.now = originalDateNowSecond;
+        if (originalOpenClawCliBin === undefined) delete process.env.OPENCLAW_CLI_BIN;
+        else process.env.OPENCLAW_CLI_BIN = originalOpenClawCliBin;
+      }
+
+      assert.ok(
+        harness.logs.some(([, msg]) => msg.includes("reflection generation start for session old-session")),
+        `old-session reflection should not be suppressed by the fresh empty-session guard; got ${JSON.stringify(harness.logs)}`,
       );
     });
   });


### PR DESCRIPTION
## Summary
- add a short-lived guard for repeated empty or missing command reflection sessions
- avoid repeated empty-session recovery/read/log work after `/new` reconnect storms
- keep old-session reflection eligible by keying the guard on action, session, and file fingerprint

Fixes #381

## Tests
- `node --test test/command-reflection-guard.test.mjs`
- `node --test test/hook-dedup-phase1.test.mjs`
- `node --test test/reflection-bypass-hook.test.mjs`
- `npm run build`