### PR TITLE
fix: update legacy slug memory ids

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -116,7 +116,12 @@ function clampInt(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, Math.floor(value)));
 }
 
+const LEGACY_STABLE_MEMORY_ID_REGEX = /^[A-Za-z0-9][A-Za-z0-9._:-]{2,127}$/;
 const LEGACY_SECONDS_TIMESTAMP_MAX = 1_000_000_000_000;
+
+function isLegacyStableMemoryId(id: string): boolean {
+  return LEGACY_STABLE_MEMORY_ID_REGEX.test(id);
+}
 
 export function normalizeMemoryTimestamp(value: unknown, fallback = Date.now()): number {
   const raw = value instanceof Date
@@ -1834,23 +1839,22 @@ export class MemoryStore {
     }
 
     return this.runWithFileLock(() => this.runSerializedUpdate(async () => {
-      // Support both full UUID and short prefix (8+ hex chars), same as delete()
-      // Also support legacy mem-md-N format from older memory-lancedb-pro versions
+      // Support full UUID, short hex prefixes, and constrained exact legacy IDs imported
+      // from older stores (for example "mem-md-..." or "data-pointer-...").
       const uuidRegex =
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
       const prefixRegex = /^[0-9a-f]{8,}$/i;
-      const legacyRegex = /^mem-md-\d+$/i;
       const isFullId = uuidRegex.test(id);
       const isPrefix = !isFullId && prefixRegex.test(id);
-      const isLegacy = !isFullId && !isPrefix && legacyRegex.test(id);
+      const isLegacyStableId = !isFullId && !isPrefix && isLegacyStableMemoryId(id);
 
-      if (!isFullId && !isPrefix && !isLegacy) {
+      if (!isFullId && !isPrefix && !isLegacyStableId) {
         throw new Error(`Invalid memory ID format: ${id}`);
       }
 
       let rows: any[];
-      if (isFullId || isLegacy) {
-        // Legacy IDs use exact string match like full UUIDs
+      if (isFullId || isLegacyStableId) {
+        // Legacy IDs use exact string match like full UUIDs.
         const safeId = escapeSqlLiteral(id);
         rows = await this.table!.query()
           .where(`id = '${safeId}'`)

--- a/test/fixtures/legacy-slug-memory.json
+++ b/test/fixtures/legacy-slug-memory.json
@@ -1,0 +1,10 @@
+{
+  "id": "data-pointer-openclaw-paths-20260527",
+  "text": "Legacy imported memory with a stable slug ID.",
+  "vector": [0, 0, 0, 0],
+  "category": "fact",
+  "scope": "global",
+  "importance": 0.7,
+  "timestamp": 1779840000000,
+  "metadata": "{}"
+}

--- a/test/update-consistency-lancedb.test.mjs
+++ b/test/update-consistency-lancedb.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import jitiFactory from "jiti";
@@ -8,6 +8,10 @@ import jitiFactory from "jiti";
 const jiti = jitiFactory(import.meta.url, { interopDefault: true });
 const { MemoryStore } = jiti("../src/store.ts");
 const { AccessTracker } = jiti("../src/access-tracker.ts");
+const legacySlugMemory = JSON.parse(
+  readFileSync(new URL("./fixtures/legacy-slug-memory.json", import.meta.url), "utf8"),
+);
+const upgradedLegacyMetadata = JSON.stringify({ memory_category: "cases" });
 
 function deferred() {
   let resolve;
@@ -197,5 +201,60 @@ describe("MemoryStore update rollback (real LanceDB backend)", () => {
     const listed = await store.list(["global"]);
     assert.equal(listed.length, 1);
     assert.equal(listed[0].text, "updated memory");
+  });
+
+  it("updates imported legacy records with stable slug IDs", async () => {
+    const store = new MemoryStore({
+      dbPath: path.join(workDir, "db"),
+      vectorDim: 4,
+    });
+
+    await store.importEntry(legacySlugMemory);
+    await store.importEntry({
+      ...legacySlugMemory,
+      id: "working-sessions-canonical-path-v2",
+      text: "Another imported legacy memory with a stable slug ID.",
+    });
+
+    const updated = await store.update(legacySlugMemory.id, {
+      text: "upgraded legacy memory",
+      metadata: upgradedLegacyMetadata,
+    });
+
+    assert.equal(updated?.id, legacySlugMemory.id);
+    assert.equal(updated?.text, "upgraded legacy memory");
+
+    const byId = await store.getById(legacySlugMemory.id);
+    assert.equal(byId?.text, "upgraded legacy memory");
+    assert.equal(byId?.metadata, upgradedLegacyMetadata);
+
+    const updatedV2 = await store.update("working-sessions-canonical-path-v2", {
+      text: "upgraded v2 legacy memory",
+      metadata: upgradedLegacyMetadata,
+    });
+
+    assert.equal(updatedV2?.id, "working-sessions-canonical-path-v2");
+    assert.equal(updatedV2?.text, "upgraded v2 legacy memory");
+  });
+
+  it("rejects clearly invalid memory IDs instead of treating them as exact legacy IDs", async () => {
+    const { store } = await createStoreWithEntry();
+    const invalidIds = [
+      "",
+      "not an id",
+      "bad/id",
+      "bad'id",
+      "bad\nid",
+      "-starts-with-symbol",
+      "ab",
+    ];
+
+    for (const invalidId of invalidIds) {
+      await assert.rejects(
+        () => store.update(invalidId, { text: "should not update" }),
+        /Invalid memory ID format/,
+        `expected invalid ID to be rejected: ${JSON.stringify(invalidId)}`,
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

- allow `MemoryStore.update()` to update imported memories with exact non-hex legacy IDs
- preserve UUID and short hex-prefix update behavior
- add fixture-backed sample data for the `data-pointer-...` legacy slug ID repro
- add a real LanceDB regression test that imports the fixture and updates it in place

## Reprex

The fixture at `test/fixtures/legacy-slug-memory.json` captures the failing legacy shape:

```json
{
  "id": "data-pointer-openclaw-paths-20260527",
  "text": "Legacy imported memory with a stable slug ID.",
  "vector": [0, 0, 0, 0],
  "category": "fact",
  "scope": "global",
  "importance": 0.7,
  "timestamp": 1748380800000,
  "metadata": "{}"
}
```

Before this change, importing that row and calling `store.update("data-pointer-openclaw-paths-20260527", ...)` failed with `Invalid memory ID format`. This blocked `memory-pro upgrade` for legacy imported rows that preserved stable slug IDs.

## Tests

- `node test/update-consistency-lancedb.test.mjs`
- `npm run test:storage-and-schema`
