### PR TITLE
fix: warn when Telegram plugin is disabled

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1767,6 +1767,41 @@ export function isAgentOrSessionExcluded(agentId, sessionKey, patterns) {
     }
     return false;
 }
+const _channelPluginDiagnosticWarnings = new Set();
+function readRecord(value) {
+    return value && typeof value === "object" && !Array.isArray(value)
+        ? value
+        : undefined;
+}
+function isChannelEnabled(config, channelName) {
+    const channels = readRecord(config.channels);
+    const channelConfig = readRecord(channels?.[channelName]);
+    return channelConfig?.enabled === true;
+}
+function isPluginExplicitlyDisabled(config, pluginName) {
+    const plugins = readRecord(config.plugins);
+    const entries = readRecord(plugins?.entries);
+    const entry = readRecord(entries?.[pluginName]);
+    if (entry?.enabled === false)
+        return true;
+    const disabled = plugins?.disabled;
+    return Array.isArray(disabled) && disabled.includes(pluginName);
+}
+export function warnForDisabledChannelPlugin(openclawConfig, logger) {
+    const config = readRecord(openclawConfig);
+    if (!config)
+        return;
+    const affectedChannels = ["telegram"].filter((channelName) => isChannelEnabled(config, channelName) &&
+        isPluginExplicitlyDisabled(config, channelName));
+    for (const channelName of affectedChannels) {
+        if (_channelPluginDiagnosticWarnings.has(channelName))
+            continue;
+        _channelPluginDiagnosticWarnings.add(channelName);
+        logger.warn(`memory-lancedb-pro: ${channelName} channel config is enabled but the ${channelName} plugin is disabled; ` +
+            `OpenClaw will not start ${channelName} providers until the plugin is re-enabled. ` +
+            `Run "openclaw plugin enable ${channelName}" and restart the gateway.`);
+    }
+}
 const memoryLanceDBProPlugin = {
     id: "memory-lancedb-pro",
     name: "Memory (LanceDB Pro)",
@@ -1808,6 +1843,7 @@ const memoryLanceDBProPlugin = {
             throw err;
         }
         const { config, resolvedDbPath, vectorDim, store, embedder, retriever, canonicalCorpusIndexer, scopeManager, migrator, smartExtractor, decayEngine, tierManager, extractionRateLimiter, reflectionErrorStateBySession, reflectionDerivedBySession, reflectionDerivedSuppressionBySession, reflectionByAgentCache, recallHistory, turnCounter, autoCaptureSeenTextCount, autoCapturePendingIngressTexts, autoCaptureRecentTexts, } = singleton;
+        warnForDisabledChannelPlugin(api.config, api.logger);
         async function sleep(ms, signal) {
             if (signal?.aborted) {
                 throw signal.reason ?? new Error("aborted");
@@ -4306,6 +4342,7 @@ export { getDefaultMdMirrorDir };
 export function resetRegistration() {
     _registeredApis = new WeakSet();
     _registeredApisMap.clear(); // dual-track: clear Map alongside WeakSet
+    _channelPluginDiagnosticWarnings.clear();
     _singletonState = null;
     _hookEventDedup.clear();
     getReflectionEmptyEventGuardMap().clear();

--- a/index.ts
+++ b/index.ts
@@ -2332,6 +2332,53 @@ export function isAgentOrSessionExcluded(
   return false;
 }
 
+const _channelPluginDiagnosticWarnings = new Set<string>();
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function isChannelEnabled(config: Record<string, unknown>, channelName: string): boolean {
+  const channels = readRecord(config.channels);
+  const channelConfig = readRecord(channels?.[channelName]);
+  return channelConfig?.enabled === true;
+}
+
+function isPluginExplicitlyDisabled(config: Record<string, unknown>, pluginName: string): boolean {
+  const plugins = readRecord(config.plugins);
+  const entries = readRecord(plugins?.entries);
+  const entry = readRecord(entries?.[pluginName]);
+  if (entry?.enabled === false) return true;
+
+  const disabled = plugins?.disabled;
+  return Array.isArray(disabled) && disabled.includes(pluginName);
+}
+
+export function warnForDisabledChannelPlugin(
+  openclawConfig: unknown,
+  logger: Pick<OpenClawPluginApi["logger"], "warn">,
+): void {
+  const config = readRecord(openclawConfig);
+  if (!config) return;
+
+  const affectedChannels = ["telegram"].filter((channelName) =>
+    isChannelEnabled(config, channelName) &&
+    isPluginExplicitlyDisabled(config, channelName),
+  );
+
+  for (const channelName of affectedChannels) {
+    if (_channelPluginDiagnosticWarnings.has(channelName)) continue;
+    _channelPluginDiagnosticWarnings.add(channelName);
+    logger.warn(
+      `memory-lancedb-pro: ${channelName} channel config is enabled but the ${channelName} plugin is disabled; ` +
+      `OpenClaw will not start ${channelName} providers until the plugin is re-enabled. ` +
+      `Run "openclaw plugin enable ${channelName}" and restart the gateway.`,
+    );
+  }
+}
+
 const memoryLanceDBProPlugin = {
   id: "memory-lancedb-pro",
   name: "Memory (LanceDB Pro)",
@@ -2397,6 +2444,10 @@ const memoryLanceDBProPlugin = {
       autoCaptureRecentTexts,
     } = singleton;
 
+    warnForDisabledChannelPlugin(
+      (api as OpenClawPluginApi & { config?: unknown }).config,
+      api.logger,
+    );
 
     async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
       if (signal?.aborted) {
@@ -5385,6 +5436,7 @@ export { getDefaultMdMirrorDir };
 export function resetRegistration() {
   _registeredApis = new WeakSet<OpenClawPluginApi>();
   _registeredApisMap.clear();  // dual-track: clear Map alongside WeakSet
+  _channelPluginDiagnosticWarnings.clear();
   _singletonState = null;
   _hookEventDedup.clear();
   getReflectionEmptyEventGuardMap().clear();

--- a/test/telegram-plugin-status-diagnostic.test.mjs
+++ b/test/telegram-plugin-status-diagnostic.test.mjs
@@ -1,0 +1,86 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginSdkStubPath = path.resolve(testDir, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+
+const {
+  resetRegistration,
+  warnForDisabledChannelPlugin,
+} = jiti("../index.ts");
+
+function createLogger() {
+  const warnings = [];
+  return {
+    warnings,
+    logger: {
+      warn(message) {
+        warnings.push(String(message));
+      },
+    },
+  };
+}
+
+describe("Telegram plugin status diagnostic", () => {
+  beforeEach(() => {
+    resetRegistration();
+  });
+
+  it("warns when Telegram channel config is enabled but the Telegram plugin is disabled", () => {
+    const { logger, warnings } = createLogger();
+
+    warnForDisabledChannelPlugin({
+      channels: {
+        telegram: { enabled: true },
+      },
+      plugins: {
+        entries: {
+          telegram: { enabled: false },
+        },
+      },
+    }, logger);
+
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /telegram channel config is enabled/i);
+    assert.match(warnings[0], /openclaw plugin enable telegram/i);
+  });
+
+  it("does not warn repeatedly for the same channel", () => {
+    const { logger, warnings } = createLogger();
+    const config = {
+      channels: { telegram: { enabled: true } },
+      plugins: { entries: { telegram: { enabled: false } } },
+    };
+
+    warnForDisabledChannelPlugin(config, logger);
+    warnForDisabledChannelPlugin(config, logger);
+
+    assert.equal(warnings.length, 1);
+  });
+
+  it("stays quiet when the Telegram plugin is not explicitly disabled", () => {
+    const { logger, warnings } = createLogger();
+
+    warnForDisabledChannelPlugin({
+      channels: {
+        telegram: { enabled: true },
+      },
+      plugins: {
+        entries: {
+          telegram: { enabled: true },
+        },
+      },
+    }, logger);
+
+    assert.deepEqual(warnings, []);
+  });
+});


### PR DESCRIPTION
## Summary
- add a startup diagnostic for the reported Telegram channel/plugin mismatch
- warn when `channels.telegram.enabled` is true but the Telegram plugin entry is explicitly disabled
- include the actionable `openclaw plugin enable telegram` recovery command

Refs #368

## Verification
- node --test test/telegram-plugin-status-diagnostic.test.mjs
- npm run build