### PR TITLE
fix: accept wrapped plugin config entries

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4004,7 +4004,13 @@ export function parsePluginConfig(value) {
         throw new Error("memory-lancedb-pro: plugin config must be an object with a top-level embedding block at " +
             "plugins.entries.memory-lancedb-pro.config.embedding.");
     }
-    const cfg = value;
+    const initialCfg = value;
+    const cfg = !initialCfg.embedding &&
+        initialCfg.config &&
+        typeof initialCfg.config === "object" &&
+        !Array.isArray(initialCfg.config)
+        ? initialCfg.config
+        : initialCfg;
     const embedding = cfg.embedding;
     if (!embedding) {
         throw new Error("memory-lancedb-pro: missing top-level config.embedding block. " +

--- a/index.ts
+++ b/index.ts
@@ -5048,7 +5048,13 @@ export function parsePluginConfig(value: unknown): PluginConfig {
       "plugins.entries.memory-lancedb-pro.config.embedding.",
     );
   }
-  const cfg = value as Record<string, unknown>;
+  const initialCfg = value as Record<string, unknown>;
+  const cfg = !initialCfg.embedding &&
+    initialCfg.config &&
+    typeof initialCfg.config === "object" &&
+    !Array.isArray(initialCfg.config)
+    ? initialCfg.config as Record<string, unknown>
+    : initialCfg;
 
   const embedding = cfg.embedding as Record<string, unknown> | undefined;
   if (!embedding) {

--- a/test/config-session-strategy-migration.test.mjs
+++ b/test/config-session-strategy-migration.test.mjs
@@ -45,6 +45,47 @@ describe("plugin config error hints", () => {
   });
 });
 
+describe("plugin entry wrapper compatibility", () => {
+  it("unwraps OpenClaw plugin entry objects before validating embedding config", () => {
+    const parsed = parsePluginConfig({
+      enabled: true,
+      config: {
+        autoCapture: true,
+        embedding: {
+          provider: "openai-compatible",
+          apiKey: "jina_test_key",
+          model: "jina-embeddings-v5-text-small",
+          baseURL: "https://api.jina.ai/v1",
+        },
+      },
+    });
+
+    assert.equal(parsed.embedding.provider, "openai-compatible");
+    assert.equal(parsed.embedding.apiKey, "jina_test_key");
+    assert.equal(parsed.embedding.model, "jina-embeddings-v5-text-small");
+    assert.equal(parsed.embedding.baseURL, "https://api.jina.ai/v1");
+    assert.equal(parsed.autoCapture, true);
+  });
+
+  it("prefers direct plugin config over a nested wrapper-like config key", () => {
+    const parsed = parsePluginConfig({
+      embedding: {
+        apiKey: "direct-key",
+        model: "text-embedding-3-small",
+      },
+      config: {
+        embedding: {
+          apiKey: "wrapped-key",
+          model: "jina-embeddings-v5-text-small",
+        },
+      },
+    });
+
+    assert.equal(parsed.embedding.apiKey, "direct-key");
+    assert.equal(parsed.embedding.model, "text-embedding-3-small");
+  });
+});
+
 describe("sessionStrategy legacy compatibility mapping", () => {
   it("maps legacy sessionMemory.enabled=true to systemSessionMemory", () => {
     const parsed = parsePluginConfig({


### PR DESCRIPTION
## Summary
- accept OpenClaw plugin entry wrapper objects before validating the plugin config
- preserve direct plugin config precedence when both direct and nested config shapes are present
- add regression coverage for the Jina/openai-compatible config shape from the issue

Fixes #651

## Verification
- node --test test/config-session-strategy-migration.test.mjs
- npm run build