### PR TITLE
docs: clarify lock management guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,20 @@ OAuth login flow:
 ## Advanced Topics
 
 <details>
+<summary><strong>Locking and concurrent writers</strong></summary>
+
+`memory-lancedb-pro` uses a cross-process file lock for LanceDB writes. This is
+enough for one gateway process, multiple agents through that gateway, and local
+processes that share the same database directory.
+
+Redis is not required for those deployments, and the current plugin does not
+automatically enable Redis locking. For multi-machine or multi-container
+writers, read [Lock Management](docs/lock-management.md) before sharing a
+LanceDB directory across processes.
+
+</details>
+
+<details>
 <summary><strong>If injected memories show up in replies</strong></summary>
 
 Sometimes the model may echo the injected `<relevant-memories>` block.

--- a/docs/lock-management.md
+++ b/docs/lock-management.md
@@ -1,0 +1,60 @@
+# Lock Management
+
+`memory-lancedb-pro` protects LanceDB writes with a cross-process file lock based on
+`proper-lockfile`. The lock target is `.memory-write.lock` inside the configured
+database directory, and the transient lock artifact is `.memory-write.lock.lock`.
+
+## When The Built-In File Lock Is Enough
+
+Use the default file lock for:
+
+- a single OpenClaw gateway process
+- multiple agents writing through the same gateway process
+- multiple local processes that share the same local filesystem path
+
+The store also batches concurrent `bulkStore()` calls before taking the write
+lock, so high-throughput auto-capture paths avoid one lock acquisition per
+memory item.
+
+## Multi-Machine Or Container Deployments
+
+The file lock only coordinates processes that can see the same lock target on a
+filesystem with reliable lock-directory semantics. For multi-machine,
+multi-container, or network-filesystem deployments, verify this before relying on
+the default lock:
+
+```bash
+openclaw memory-pro stats --json
+ls -la "$(dirname "$MEMORY_LANCEDB_PRO_DB_PATH")"
+```
+
+If each process has its own local database directory, no lock can protect writes
+across those processes because they are not writing to the same LanceDB store.
+
+## Redis Status
+
+Redis is not required for single-gateway or same-filesystem deployments, and the
+current plugin does not enable a Redis lock automatically. If you operate
+multiple independent writers, prefer one of these approaches:
+
+- route writes through one OpenClaw gateway
+- place the LanceDB directory on a filesystem whose lock-directory behavior is
+  known to work with `proper-lockfile`
+- add an explicit external write coordinator before enabling multiple writers
+
+Do not use a no-op lock fallback for write paths. If an external coordinator is
+unavailable, fall back to the built-in file lock so failed Redis setup does not
+silently remove write protection.
+
+## Troubleshooting Lock Contention
+
+Symptoms of lock contention include slow memory writes, delayed auto-capture, or
+warnings about stale `.memory-write.lock.lock` artifacts.
+
+Checklist:
+
+1. Confirm all writers use the same `dbPath`.
+2. Confirm old `.memory-write.lock.lock` artifacts are cleaned up by the store.
+3. Prefer `bulkStore()` for batch writes instead of repeated `store()` calls.
+4. Avoid multiple independent gateway processes writing to separate copies of the
+   same intended memory corpus.

--- a/docs/openclaw-integration-playbook.md
+++ b/docs/openclaw-integration-playbook.md
@@ -134,6 +134,8 @@ Confirm:
 - the plugin registers a memory capability, not only legacy hooks/tools
 - the expected hooks are enabled
 - the gateway has been restarted after config changes
+- for multi-agent or multi-process write tests, the deployment matches the
+  [lock-management requirements](lock-management.md)
 
 If you use plugin session memory, `openclaw hooks list --json` should show the plugin hook:
 


### PR DESCRIPTION
## Summary
- document the current proper-lockfile-based write lock behavior
- clarify when Redis is not required and when multi-writer deployments need external coordination
- link lock-management guidance from the README and integration playbook

Fixes #663

## Verification
- node --test test/cross-process-lock.test.mjs