### PR TITLE
fix: prevent minutes-long event-loop freeze on first LanceDB load (getReport reverse-DNS hang)

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -105,6 +105,20 @@ export const loadLanceDB = async (): Promise<
   typeof import("@lancedb/lancedb")
 > => {
   if (!lancedbImportPromise) {
+    // @lancedb/lancedb's napi-rs loader (dist/native.js) detects musl via
+    // process.report.getReport(). The report's network section performs
+    // reverse-DNS lookups for every network interface, synchronously on the
+    // calling thread; on hosts with several interfaces and a slow or flaky
+    // DNS path (measured on WSL2 + Tailscale) this blocks the event loop for
+    // 110-250s on the FIRST LanceDB load — the host app's HTTP server and
+    // pollers freeze with CPU at 0% (main thread stuck in poll()). Excluding
+    // the network section turns the measured 235s hang into ~3ms and loses
+    // nothing: isMusl() only reads report.header.glibcVersionRuntime.
+    try {
+      (process.report as { excludeNetwork?: boolean }).excludeNetwork = true;
+    } catch {
+      /* Node < 22 without the flag — keep the previous behavior */
+    }
     // Use a createRequire-built require() so LanceDB's CommonJS native bindings
     // keep Windows-safe CJS semantics while still working in pure ESM runtimes.
     // Do not name this binding "require": bundlers may rewrite bare require()


### PR DESCRIPTION
## Summary

The **first** `require("@lancedb/lancedb")` in a long-lived host process can block the Node.js event loop for **minutes** — frozen HTTP endpoints, stalled pollers, CPU at 0%. This PR adds one guarded line before the load: `process.report.excludeNetwork = true`.

Measured effect on the affected host: **235s → 3ms**.

## Root cause (measured, not guessed)

`@lancedb/lancedb`'s napi-rs loader (`dist/native.js`) detects musl via:

```js
const { glibcVersionRuntime } = process.report.getReport().header;
```

`getReport()` builds the **network section** of the diagnostic report, which performs **reverse-DNS lookups for every network interface, synchronously on the calling thread**. On a host with several interfaces (WSL2 + Tailscale in our case) and a slow/flaky DNS path, each lookup waits through resolver timeouts.

Evidence chain from our debugging session (OpenClaw gateway, Node 22.22, plugin v1.0.32 — but the mechanism is version-independent):

- Step-level instrumentation: `native require done in 252476ms` — everything after it (connect/openTable/query) took milliseconds.
- Kernel-state sampling of the main thread during the freeze: `state=S wchan=poll_schedule_timeout`, CPU ticks frozen — the glibc resolver waiting in `poll()`. `read_bytes` only jumped by the size of the `.node` binary *after* the hang ended, proving the hang precedes the actual dlopen.
- 4/4 cold starts froze (110s / 237s / 235s / 252s) before the fix; 0/3 after, with the host's health endpoint returning 200 throughout.
- With instrumentation inside `isMusl()`: `getReport()` with `excludeNetwork=true` returns in 3ms.

Because the plugin loads LanceDB lazily, *whoever touches the store first pays this cost on the host's main thread* — startup checks, backups, or the first auto-recall of a user message. The symptom is easy to misattribute (we first blamed LanceDB native locking, then network APIs, before the kernel sampling pinned it).

## Why this is safe

- `isMusl()` only reads `header.glibcVersionRuntime`, which is unaffected by the network section.
- `excludeNetwork` exists since Node 22; the assignment is wrapped in `try/catch` so older runtimes keep the previous behavior.
- The flag only affects diagnostic report content for the host process; it does not change networking behavior.

## Notes

- Any package using the standard napi-rs loader template has this failure mode; fixing it at the load site protects this plugin regardless of upstream `@lancedb/lancedb` changes.
- Verified live on the v1.0.32 lineage (where we debugged it) and rebased onto current `master`, which already uses `requireCJS` — the two changes are complementary: `requireCJS` fixes *how* the module resolves, this fixes *what hangs inside it*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
