### PR TITLE
fix: update legacy slug memory ids

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -875,16 +875,13 @@ export class MemoryStore {
     }
 
     return this.runWithFileLock(() => this.runSerializedUpdate(async () => {
-      // Support both full UUID and short prefix (8+ hex chars), same as delete()
+      // Support full UUID, short hex prefixes, and exact legacy IDs imported
+      // from older stores (for example "data-pointer-...").
       const uuidRegex =
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
       const prefixRegex = /^[0-9a-f]{8,}$/i;
       const isFullId = uuidRegex.test(id);
       const isPrefix = !isFullId && prefixRegex.test(id);
-
-      if (!isFullId && !isPrefix) {
-        throw new Error(`Invalid memory ID format: ${id}`);
-      }
 
       let rows: any[];
       if (isFullId) {
@@ -893,7 +890,7 @@ export class MemoryStore {
           .where(`id = '${safeId}'`)
           .limit(1)
           .toArray();
-      } else {
+      } else if (isPrefix) {
         // Prefix match
         const all = await this.table!.query()
           .select([
@@ -914,6 +911,12 @@ export class MemoryStore {
             `Ambiguous prefix "${id}" matches ${rows.length} memories. Use a longer prefix or full ID.`,
           );
         }
+      } else {
+        const safeId = escapeSqlLiteral(id);
+        rows = await this.table!.query()
+          .where(`id = '${safeId}'`)
+          .limit(1)
+          .toArray();
       }
 
       if (rows.length === 0) return null;

--- a/test/update-consistency-lancedb.test.mjs
+++ b/test/update-consistency-lancedb.test.mjs
@@ -198,4 +198,34 @@ describe("MemoryStore update rollback (real LanceDB backend)", () => {
     assert.equal(listed.length, 1);
     assert.equal(listed[0].text, "updated memory");
   });
+
+  it("updates imported legacy records with stable slug IDs", async () => {
+    const store = new MemoryStore({
+      dbPath: path.join(workDir, "db"),
+      vectorDim: 4,
+    });
+
+    await store.importEntry({
+      id: "data-pointer-openclaw-paths-20260527",
+      text: "legacy imported memory",
+      vector: [0, 0, 0, 0],
+      category: "fact",
+      scope: "global",
+      importance: 0.7,
+      timestamp: 1234567890,
+      metadata: "{}",
+    });
+
+    const updated = await store.update("data-pointer-openclaw-paths-20260527", {
+      text: "upgraded legacy memory",
+      metadata: "{\"memory_category\":\"cases\"}",
+    });
+
+    assert.equal(updated?.id, "data-pointer-openclaw-paths-20260527");
+    assert.equal(updated?.text, "upgraded legacy memory");
+
+    const byId = await store.getById("data-pointer-openclaw-paths-20260527");
+    assert.equal(byId?.text, "upgraded legacy memory");
+    assert.equal(byId?.metadata, "{\"memory_category\":\"cases\"}");
+  });
 });


### PR DESCRIPTION
## Summary

- allow `MemoryStore.update()` to resolve exact non-hex legacy IDs imported from older stores
- preserve existing full UUID and short hex-prefix update behavior
- add a LanceDB regression test for imported slug-style memory IDs

## Context

Legacy imports can preserve stable IDs such as `data-pointer-openclaw-paths-20260527`. `importEntry()` and `getById()` already support those IDs, but `update()` rejected anything that was not a full UUID or hex prefix. That caused `memory-pro upgrade` to fail with `Invalid memory ID format` when upgrading legacy records in place.

## Test

- `node test/update-consistency-lancedb.test.mjs`
