### PR TITLE
fix: declare memory_reflection_resolve contract and remove duplicate contracts key

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,24 +1,4 @@
 {
-  "contracts": {
-    "tools": [
-      "memory_recall",
-      "memory_search",
-      "memory_get",
-      "memory_store",
-      "memory_forget",
-      "memory_update",
-      "memory_stats",
-      "memory_debug",
-      "memory_list",
-      "memory_promote",
-      "memory_archive",
-      "memory_compact",
-      "memory_explain_rank",
-      "self_improvement_log",
-      "self_improvement_extract_skill",
-      "self_improvement_review"
-    ]
-  },
   "id": "memory-lancedb-pro",
   "name": "Memory (LanceDB Pro)",
   "description": "Enhanced LanceDB-backed long-term memory with hybrid retrieval, multi-scope isolation, long-context chunking, and management CLI",
@@ -2073,6 +2053,7 @@
       "memory_archive",
       "memory_promote",
       "memory_explain_rank",
+      "memory_reflection_resolve",
       "self_improvement_log",
       "self_improvement_extract_skill",
       "self_improvement_review"


### PR DESCRIPTION
## Problem

The plugin registers `memory_reflection_resolve` via `registerMemoryReflectionResolveTool()` called from `registerAllMemoryTools()` in `src/tools.ts`, but the tool was missing from `contracts.tools` in `openclaw.plugin.json`.

This causes a gateway warning on every start:
```
plugin must declare contracts.tools for: memory_reflection_resolve
```

## Changes

1. **Add `memory_reflection_resolve` to `contracts.tools`** — placed with the other `memory_*` tools, after `memory_explain_rank`.

2. **Remove the duplicate top-level `contracts` key** (line 2 of the file). JSON allows duplicate object keys but parsers silently use the last one, making the first declaration dead code. The canonical `contracts` declaration is the one at the end of the file (after `configSchema`).

## Verification

`memory_reflection_resolve` is defined and registered:
- `src/tools.ts` — `registerMemoryReflectionResolveTool()` defined, registered via `registerAllMemoryTools()`
- `index.ts` — `registerAllMemoryTools` imported and called on plugin init