### PR TITLE
feat: add code-boundary chunking option

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -105,6 +105,25 @@ function parsePositiveInt(value) {
     }
     return undefined;
 }
+function parseAstChunkingConfig(value) {
+    if (value === undefined || value === null)
+        return undefined;
+    if (typeof value !== "object" || Array.isArray(value))
+        return undefined;
+    const raw = value;
+    const config = {};
+    if (typeof raw.enabled === "boolean") {
+        config.enabled = raw.enabled;
+    }
+    if (Array.isArray(raw.languages)) {
+        const allowed = new Set(["javascript", "typescript", "python"]);
+        const languages = raw.languages.filter((item) => typeof item === "string" && allowed.has(item));
+        if (languages.length > 0) {
+            config.languages = languages;
+        }
+    }
+    return config;
+}
 // Like parsePositiveInt but allows 0. Used for fields where 0 is a meaningful
 // "disabled" sentinel (e.g. autoRecallBadRecallDecayMs=0 disables decay).
 function parseNonNegativeInt(value) {
@@ -1547,6 +1566,7 @@ function _initPluginState(api) {
         taskPassage: config.embedding.taskPassage,
         normalized: config.embedding.normalized,
         chunking: config.embedding.chunking,
+        astChunking: config.embedding.astChunking,
         clientTimeoutMs: config.embedding.clientTimeoutMs,
     });
     const decayEngine = createDecayEngine({
@@ -3925,6 +3945,7 @@ export function parsePluginConfig(value) {
             chunking: typeof embedding.chunking === "boolean"
                 ? embedding.chunking
                 : undefined,
+            astChunking: parseAstChunkingConfig(embedding.astChunking),
             clientTimeoutMs: parsePositiveInt(embedding.clientTimeoutMs),
         },
         dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : undefined,

--- a/dist/src/chunker.js
+++ b/dist/src/chunker.js
@@ -139,6 +139,7 @@ function getCjkRatio(text) {
 // char limits by this factor to stay within the model's token budget.
 const CJK_CHAR_TOKEN_DIVISOR = 2.5;
 const CJK_RATIO_THRESHOLD = 0.3;
+const DEFAULT_AST_LANGUAGES = ["javascript", "typescript", "python"];
 // ============================================================================
 // Chunking Core
 // ============================================================================
@@ -195,13 +196,366 @@ export function chunkDocument(text, config = DEFAULT_CHUNKER_CONFIG) {
         chunkCount: chunks.length,
     };
 }
+// ============================================================================
+// Code-Boundary Chunking
+// ============================================================================
+function getAstLanguages(config) {
+    const languages = config?.languages?.length ? config.languages : DEFAULT_AST_LANGUAGES;
+    return new Set(languages);
+}
+export function detectCodeLanguage(text) {
+    const tsIndicators = [
+        /^\s*(?:export\s+)?(?:interface|type|enum)\s+\w+/m,
+        /:\s*(?:string|number|boolean|unknown|any)\b/,
+        /\bPromise<[^>]+>/,
+    ].filter((pattern) => pattern.test(text)).length;
+    const jsIndicators = [
+        /^\s*(?:export\s+(?:default\s+)?)?(?:async\s+)?function\s+\w+\s*\(/m,
+        /^\s*(?:export\s+(?:default\s+)?)?(?:abstract\s+)?class\s+\w+/m,
+        /^\s*(?:export\s+)?(?:const|let|var)\s+\w+\s*=/m,
+        /\bimport\s+[^;]+?\s+from\s+["'][^"']+["']/,
+        /=>/,
+    ].filter((pattern) => pattern.test(text)).length;
+    const pythonIndicators = [
+        /^\s*(?:async\s+)?def\s+\w+\s*\(/m,
+        /^\s*class\s+\w+.*:/m,
+        /^\s*(?:from\s+\w+(?:\.\w+)*\s+import|import\s+\w+)/m,
+        /^\s*if\s+__name__\s*==\s*["']__main__["']\s*:/m,
+    ].filter((pattern) => pattern.test(text)).length;
+    if (pythonIndicators >= 2 || (pythonIndicators >= 1 && jsIndicators === 0 && tsIndicators === 0)) {
+        return "python";
+    }
+    if (tsIndicators > 0 && jsIndicators > 0)
+        return "typescript";
+    if (jsIndicators >= 2 || (jsIndicators >= 1 && pythonIndicators === 0))
+        return "javascript";
+    return null;
+}
+function getLineStart(text, index) {
+    const prevNewline = text.lastIndexOf("\n", Math.max(0, index - 1));
+    return prevNewline === -1 ? 0 : prevNewline + 1;
+}
+function getLineEnd(text, index) {
+    const nextNewline = text.indexOf("\n", index);
+    return nextNewline === -1 ? text.length : nextNewline + 1;
+}
+function jsBraceDepthAt(text, end) {
+    let depth = 0;
+    let state = "code";
+    let escaped = false;
+    for (let i = 0; i < end; i++) {
+        const ch = text[i];
+        const next = text[i + 1];
+        if (state === "lineComment") {
+            if (ch === "\n")
+                state = "code";
+            continue;
+        }
+        if (state === "blockComment") {
+            if (ch === "*" && next === "/") {
+                state = "code";
+                i++;
+            }
+            continue;
+        }
+        if (state === "single" || state === "double" || state === "template") {
+            const quote = state === "single" ? "'" : state === "double" ? "\"" : "`";
+            if (escaped) {
+                escaped = false;
+            }
+            else if (ch === "\\") {
+                escaped = true;
+            }
+            else if (ch === quote) {
+                state = "code";
+            }
+            continue;
+        }
+        if (ch === "/" && next === "/") {
+            state = "lineComment";
+            i++;
+        }
+        else if (ch === "/" && next === "*") {
+            state = "blockComment";
+            i++;
+        }
+        else if (ch === "'") {
+            state = "single";
+        }
+        else if (ch === "\"") {
+            state = "double";
+        }
+        else if (ch === "`") {
+            state = "template";
+        }
+        else if (ch === "{") {
+            depth++;
+        }
+        else if (ch === "}") {
+            depth = Math.max(0, depth - 1);
+        }
+    }
+    return depth;
+}
+function findMatchingJsBrace(text, openIndex) {
+    let depth = 0;
+    let state = "code";
+    let escaped = false;
+    for (let i = openIndex; i < text.length; i++) {
+        const ch = text[i];
+        const next = text[i + 1];
+        if (state === "lineComment") {
+            if (ch === "\n")
+                state = "code";
+            continue;
+        }
+        if (state === "blockComment") {
+            if (ch === "*" && next === "/") {
+                state = "code";
+                i++;
+            }
+            continue;
+        }
+        if (state === "single" || state === "double" || state === "template") {
+            const quote = state === "single" ? "'" : state === "double" ? "\"" : "`";
+            if (escaped) {
+                escaped = false;
+            }
+            else if (ch === "\\") {
+                escaped = true;
+            }
+            else if (ch === quote) {
+                state = "code";
+            }
+            continue;
+        }
+        if (ch === "/" && next === "/") {
+            state = "lineComment";
+            i++;
+        }
+        else if (ch === "/" && next === "*") {
+            state = "blockComment";
+            i++;
+        }
+        else if (ch === "'") {
+            state = "single";
+        }
+        else if (ch === "\"") {
+            state = "double";
+        }
+        else if (ch === "`") {
+            state = "template";
+        }
+        else if (ch === "{") {
+            depth++;
+        }
+        else if (ch === "}") {
+            depth--;
+            if (depth === 0)
+                return i;
+        }
+    }
+    return -1;
+}
+function findOpeningJsBrace(text, start) {
+    let state = "code";
+    let escaped = false;
+    for (let i = start; i < text.length; i++) {
+        const ch = text[i];
+        const next = text[i + 1];
+        if (state === "lineComment") {
+            if (ch === "\n")
+                state = "code";
+            continue;
+        }
+        if (state === "blockComment") {
+            if (ch === "*" && next === "/") {
+                state = "code";
+                i++;
+            }
+            continue;
+        }
+        if (state === "single" || state === "double" || state === "template") {
+            const quote = state === "single" ? "'" : state === "double" ? "\"" : "`";
+            if (escaped) {
+                escaped = false;
+            }
+            else if (ch === "\\") {
+                escaped = true;
+            }
+            else if (ch === quote) {
+                state = "code";
+            }
+            continue;
+        }
+        if (ch === "/" && next === "/") {
+            state = "lineComment";
+            i++;
+        }
+        else if (ch === "/" && next === "*") {
+            state = "blockComment";
+            i++;
+        }
+        else if (ch === "'") {
+            state = "single";
+        }
+        else if (ch === "\"") {
+            state = "double";
+        }
+        else if (ch === "`") {
+            state = "template";
+        }
+        else if (ch === "{") {
+            return i;
+        }
+        else if (ch === "\n" && text.slice(start, i).includes(";")) {
+            return -1;
+        }
+    }
+    return -1;
+}
+function findJsCodeUnits(text) {
+    const units = [];
+    const declarationPattern = /^[ \t]*(?:(?:export|declare)\s+)*(?:default\s+)?(?:(?:abstract\s+)?class\s+[$A-Z_a-z][$\w]*|(?:async\s+)?function\s+[$A-Z_a-z][$\w]*|(?:const|let|var)\s+[$A-Z_a-z][$\w]*\s*=\s*(?:async\s*)?(?:\([^)]*\)|[$A-Z_a-z][$\w]*)\s*=>)/gm;
+    for (const match of text.matchAll(declarationPattern)) {
+        const matchIndex = match.index ?? 0;
+        const lineStart = getLineStart(text, matchIndex);
+        if (jsBraceDepthAt(text, matchIndex) !== 0)
+            continue;
+        const openBrace = findOpeningJsBrace(text, matchIndex);
+        if (openBrace === -1)
+            return null;
+        const closeBrace = findMatchingJsBrace(text, openBrace);
+        if (closeBrace === -1)
+            return null;
+        let end = getLineEnd(text, closeBrace + 1);
+        if (text[end] === ";")
+            end = getLineEnd(text, end + 1);
+        const previous = units[units.length - 1];
+        if (!previous || lineStart >= previous.end) {
+            units.push({ start: lineStart, end });
+        }
+    }
+    return units.length > 0 ? units : null;
+}
+function getBaseIndent(text) {
+    let min = Number.POSITIVE_INFINITY;
+    for (const line of text.split(/\r\n|\n|\r/)) {
+        if (line.trim().length === 0)
+            continue;
+        const indent = line.match(/^[ \t]*/)?.[0].length ?? 0;
+        min = Math.min(min, indent);
+    }
+    return Number.isFinite(min) ? min : 0;
+}
+function findPythonCodeUnits(text) {
+    const units = [];
+    const baseIndent = getBaseIndent(text);
+    const lines = text.matchAll(/^([ \t]*)(.*)(?:\r?\n|$)/gm);
+    const candidates = [];
+    for (const match of lines) {
+        const start = match.index ?? 0;
+        const indent = match[1] ?? "";
+        const body = match[2] ?? "";
+        if (indent.length === baseIndent && /^(?:async\s+def|def|class)\s+\w+/.test(body.trimStart())) {
+            let adjustedStart = start;
+            let cursor = start;
+            while (cursor > 0) {
+                const prevEnd = cursor - 1;
+                const prevStart = getLineStart(text, prevEnd);
+                const prevLine = text.slice(prevStart, cursor).trim();
+                if (!prevLine.startsWith("@"))
+                    break;
+                adjustedStart = prevStart;
+                cursor = prevStart;
+            }
+            candidates.push(adjustedStart);
+        }
+    }
+    for (let i = 0; i < candidates.length; i++) {
+        const start = candidates[i];
+        const end = i + 1 < candidates.length ? candidates[i + 1] : text.length;
+        units.push({ start, end });
+    }
+    return units.length > 0 ? units : null;
+}
+function buildBoundaryChunks(text, units, config) {
+    const spans = [];
+    let previousEnd = 0;
+    for (const unit of units) {
+        const start = previousEnd;
+        const end = unit.end;
+        if (end <= start)
+            continue;
+        spans.push({ start, end });
+        previousEnd = end;
+    }
+    if (previousEnd < text.length) {
+        spans.push({ start: previousEnd, end: text.length });
+    }
+    const chunks = [];
+    const metadatas = [];
+    let currentStart = null;
+    let currentEnd = null;
+    const flush = () => {
+        if (currentStart === null || currentEnd === null)
+            return;
+        const { chunk, meta } = sliceTrimWithIndices(text, currentStart, currentEnd);
+        if (chunk.length > 0) {
+            chunks.push(chunk);
+            metadatas.push(meta);
+        }
+        currentStart = null;
+        currentEnd = null;
+    };
+    for (const span of spans) {
+        const trimmed = sliceTrimWithIndices(text, span.start, span.end);
+        if (trimmed.chunk.length === 0)
+            continue;
+        if (trimmed.chunk.length > config.maxChunkSize)
+            return null;
+        if (currentStart === null || currentEnd === null) {
+            currentStart = span.start;
+            currentEnd = span.end;
+            continue;
+        }
+        const candidate = sliceTrimWithIndices(text, currentStart, span.end);
+        if (candidate.chunk.length <= config.maxChunkSize) {
+            currentEnd = span.end;
+            continue;
+        }
+        flush();
+        currentStart = span.start;
+        currentEnd = span.end;
+    }
+    flush();
+    if (chunks.length === 0)
+        return null;
+    return {
+        chunks,
+        metadatas,
+        totalOriginalLength: text.length,
+        chunkCount: chunks.length,
+    };
+}
+export function chunkCodeByBoundaries(text, config, astConfig) {
+    if (!astConfig.enabled)
+        return null;
+    const language = detectCodeLanguage(text);
+    if (!language || !getAstLanguages(astConfig).has(language))
+        return null;
+    const units = language === "python" ? findPythonCodeUnits(text) : findJsCodeUnits(text);
+    if (!units)
+        return null;
+    return buildBoundaryChunks(text, units, config);
+}
 /**
  * Smart chunker that adapts to model context limits.
  *
  * We intentionally pick conservative char limits (70% of the reported limit)
  * since token/char ratios vary.
  */
-export function smartChunk(text, embedderModel) {
+export function smartChunk(text, embedderModel, astConfig) {
     const limit = embedderModel ? EMBEDDING_CONTEXT_LIMITS[embedderModel] : undefined;
     const base = limit ?? 8192;
     // CJK characters consume ~2-3 tokens each, so a char-based limit that works
@@ -215,6 +569,16 @@ export function smartChunk(text, embedderModel) {
         semanticSplit: true,
         maxLinesPerChunk: 50,
     };
+    if (astConfig?.enabled) {
+        try {
+            const astResult = chunkCodeByBoundaries(text, config, astConfig);
+            if (astResult)
+                return astResult;
+        }
+        catch {
+            // Hard fallback: AST/code-boundary splitting must never break existing chunking.
+        }
+    }
     return chunkDocument(text, config);
 }
 export default chunkDocument;

--- a/dist/src/embedder.js
+++ b/dist/src/embedder.js
@@ -378,6 +378,8 @@ export class Embedder {
     _omitDimensions;
     /** Enable automatic chunking for long documents (default: true) */
     _autoChunk;
+    /** Optional code-boundary-aware chunking configuration */
+    _astChunking;
     constructor(config) {
         // Normalize apiKey to array and resolve environment variables
         const apiKeys = Array.isArray(config.apiKey) ? config.apiKey : [config.apiKey];
@@ -391,6 +393,7 @@ export class Embedder {
         this._omitDimensions = config.omitDimensions === true;
         // Enable auto-chunking by default for better handling of long documents
         this._autoChunk = config.chunking !== false;
+        this._astChunking = config.astChunking;
         const profile = detectEmbeddingProviderProfile(this._baseURL, this._model);
         this._capabilities = getEmbeddingCapabilities(profile);
         const clientTimeoutMs = Number.isFinite(config.clientTimeoutMs) && config.clientTimeoutMs > 0
@@ -738,7 +741,7 @@ export class Embedder {
             if (isContextError && this._autoChunk) {
                 try {
                     console.log(`Document exceeded context limit (${errorMsg}), attempting chunking...`);
-                    const chunkResult = smartChunk(text, this._model);
+                    const chunkResult = smartChunk(text, this._model, this._astChunking);
                     if (chunkResult.chunks.length === 0) {
                         throw new Error(`Failed to chunk document: ${errorMsg}`);
                     }
@@ -840,7 +843,7 @@ export class Embedder {
                 try {
                     console.log(`Batch embedding failed with context error, attempting chunking...`);
                     const chunkResults = await Promise.all(validTexts.map(async (text, idx) => {
-                        const chunkResult = smartChunk(text, this._model);
+                        const chunkResult = smartChunk(text, this._model, this._astChunking);
                         if (chunkResult.chunks.length === 0) {
                             throw new Error("Chunker produced no chunks");
                         }

--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,7 @@ import {
   createEmbedder,
   getEffectiveVectorDimensions,
 } from "./src/embedder.js";
+import type { ChunkerAstConfig, CodeChunkLanguage } from "./src/chunker.js";
 import { createRetriever, DEFAULT_RETRIEVAL_CONFIG, type RetrievalConfig } from "./src/retriever.js";
 import { createScopeManager, resolveScopeFilter, isSystemBypassId, parseAgentIdFromSessionKey } from "./src/scopes.js";
 import { createMigrator } from "./src/migrate.js";
@@ -116,6 +117,7 @@ interface PluginConfig {
     taskPassage?: string;
     normalized?: boolean;
     chunking?: boolean;
+    astChunking?: ChunkerAstConfig;
     clientTimeoutMs?: number;
   };
   dbPath?: string;
@@ -352,6 +354,30 @@ function parsePositiveInt(value: unknown): number | undefined {
     if (Number.isFinite(n) && n > 0) return Math.floor(n);
   }
   return undefined;
+}
+
+function parseAstChunkingConfig(value: unknown): ChunkerAstConfig | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "object" || Array.isArray(value)) return undefined;
+
+  const raw = value as Record<string, unknown>;
+  const config: ChunkerAstConfig = {};
+
+  if (typeof raw.enabled === "boolean") {
+    config.enabled = raw.enabled;
+  }
+
+  if (Array.isArray(raw.languages)) {
+    const allowed = new Set<CodeChunkLanguage>(["javascript", "typescript", "python"]);
+    const languages = raw.languages.filter((item): item is CodeChunkLanguage =>
+      typeof item === "string" && allowed.has(item as CodeChunkLanguage),
+    );
+    if (languages.length > 0) {
+      config.languages = languages;
+    }
+  }
+
+  return config;
 }
 
 // Like parsePositiveInt but allows 0. Used for fields where 0 is a meaningful
@@ -2065,6 +2091,7 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
     taskPassage: config.embedding.taskPassage,
     normalized: config.embedding.normalized,
     chunking: config.embedding.chunking,
+    astChunking: config.embedding.astChunking,
     clientTimeoutMs: config.embedding.clientTimeoutMs,
   });
   const decayEngine = createDecayEngine({
@@ -4945,6 +4972,7 @@ export function parsePluginConfig(value: unknown): PluginConfig {
         typeof embedding.chunking === "boolean"
           ? embedding.chunking
           : undefined,
+      astChunking: parseAstChunkingConfig(embedding.astChunking),
       clientTimeoutMs: parsePositiveInt(embedding.clientTimeoutMs),
     },
     dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : undefined,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -106,6 +106,35 @@
             "default": true,
             "description": "Enable automatic chunking for documents exceeding embedding context limits"
           },
+          "astChunking": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Experimental code-boundary-aware chunking for supported code blocks. Disabled by default and falls back to normal chunking when unsupported.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Enable code-boundary-aware chunking for JavaScript, TypeScript, and Python code blocks"
+              },
+              "languages": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "javascript",
+                    "typescript",
+                    "python"
+                  ]
+                },
+                "default": [
+                  "javascript",
+                  "typescript",
+                  "python"
+                ],
+                "description": "Languages eligible for code-boundary-aware chunking"
+              }
+            }
+          },
           "clientTimeoutMs": {
             "type": "integer",
             "minimum": 1000,
@@ -1495,6 +1524,11 @@
     "embedding.chunking": {
       "label": "Auto-Chunk Documents",
       "help": "Automatically split long documents into chunks when they exceed embedding context limits. Enabled by default.",
+      "advanced": true
+    },
+    "embedding.astChunking.enabled": {
+      "label": "AST Code Chunking",
+      "help": "Experimental: keep supported JavaScript, TypeScript, and Python functions/classes together when auto-chunking long code. Disabled by default.",
       "advanced": true
     },
     "embedding.clientTimeoutMs": {

--- a/src/chunker.ts
+++ b/src/chunker.ts
@@ -26,6 +26,15 @@ export interface ChunkResult {
   chunkCount: number;
 }
 
+export type CodeChunkLanguage = "javascript" | "typescript" | "python";
+
+export interface ChunkerAstConfig {
+  /** Enable code-boundary-aware chunking for supported languages. Default: false. */
+  enabled?: boolean;
+  /** Supported language whitelist. Defaults to JS/TS/Python. */
+  languages?: CodeChunkLanguage[];
+}
+
 export interface ChunkerConfig {
   /** Maximum characters per chunk. */
   maxChunkSize: number;
@@ -188,6 +197,13 @@ function getCjkRatio(text: string): number {
 const CJK_CHAR_TOKEN_DIVISOR = 2.5;
 const CJK_RATIO_THRESHOLD = 0.3;
 
+const DEFAULT_AST_LANGUAGES: CodeChunkLanguage[] = ["javascript", "typescript", "python"];
+
+interface CodeUnit {
+  start: number;
+  end: number;
+}
+
 // ============================================================================
 // Chunking Core
 // ============================================================================
@@ -255,13 +271,378 @@ export function chunkDocument(text: string, config: ChunkerConfig = DEFAULT_CHUN
   };
 }
 
+// ============================================================================
+// Code-Boundary Chunking
+// ============================================================================
+
+function getAstLanguages(config?: ChunkerAstConfig): Set<CodeChunkLanguage> {
+  const languages = config?.languages?.length ? config.languages : DEFAULT_AST_LANGUAGES;
+  return new Set(languages);
+}
+
+export function detectCodeLanguage(text: string): CodeChunkLanguage | null {
+  const tsIndicators = [
+    /^\s*(?:export\s+)?(?:interface|type|enum)\s+\w+/m,
+    /:\s*(?:string|number|boolean|unknown|any)\b/,
+    /\bPromise<[^>]+>/,
+  ].filter((pattern) => pattern.test(text)).length;
+
+  const jsIndicators = [
+    /^\s*(?:export\s+(?:default\s+)?)?(?:async\s+)?function\s+\w+\s*\(/m,
+    /^\s*(?:export\s+(?:default\s+)?)?(?:abstract\s+)?class\s+\w+/m,
+    /^\s*(?:export\s+)?(?:const|let|var)\s+\w+\s*=/m,
+    /\bimport\s+[^;]+?\s+from\s+["'][^"']+["']/,
+    /=>/,
+  ].filter((pattern) => pattern.test(text)).length;
+
+  const pythonIndicators = [
+    /^\s*(?:async\s+)?def\s+\w+\s*\(/m,
+    /^\s*class\s+\w+.*:/m,
+    /^\s*(?:from\s+\w+(?:\.\w+)*\s+import|import\s+\w+)/m,
+    /^\s*if\s+__name__\s*==\s*["']__main__["']\s*:/m,
+  ].filter((pattern) => pattern.test(text)).length;
+
+  if (pythonIndicators >= 2 || (pythonIndicators >= 1 && jsIndicators === 0 && tsIndicators === 0)) {
+    return "python";
+  }
+
+  if (tsIndicators > 0 && jsIndicators > 0) return "typescript";
+  if (jsIndicators >= 2 || (jsIndicators >= 1 && pythonIndicators === 0)) return "javascript";
+  return null;
+}
+
+function getLineStart(text: string, index: number): number {
+  const prevNewline = text.lastIndexOf("\n", Math.max(0, index - 1));
+  return prevNewline === -1 ? 0 : prevNewline + 1;
+}
+
+function getLineEnd(text: string, index: number): number {
+  const nextNewline = text.indexOf("\n", index);
+  return nextNewline === -1 ? text.length : nextNewline + 1;
+}
+
+function jsBraceDepthAt(text: string, end: number): number {
+  let depth = 0;
+  let state: "code" | "single" | "double" | "template" | "lineComment" | "blockComment" = "code";
+  let escaped = false;
+
+  for (let i = 0; i < end; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (state === "lineComment") {
+      if (ch === "\n") state = "code";
+      continue;
+    }
+    if (state === "blockComment") {
+      if (ch === "*" && next === "/") {
+        state = "code";
+        i++;
+      }
+      continue;
+    }
+    if (state === "single" || state === "double" || state === "template") {
+      const quote = state === "single" ? "'" : state === "double" ? "\"" : "`";
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        state = "code";
+      }
+      continue;
+    }
+
+    if (ch === "/" && next === "/") {
+      state = "lineComment";
+      i++;
+    } else if (ch === "/" && next === "*") {
+      state = "blockComment";
+      i++;
+    } else if (ch === "'") {
+      state = "single";
+    } else if (ch === "\"") {
+      state = "double";
+    } else if (ch === "`") {
+      state = "template";
+    } else if (ch === "{") {
+      depth++;
+    } else if (ch === "}") {
+      depth = Math.max(0, depth - 1);
+    }
+  }
+
+  return depth;
+}
+
+function findMatchingJsBrace(text: string, openIndex: number): number {
+  let depth = 0;
+  let state: "code" | "single" | "double" | "template" | "lineComment" | "blockComment" = "code";
+  let escaped = false;
+
+  for (let i = openIndex; i < text.length; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (state === "lineComment") {
+      if (ch === "\n") state = "code";
+      continue;
+    }
+    if (state === "blockComment") {
+      if (ch === "*" && next === "/") {
+        state = "code";
+        i++;
+      }
+      continue;
+    }
+    if (state === "single" || state === "double" || state === "template") {
+      const quote = state === "single" ? "'" : state === "double" ? "\"" : "`";
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        state = "code";
+      }
+      continue;
+    }
+
+    if (ch === "/" && next === "/") {
+      state = "lineComment";
+      i++;
+    } else if (ch === "/" && next === "*") {
+      state = "blockComment";
+      i++;
+    } else if (ch === "'") {
+      state = "single";
+    } else if (ch === "\"") {
+      state = "double";
+    } else if (ch === "`") {
+      state = "template";
+    } else if (ch === "{") {
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+
+  return -1;
+}
+
+function findOpeningJsBrace(text: string, start: number): number {
+  let state: "code" | "single" | "double" | "template" | "lineComment" | "blockComment" = "code";
+  let escaped = false;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (state === "lineComment") {
+      if (ch === "\n") state = "code";
+      continue;
+    }
+    if (state === "blockComment") {
+      if (ch === "*" && next === "/") {
+        state = "code";
+        i++;
+      }
+      continue;
+    }
+    if (state === "single" || state === "double" || state === "template") {
+      const quote = state === "single" ? "'" : state === "double" ? "\"" : "`";
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        state = "code";
+      }
+      continue;
+    }
+
+    if (ch === "/" && next === "/") {
+      state = "lineComment";
+      i++;
+    } else if (ch === "/" && next === "*") {
+      state = "blockComment";
+      i++;
+    } else if (ch === "'") {
+      state = "single";
+    } else if (ch === "\"") {
+      state = "double";
+    } else if (ch === "`") {
+      state = "template";
+    } else if (ch === "{") {
+      return i;
+    } else if (ch === "\n" && text.slice(start, i).includes(";")) {
+      return -1;
+    }
+  }
+
+  return -1;
+}
+
+function findJsCodeUnits(text: string): CodeUnit[] | null {
+  const units: CodeUnit[] = [];
+  const declarationPattern =
+    /^[ \t]*(?:(?:export|declare)\s+)*(?:default\s+)?(?:(?:abstract\s+)?class\s+[$A-Z_a-z][$\w]*|(?:async\s+)?function\s+[$A-Z_a-z][$\w]*|(?:const|let|var)\s+[$A-Z_a-z][$\w]*\s*=\s*(?:async\s*)?(?:\([^)]*\)|[$A-Z_a-z][$\w]*)\s*=>)/gm;
+
+  for (const match of text.matchAll(declarationPattern)) {
+    const matchIndex = match.index ?? 0;
+    const lineStart = getLineStart(text, matchIndex);
+    if (jsBraceDepthAt(text, matchIndex) !== 0) continue;
+
+    const openBrace = findOpeningJsBrace(text, matchIndex);
+    if (openBrace === -1) return null;
+
+    const closeBrace = findMatchingJsBrace(text, openBrace);
+    if (closeBrace === -1) return null;
+
+    let end = getLineEnd(text, closeBrace + 1);
+    if (text[end] === ";") end = getLineEnd(text, end + 1);
+
+    const previous = units[units.length - 1];
+    if (!previous || lineStart >= previous.end) {
+      units.push({ start: lineStart, end });
+    }
+  }
+
+  return units.length > 0 ? units : null;
+}
+
+function getBaseIndent(text: string): number {
+  let min = Number.POSITIVE_INFINITY;
+  for (const line of text.split(/\r\n|\n|\r/)) {
+    if (line.trim().length === 0) continue;
+    const indent = line.match(/^[ \t]*/)?.[0].length ?? 0;
+    min = Math.min(min, indent);
+  }
+  return Number.isFinite(min) ? min : 0;
+}
+
+function findPythonCodeUnits(text: string): CodeUnit[] | null {
+  const units: CodeUnit[] = [];
+  const baseIndent = getBaseIndent(text);
+  const lines = text.matchAll(/^([ \t]*)(.*)(?:\r?\n|$)/gm);
+  const candidates: number[] = [];
+
+  for (const match of lines) {
+    const start = match.index ?? 0;
+    const indent = match[1] ?? "";
+    const body = match[2] ?? "";
+    if (indent.length === baseIndent && /^(?:async\s+def|def|class)\s+\w+/.test(body.trimStart())) {
+      let adjustedStart = start;
+      let cursor = start;
+      while (cursor > 0) {
+        const prevEnd = cursor - 1;
+        const prevStart = getLineStart(text, prevEnd);
+        const prevLine = text.slice(prevStart, cursor).trim();
+        if (!prevLine.startsWith("@")) break;
+        adjustedStart = prevStart;
+        cursor = prevStart;
+      }
+      candidates.push(adjustedStart);
+    }
+  }
+
+  for (let i = 0; i < candidates.length; i++) {
+    const start = candidates[i];
+    const end = i + 1 < candidates.length ? candidates[i + 1] : text.length;
+    units.push({ start, end });
+  }
+
+  return units.length > 0 ? units : null;
+}
+
+function buildBoundaryChunks(text: string, units: CodeUnit[], config: ChunkerConfig): ChunkResult | null {
+  const spans: CodeUnit[] = [];
+  let previousEnd = 0;
+
+  for (const unit of units) {
+    const start = previousEnd;
+    const end = unit.end;
+    if (end <= start) continue;
+    spans.push({ start, end });
+    previousEnd = end;
+  }
+
+  if (previousEnd < text.length) {
+    spans.push({ start: previousEnd, end: text.length });
+  }
+
+  const chunks: string[] = [];
+  const metadatas: ChunkMetadata[] = [];
+  let currentStart: number | null = null;
+  let currentEnd: number | null = null;
+
+  const flush = () => {
+    if (currentStart === null || currentEnd === null) return;
+    const { chunk, meta } = sliceTrimWithIndices(text, currentStart, currentEnd);
+    if (chunk.length > 0) {
+      chunks.push(chunk);
+      metadatas.push(meta);
+    }
+    currentStart = null;
+    currentEnd = null;
+  };
+
+  for (const span of spans) {
+    const trimmed = sliceTrimWithIndices(text, span.start, span.end);
+    if (trimmed.chunk.length === 0) continue;
+    if (trimmed.chunk.length > config.maxChunkSize) return null;
+
+    if (currentStart === null || currentEnd === null) {
+      currentStart = span.start;
+      currentEnd = span.end;
+      continue;
+    }
+
+    const candidate = sliceTrimWithIndices(text, currentStart, span.end);
+    if (candidate.chunk.length <= config.maxChunkSize) {
+      currentEnd = span.end;
+      continue;
+    }
+
+    flush();
+    currentStart = span.start;
+    currentEnd = span.end;
+  }
+
+  flush();
+
+  if (chunks.length === 0) return null;
+  return {
+    chunks,
+    metadatas,
+    totalOriginalLength: text.length,
+    chunkCount: chunks.length,
+  };
+}
+
+export function chunkCodeByBoundaries(
+  text: string,
+  config: ChunkerConfig,
+  astConfig: ChunkerAstConfig,
+): ChunkResult | null {
+  if (!astConfig.enabled) return null;
+
+  const language = detectCodeLanguage(text);
+  if (!language || !getAstLanguages(astConfig).has(language)) return null;
+
+  const units = language === "python" ? findPythonCodeUnits(text) : findJsCodeUnits(text);
+  if (!units) return null;
+
+  return buildBoundaryChunks(text, units, config);
+}
+
 /**
  * Smart chunker that adapts to model context limits.
  *
  * We intentionally pick conservative char limits (70% of the reported limit)
  * since token/char ratios vary.
  */
-export function smartChunk(text: string, embedderModel?: string): ChunkResult {
+export function smartChunk(text: string, embedderModel?: string, astConfig?: ChunkerAstConfig): ChunkResult {
   const limit = embedderModel ? EMBEDDING_CONTEXT_LIMITS[embedderModel] : undefined;
   const base = limit ?? 8192;
 
@@ -277,6 +658,15 @@ export function smartChunk(text: string, embedderModel?: string): ChunkResult {
     semanticSplit: true,
     maxLinesPerChunk: 50,
   };
+
+  if (astConfig?.enabled) {
+    try {
+      const astResult = chunkCodeByBoundaries(text, config, astConfig);
+      if (astResult) return astResult;
+    } catch {
+      // Hard fallback: AST/code-boundary splitting must never break existing chunking.
+    }
+  }
 
   return chunkDocument(text, config);
 }

--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -10,7 +10,7 @@
 
 import OpenAI from "openai";
 import { createHash } from "node:crypto";
-import { smartChunk } from "./chunker.js";
+import { smartChunk, type ChunkerAstConfig } from "./chunker.js";
 
 // ============================================================================
 // Embedding Cache (LRU with TTL)
@@ -125,6 +125,8 @@ export interface EmbeddingConfig {
   omitDimensions?: boolean;
   /** Enable automatic chunking for documents exceeding context limits (default: true) */
   chunking?: boolean;
+  /** Enable code-boundary-aware chunking for supported code blocks. Default: disabled. */
+  astChunking?: ChunkerAstConfig;
   /** OpenAI SDK per-request timeout in ms. Defaults to 30000. */
   clientTimeoutMs?: number;
 }
@@ -484,8 +486,10 @@ export class Embedder {
   private readonly _omitDimensions: boolean;
   /** Enable automatic chunking for long documents (default: true) */
   private readonly _autoChunk: boolean;
+  /** Optional code-boundary-aware chunking configuration */
+  private readonly _astChunking?: ChunkerAstConfig;
 
-  constructor(config: EmbeddingConfig & { chunking?: boolean }) {
+  constructor(config: EmbeddingConfig & { chunking?: boolean; astChunking?: ChunkerAstConfig }) {
     // Normalize apiKey to array and resolve environment variables
     const apiKeys = Array.isArray(config.apiKey) ? config.apiKey : [config.apiKey];
     const resolvedKeys = apiKeys.map(k => resolveEnvVars(k));
@@ -499,6 +503,7 @@ export class Embedder {
     this._omitDimensions = config.omitDimensions === true;
     // Enable auto-chunking by default for better handling of long documents
     this._autoChunk = config.chunking !== false;
+    this._astChunking = config.astChunking;
     const profile = detectEmbeddingProviderProfile(this._baseURL, this._model);
     this._capabilities = getEmbeddingCapabilities(profile);
     const clientTimeoutMs = Number.isFinite(config.clientTimeoutMs) && config.clientTimeoutMs! > 0
@@ -922,7 +927,7 @@ export class Embedder {
       if (isContextError && this._autoChunk) {
         try {
           console.log(`Document exceeded context limit (${errorMsg}), attempting chunking...`);
-          const chunkResult = smartChunk(text, this._model);
+          const chunkResult = smartChunk(text, this._model, this._astChunking);
 
           if (chunkResult.chunks.length === 0) {
             throw new Error(`Failed to chunk document: ${errorMsg}`);
@@ -1056,7 +1061,7 @@ export class Embedder {
 
           const chunkResults = await Promise.all(
             validTexts.map(async (text, idx) => {
-              const chunkResult = smartChunk(text, this._model);
+              const chunkResult = smartChunk(text, this._model, this._astChunking);
               if (chunkResult.chunks.length === 0) {
                 throw new Error("Chunker produced no chunks");
               }

--- a/test/chunker-ast-code-boundary.test.mjs
+++ b/test/chunker-ast-code-boundary.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const { detectCodeLanguage, smartChunk } = jiti("../src/chunker.ts");
+
+const AST_ON = { enabled: true };
+const MODEL = "gemini-embedding-001";
+
+function assertBalancedBraces(chunk) {
+  const opens = (chunk.match(/\{/g) ?? []).length;
+  const closes = (chunk.match(/\}/g) ?? []).length;
+  assert.equal(opens, closes, `expected balanced braces in chunk:\n${chunk}`);
+}
+
+function buildTypeScriptFixture() {
+  const repeatedChecks = Array.from({ length: 13 }, (_, idx) => {
+    return `  if (auditTrail.includes("step-${idx}")) {\n    events.push("step-${idx}");\n  }`;
+  }).join("\n");
+
+  return `import { LoginCredentials, AuthResult } from "./auth-types";
+
+export async function handleUserLogin(
+  userId: string,
+  credentials: LoginCredentials,
+): Promise<AuthResult> {
+  const events: string[] = [];
+  const auditTrail = credentials.auditTrail ?? [];
+${repeatedChecks}
+  if (!credentials.password) {
+    return { success: false, error: "INVALID_PASSWORD", events };
+  }
+  return { success: true, session: { userId }, events };
+}
+
+export async function verifyPassword(
+  inputPassword: string,
+  storedHash: string,
+): Promise<boolean> {
+  const bcrypt = await import("bcrypt");
+  const normalized = inputPassword.trim();
+  if (normalized.length === 0) {
+    return false;
+  }
+  return bcrypt.compare(normalized, storedHash);
+}
+`;
+}
+
+function buildPythonFixture() {
+  const classLines = Array.from({ length: 15 }, (_, idx) => {
+    return `        if "step_${idx}" in payload:\n            events.append("step_${idx}")`;
+  }).join("\n");
+
+  return `import hashlib
+
+class LoginHandler:
+    def handle_user_login(self, payload):
+        events = []
+${classLines}
+        if not payload.get("password"):
+            return {"success": False, "error": "INVALID_PASSWORD", "events": events}
+        return {"success": True, "events": events}
+
+def verify_password(input_password, stored_hash):
+    normalized = input_password.strip()
+    if not normalized:
+        return False
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return digest == stored_hash
+`;
+}
+
+{
+  const code = buildTypeScriptFixture();
+  const result = smartChunk(code, MODEL, AST_ON);
+
+  assert.equal(detectCodeLanguage(code), "typescript");
+  assert(result.chunkCount > 1, "fixture should split into multiple chunks");
+  assert(result.chunks.every((chunk) => chunk.length <= 1433), "chunks should stay under model-derived limit");
+  result.chunks.forEach(assertBalancedBraces);
+
+  const loginChunk = result.chunks.find((chunk) => chunk.includes("handleUserLogin"));
+  assert(loginChunk, "expected handleUserLogin chunk");
+  assert(loginChunk.includes('return { success: true, session: { userId }, events };'));
+
+  const verifyChunk = result.chunks.find((chunk) => chunk.includes("verifyPassword"));
+  assert(verifyChunk, "expected verifyPassword chunk");
+  assert(verifyChunk.includes('return bcrypt.compare(normalized, storedHash);'));
+  assert(!verifyChunk.trimStart().startsWith("}"), "verifyPassword chunk should not start with a dangling brace");
+}
+
+{
+  const code = buildPythonFixture();
+  const result = smartChunk(code, MODEL, AST_ON);
+
+  assert.equal(detectCodeLanguage(code), "python");
+  assert(result.chunkCount > 1, "fixture should split into multiple chunks");
+
+  const classChunk = result.chunks.find((chunk) => chunk.includes("class LoginHandler"));
+  assert(classChunk, "expected LoginHandler chunk");
+  assert(classChunk.includes('return {"success": True, "events": events}'));
+
+  const verifyChunk = result.chunks.find((chunk) => chunk.includes("def verify_password"));
+  assert(verifyChunk, "expected verify_password chunk");
+  assert(verifyChunk.includes("return digest == stored_hash"));
+  assert(!verifyChunk.includes("class LoginHandler"), "Python function should not be merged back into class chunk");
+}
+
+{
+  const malformed = `function brokenExample() {\n  if (true) {\n    return "missing braces";\n`;
+  assert.deepEqual(
+    smartChunk(malformed, MODEL, AST_ON),
+    smartChunk(malformed, MODEL),
+    "malformed JS should hard-fallback to the existing splitter",
+  );
+}
+
+{
+  const code = buildTypeScriptFixture();
+  assert.deepEqual(
+    smartChunk(code, MODEL, { enabled: true, languages: ["python"] }),
+    smartChunk(code, MODEL),
+    "language whitelist misses should use the existing splitter",
+  );
+}
+
+console.log("chunker AST/code-boundary regression tests passed");

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -115,6 +115,20 @@ assert.equal(
   true,
   "embedding.chunking schema default should match runtime default",
 );
+assert.equal(
+  manifest.configSchema.properties.embedding.properties.astChunking.properties.enabled.default,
+  false,
+  "embedding.astChunking.enabled should default off",
+);
+assert.deepEqual(
+  manifest.configSchema.properties.embedding.properties.astChunking.properties.languages.default,
+  ["javascript", "typescript", "python"],
+  "embedding.astChunking.languages should default to Phase 1 languages",
+);
+assert.ok(
+  Object.prototype.hasOwnProperty.call(manifest.uiHints, "embedding.astChunking.enabled"),
+  "uiHints should expose embedding.astChunking.enabled",
+);
 assert.ok(
   !(manifest.configSchema.required ?? []).includes("embedding"),
   "root configSchema should not require embedding because OpenClaw preflight validates undefined plugin config as {} before runtime parsePluginConfig can emit the clearer activation error",
@@ -202,6 +216,24 @@ assert.equal(
   pkg.dependencies["apache-arrow"],
   "18.1.0",
   "package.json should declare apache-arrow directly so OpenClaw plugin installs do not miss the LanceDB runtime dependency",
+);
+
+assert.deepEqual(
+  plugin.parsePluginConfig({
+    embedding: {
+      provider: "openai-compatible",
+      apiKey: "dummy",
+      astChunking: {
+        enabled: true,
+        languages: ["typescript", "python", "ruby"],
+      },
+    },
+  }).embedding.astChunking,
+  {
+    enabled: true,
+    languages: ["typescript", "python"],
+  },
+  "parsePluginConfig should wire supported AST chunking settings and discard unsupported language names",
 );
 
 const workDir = mkdtempSync(path.join(tmpdir(), "memory-plugin-regression-"));


### PR DESCRIPTION
## Summary
- add default-off `embedding.astChunking` config for code-boundary-aware chunking
- keep top-level JavaScript, TypeScript, and Python functions/classes intact when safe
- hard-fallback to existing chunking for disabled config, unsupported language, malformed code, or oversized units

Refs #692

## Tests
- `node test/chunker-ast-code-boundary.test.mjs`
- `node test/plugin-manifest-regression.mjs`
- `node test/cjk-recursion-regression.test.mjs`
- `npm run build`

## Notes
- This is a conservative Phase 1 implementation and does not add tree-sitter/WASM parsing. It intentionally leaves complex syntax and oversized declarations on the existing fallback path.