### PR TITLE
fix: normalize memory category filters

### DIFF
--- a/dist/src/memory-categories.js
+++ b/dist/src/memory-categories.js
@@ -24,6 +24,22 @@ export const TOOL_MEMORY_CATEGORIES = [
     ...MEMORY_CATEGORIES,
     ...LEGACY_MEMORY_CATEGORIES,
 ];
+const SMART_TO_STORAGE_CATEGORY = {
+    profile: "fact",
+    preferences: "preference",
+    entities: "entity",
+    events: "decision",
+    cases: "fact",
+    patterns: "other",
+};
+const LEGACY_TO_SMART_CATEGORY = {
+    preference: "preferences",
+    fact: "cases",
+    decision: "events",
+    entity: "entities",
+    reflection: "patterns",
+    other: "patterns",
+};
 /** Categories that always merge (skip dedup entirely). */
 export const ALWAYS_MERGE_CATEGORIES = new Set(["profile"]);
 /** Categories that support MERGE decision from LLM dedup. */
@@ -58,16 +74,24 @@ export function normalizeCategory(raw) {
     }
     return null;
 }
-export function matchesMemoryCategoryFilter(entryCategory, requestedCategory) {
+export function matchesMemoryCategoryFilter(entryCategory, requestedCategory, entryMetadata) {
     const rawEntryCategory = entryCategory.toLowerCase().trim();
     const rawRequestedCategory = requestedCategory.toLowerCase().trim();
     if (rawEntryCategory === rawRequestedCategory)
         return true;
+    const metadataCategory = extractMetadataMemoryCategory(entryMetadata);
     const normalizedEntryCategory = normalizeCategory(rawEntryCategory);
     const normalizedRequestedCategory = normalizeCategory(rawRequestedCategory);
-    return normalizedEntryCategory !== null &&
-        normalizedRequestedCategory !== null &&
-        normalizedEntryCategory === normalizedRequestedCategory;
+    if (metadataCategory && normalizedRequestedCategory) {
+        return metadataCategory === normalizedRequestedCategory;
+    }
+    if (normalizedEntryCategory && normalizedRequestedCategory) {
+        return normalizedEntryCategory === normalizedRequestedCategory;
+    }
+    if (normalizedRequestedCategory && isLegacyMemoryCategory(rawEntryCategory)) {
+        return LEGACY_TO_SMART_CATEGORY[rawEntryCategory] === normalizedRequestedCategory;
+    }
+    return false;
 }
 export function resolveCategoryFilterCandidates(requestedCategory) {
     const rawRequestedCategory = requestedCategory.toLowerCase().trim();
@@ -75,6 +99,7 @@ export function resolveCategoryFilterCandidates(requestedCategory) {
     const candidates = new Set([rawRequestedCategory]);
     if (normalizedRequestedCategory) {
         candidates.add(normalizedRequestedCategory);
+        candidates.add(SMART_TO_STORAGE_CATEGORY[normalizedRequestedCategory]);
         for (const category of TOOL_MEMORY_CATEGORIES) {
             if (normalizeCategory(category) === normalizedRequestedCategory) {
                 candidates.add(category);
@@ -82,4 +107,43 @@ export function resolveCategoryFilterCandidates(requestedCategory) {
         }
     }
     return [...candidates];
+}
+export function getStorageCategoryForMemoryCategory(category) {
+    return SMART_TO_STORAGE_CATEGORY[category];
+}
+export function resolveToolMemoryCategory(rawCategory) {
+    const raw = rawCategory.toLowerCase().trim();
+    const normalized = normalizeCategory(raw);
+    if (normalized) {
+        return {
+            memoryCategory: normalized,
+            storageCategory: SMART_TO_STORAGE_CATEGORY[normalized],
+        };
+    }
+    if (isLegacyMemoryCategory(raw)) {
+        return {
+            memoryCategory: LEGACY_TO_SMART_CATEGORY[raw],
+            storageCategory: raw,
+        };
+    }
+    return {
+        memoryCategory: "patterns",
+        storageCategory: "other",
+    };
+}
+function isLegacyMemoryCategory(value) {
+    return LEGACY_MEMORY_CATEGORIES.includes(value);
+}
+function extractMetadataMemoryCategory(rawMetadata) {
+    if (!rawMetadata)
+        return null;
+    try {
+        const parsed = JSON.parse(rawMetadata);
+        if (typeof parsed.memory_category !== "string")
+            return null;
+        return normalizeCategory(parsed.memory_category);
+    }
+    catch {
+        return null;
+    }
 }

--- a/dist/src/memory-categories.js
+++ b/dist/src/memory-categories.js
@@ -12,6 +12,18 @@ export const MEMORY_CATEGORIES = [
     "cases",
     "patterns",
 ];
+export const LEGACY_MEMORY_CATEGORIES = [
+    "preference",
+    "fact",
+    "decision",
+    "entity",
+    "reflection",
+    "other",
+];
+export const TOOL_MEMORY_CATEGORIES = [
+    ...MEMORY_CATEGORIES,
+    ...LEGACY_MEMORY_CATEGORIES,
+];
 /** Categories that always merge (skip dedup entirely). */
 export const ALWAYS_MERGE_CATEGORIES = new Set(["profile"]);
 /** Categories that support MERGE decision from LLM dedup. */
@@ -33,8 +45,41 @@ export const APPEND_ONLY_CATEGORIES = new Set([
 /** Validate and normalize a category string. */
 export function normalizeCategory(raw) {
     const lower = raw.toLowerCase().trim();
-    if (MEMORY_CATEGORIES.includes(lower)) {
-        return lower;
+    const aliases = {
+        preference: "preferences",
+        entity: "entities",
+        event: "events",
+        case: "cases",
+        pattern: "patterns",
+    };
+    const normalized = aliases[lower] ?? lower;
+    if (MEMORY_CATEGORIES.includes(normalized)) {
+        return normalized;
     }
     return null;
+}
+export function matchesMemoryCategoryFilter(entryCategory, requestedCategory) {
+    const rawEntryCategory = entryCategory.toLowerCase().trim();
+    const rawRequestedCategory = requestedCategory.toLowerCase().trim();
+    if (rawEntryCategory === rawRequestedCategory)
+        return true;
+    const normalizedEntryCategory = normalizeCategory(rawEntryCategory);
+    const normalizedRequestedCategory = normalizeCategory(rawRequestedCategory);
+    return normalizedEntryCategory !== null &&
+        normalizedRequestedCategory !== null &&
+        normalizedEntryCategory === normalizedRequestedCategory;
+}
+export function resolveCategoryFilterCandidates(requestedCategory) {
+    const rawRequestedCategory = requestedCategory.toLowerCase().trim();
+    const normalizedRequestedCategory = normalizeCategory(rawRequestedCategory);
+    const candidates = new Set([rawRequestedCategory]);
+    if (normalizedRequestedCategory) {
+        candidates.add(normalizedRequestedCategory);
+        for (const category of TOOL_MEMORY_CATEGORIES) {
+            if (normalizeCategory(category) === normalizedRequestedCategory) {
+                candidates.add(category);
+            }
+        }
+    }
+    return [...candidates];
 }

--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -462,7 +462,7 @@ export class MemoryRetriever {
             failureStage = "vector.vectorSearch";
             const results = await this.store.vectorSearch(queryVector, candidatePoolSize, this.config.minScore, scopeFilter, { excludeInactive: true });
             const filtered = category
-                ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
+                ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category, r.entry.metadata))
                 : results;
             // Filter expired memories early — before scoring — so they don't
             // occupy candidate slots that should go to live memories.
@@ -530,7 +530,7 @@ export class MemoryRetriever {
         trace?.startStage("bm25_search", []);
         const bm25Results = await this.store.bm25Search(query, candidatePoolSize, scopeFilter, { excludeInactive: true });
         const categoryFiltered = category
-            ? bm25Results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
+            ? bm25Results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category, r.entry.metadata))
             : bm25Results;
         const mustContainFiltered = categoryFiltered.filter((r) => {
             const textLower = r.entry.text.toLowerCase();
@@ -770,7 +770,7 @@ export class MemoryRetriever {
         const results = await this.store.vectorSearch(queryVector, limit, 0.1, scopeFilter, { excludeInactive: true });
         // Filter by category if specified
         const filtered = category
-            ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
+            ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category, r.entry.metadata))
             : results;
         return filtered.map((result, index) => ({
             ...result,
@@ -781,7 +781,7 @@ export class MemoryRetriever {
         const results = await this.store.bm25Search(query, limit, scopeFilter, { excludeInactive: true });
         // Filter by category if specified
         const filtered = category
-            ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
+            ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category, r.entry.metadata))
             : results;
         return filtered.map((result, index) => ({
             ...result,
@@ -877,8 +877,9 @@ export class MemoryRetriever {
                 const model = this.config.rerankModel || "jina-reranker-v3";
                 const endpoint = this.config.rerankEndpoint || "https://api.jina.ai/v1/rerank";
                 const documents = results.map((r) => r.entry.text);
+                const rerankTopN = Math.min(results.length, Math.max(1, this.config.candidatePoolSize));
                 // Build provider-specific request
-                const { headers, body } = buildRerankRequest(provider, this.config.rerankApiKey || "", model, query, documents, results.length);
+                const { headers, body } = buildRerankRequest(provider, this.config.rerankApiKey || "", model, query, documents, rerankTopN);
                 // Timeout: configurable via rerankTimeoutMs (default: 5000ms)
                 const controller = new AbortController();
                 const timeout = setTimeout(() => controller.abort(), this.config.rerankTimeoutMs ?? 5000);

--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -6,6 +6,7 @@ import { computeEffectiveHalfLife, parseAccessMetadata, } from "./access-tracker
 import { filterNoise } from "./noise-filter.js";
 import { expandQuery } from "./query-expander.js";
 import { getDecayableFromEntry, isMemoryExpired, parseSmartMetadata, toLifecycleMemory, } from "./smart-metadata.js";
+import { matchesMemoryCategoryFilter } from "./memory-categories.js";
 import { TraceCollector } from "./retrieval-trace.js";
 // ============================================================================
 // Default Configuration
@@ -461,7 +462,7 @@ export class MemoryRetriever {
             failureStage = "vector.vectorSearch";
             const results = await this.store.vectorSearch(queryVector, candidatePoolSize, this.config.minScore, scopeFilter, { excludeInactive: true });
             const filtered = category
-                ? results.filter((r) => r.entry.category === category)
+                ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
                 : results;
             // Filter expired memories early — before scoring — so they don't
             // occupy candidate slots that should go to live memories.
@@ -529,7 +530,7 @@ export class MemoryRetriever {
         trace?.startStage("bm25_search", []);
         const bm25Results = await this.store.bm25Search(query, candidatePoolSize, scopeFilter, { excludeInactive: true });
         const categoryFiltered = category
-            ? bm25Results.filter((r) => r.entry.category === category)
+            ? bm25Results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
             : bm25Results;
         const mustContainFiltered = categoryFiltered.filter((r) => {
             const textLower = r.entry.text.toLowerCase();
@@ -769,7 +770,7 @@ export class MemoryRetriever {
         const results = await this.store.vectorSearch(queryVector, limit, 0.1, scopeFilter, { excludeInactive: true });
         // Filter by category if specified
         const filtered = category
-            ? results.filter((r) => r.entry.category === category)
+            ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
             : results;
         return filtered.map((result, index) => ({
             ...result,
@@ -780,7 +781,7 @@ export class MemoryRetriever {
         const results = await this.store.bm25Search(query, limit, scopeFilter, { excludeInactive: true });
         // Filter by category if specified
         const filtered = category
-            ? results.filter((r) => r.entry.category === category)
+            ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
             : results;
         return filtered.map((result, index) => ({
             ...result,

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -7,7 +7,7 @@ import { existsSync, accessSync, constants, mkdirSync, realpathSync, lstatSync, 
 import { access as accessAsync, lstat as lstatAsync, mkdir as mkdirAsync, realpath as realpathAsync, rmdir as rmdirAsync, stat as statAsync, unlink as unlinkAsync, writeFile as writeFileAsync, } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { resolveCategoryFilterCandidates } from "./memory-categories.js";
+import { matchesMemoryCategoryFilter, resolveCategoryFilterCandidates } from "./memory-categories.js";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
 // ============================================================================
 // LanceDB Dynamic Import
@@ -51,7 +51,11 @@ function clampInt(value, min, max) {
         return min;
     return Math.min(max, Math.max(min, Math.floor(value)));
 }
+const LEGACY_STABLE_MEMORY_ID_REGEX = /^[A-Za-z0-9][A-Za-z0-9._:-]{2,127}$/;
 const LEGACY_SECONDS_TIMESTAMP_MAX = 1_000_000_000_000;
+function isLegacyStableMemoryId(id) {
+    return LEGACY_STABLE_MEMORY_ID_REGEX.test(id);
+}
 export function normalizeMemoryTimestamp(value, fallback = Date.now()) {
     const raw = value instanceof Date
         ? value.getTime()
@@ -1450,7 +1454,7 @@ export class MemoryStore {
             "timestamp",
             "metadata",
         ]);
-        return results
+        const entries = results
             .map((row) => ({
             id: row.id,
             text: row.text,
@@ -1460,7 +1464,10 @@ export class MemoryStore {
             importance: Number(row.importance),
             timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
             metadata: row.metadata || "{}",
-        }))
+        }));
+        return (category
+            ? entries.filter((entry) => matchesMemoryCategoryFilter(entry.category, category, entry.metadata))
+            : entries)
             .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))
             .slice(offset, offset + limit);
     }
@@ -1689,20 +1696,19 @@ export class MemoryStore {
             throw new Error(`Memory ${id} is outside accessible scopes`);
         }
         return this.runWithFileLock(() => this.runSerializedUpdate(async () => {
-            // Support both full UUID and short prefix (8+ hex chars), same as delete()
-            // Also support legacy mem-md-N format from older memory-lancedb-pro versions
+            // Support full UUID, short hex prefixes, and constrained exact legacy IDs imported
+            // from older stores (for example "mem-md-..." or "data-pointer-...").
             const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
             const prefixRegex = /^[0-9a-f]{8,}$/i;
-            const legacyRegex = /^mem-md-\d+$/i;
             const isFullId = uuidRegex.test(id);
             const isPrefix = !isFullId && prefixRegex.test(id);
-            const isLegacy = !isFullId && !isPrefix && legacyRegex.test(id);
-            if (!isFullId && !isPrefix && !isLegacy) {
+            const isLegacyStableId = !isFullId && !isPrefix && isLegacyStableMemoryId(id);
+            if (!isFullId && !isPrefix && !isLegacyStableId) {
                 throw new Error(`Invalid memory ID format: ${id}`);
             }
             let rows;
-            if (isFullId || isLegacy) {
-                // Legacy IDs use exact string match like full UUIDs
+            if (isFullId || isLegacyStableId) {
+                // Legacy IDs use exact string match like full UUIDs.
                 const safeId = escapeSqlLiteral(id);
                 rows = await this.table.query()
                     .where(`id = '${safeId}'`)

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -7,6 +7,7 @@ import { existsSync, accessSync, constants, mkdirSync, realpathSync, lstatSync, 
 import { access as accessAsync, lstat as lstatAsync, mkdir as mkdirAsync, realpath as realpathAsync, rmdir as rmdirAsync, stat as statAsync, unlink as unlinkAsync, writeFile as writeFileAsync, } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveCategoryFilterCandidates } from "./memory-categories.js";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
 // ============================================================================
 // LanceDB Dynamic Import
@@ -1433,7 +1434,10 @@ export class MemoryStore {
             conditions.push(`((${scopeConditions}) OR scope IS NULL)`);
         }
         if (category) {
-            conditions.push(`category = '${escapeSqlLiteral(category)}'`);
+            const categoryConditions = resolveCategoryFilterCandidates(category)
+                .map((candidate) => `category = '${escapeSqlLiteral(candidate)}'`)
+                .join(" OR ");
+            conditions.push(`(${categoryConditions})`);
         }
         const applyConditions = (query) => conditions.length > 0 ? query.where(conditions.join(" AND ")) : query;
         // Fetch all matching rows (no pre-limit) so app-layer sort is correct across full dataset

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -11,21 +11,14 @@ import { stripEnvelopeMetadata } from "./smart-extractor.js";
 import { isSystemBypassId, resolveScopeFilter, parseAgentIdFromSessionKey } from "./scopes.js";
 import { appendRelation, buildSmartMetadata, deriveFactKey, parseSmartMetadata, stringifySmartMetadata, } from "./smart-metadata.js";
 import { classifyTemporal, inferExpiry } from "./temporal-classifier.js";
-import { TEMPORAL_VERSIONED_CATEGORIES } from "./memory-categories.js";
+import { TEMPORAL_VERSIONED_CATEGORIES, TOOL_MEMORY_CATEGORIES, } from "./memory-categories.js";
 import { appendSelfImprovementEntry, countSelfImprovementEntries, DEFAULT_SELF_IMPROVEMENT_MAX_ENTRIES, ensureSelfImprovementLearningFiles, } from "./self-improvement-files.js";
 import { getDisplayCategoryTag, parseReflectionMetadata } from "./reflection-metadata.js";
 import { filterUserMdExclusiveRecallResults, isUserMdExclusiveMemory, } from "./workspace-boundary.js";
 // ============================================================================
 // Types
 // ============================================================================
-export const MEMORY_CATEGORIES = [
-    "preference",
-    "fact",
-    "decision",
-    "entity",
-    "reflection",
-    "other",
-];
+export const MEMORY_CATEGORIES = TOOL_MEMORY_CATEGORIES;
 function stringEnum(values) {
     return Type.Unsafe({
         type: "string",

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -11,7 +11,7 @@ import { stripEnvelopeMetadata } from "./smart-extractor.js";
 import { isSystemBypassId, resolveScopeFilter, parseAgentIdFromSessionKey } from "./scopes.js";
 import { appendRelation, buildSmartMetadata, deriveFactKey, parseSmartMetadata, stringifySmartMetadata, } from "./smart-metadata.js";
 import { classifyTemporal, inferExpiry } from "./temporal-classifier.js";
-import { TEMPORAL_VERSIONED_CATEGORIES, TOOL_MEMORY_CATEGORIES, } from "./memory-categories.js";
+import { matchesMemoryCategoryFilter, resolveToolMemoryCategory, TEMPORAL_VERSIONED_CATEGORIES, TOOL_MEMORY_CATEGORIES, } from "./memory-categories.js";
 import { appendSelfImprovementEntry, countSelfImprovementEntries, DEFAULT_SELF_IMPROVEMENT_MAX_ENTRIES, ensureSelfImprovementLearningFiles, } from "./self-improvement-files.js";
 import { getDisplayCategoryTag, parseReflectionMetadata } from "./reflection-metadata.js";
 import { filterUserMdExclusiveRecallResults, isUserMdExclusiveMemory, } from "./workspace-boundary.js";
@@ -55,7 +55,7 @@ function truncateText(text, maxChars) {
     return `${clipped}…`;
 }
 function deriveManualMemoryLayer(category) {
-    if (category === "preference" || category === "decision" || category === "fact") {
+    if (category === "profile" || category === "preferences" || category === "events") {
         return "durable";
     }
     return "working";
@@ -708,6 +708,7 @@ export function registerMemoryStoreTool(api, context) {
                         };
                     }
                     const safeImportance = clamp01(importance, 0.7);
+                    const { memoryCategory, storageCategory } = resolveToolMemoryCategory(category);
                     const vector = await runtimeContext.embedder.embedPassage(stripped);
                     // Temporal awareness: classify and infer expiry
                     const temporalType = classifyTemporal(stripped);
@@ -716,12 +717,9 @@ export function registerMemoryStoreTool(api, context) {
                     // (bypasses importance/recency weighting).
                     // Fail-open by design: dedup must never block a legitimate memory write.
                     // excludeInactive: superseded historical records must not block new writes.
-                    // Align with TEMPORAL_VERSIONED_CATEGORIES: only preference and entity
-                    // are semantically version-controlled. "fact"/"other" can reverse-map
-                    // to unrelated semantic categories, risking cross-supersede.
-                    const SUPERSEDE_ELIGIBLE = new Set([
-                        "preference", "entity",
-                    ]);
+                    // Align with TEMPORAL_VERSIONED_CATEGORIES at the smart-category
+                    // layer so legacy storage categories like "fact" don't cross-match
+                    // unrelated profile/case memories.
                     let existing = [];
                     try {
                         existing = await runtimeContext.store.vectorSearch(vector, 3, 0.1, [
@@ -754,8 +752,8 @@ export function registerMemoryStoreTool(api, context) {
                     // one as superseded and store the new one with a supersedes link.
                     const supersedeCandidate = existing.find((r) => r.score > 0.95 &&
                         r.score <= 0.98 &&
-                        r.entry.category === category &&
-                        SUPERSEDE_ELIGIBLE.has(r.entry.category));
+                        TEMPORAL_VERSIONED_CATEGORIES.has(memoryCategory) &&
+                        matchesMemoryCategoryFilter(r.entry.category, memoryCategory, r.entry.metadata));
                     if (supersedeCandidate) {
                         const oldEntry = supersedeCandidate.entry;
                         const oldMeta = parseSmartMetadata(oldEntry.metadata, oldEntry);
@@ -763,7 +761,7 @@ export function registerMemoryStoreTool(api, context) {
                         const factKey = oldMeta.fact_key ?? deriveFactKey(oldMeta.memory_category, text);
                         // Store new memory with supersedes link, preserving canonical fields
                         // from the old entry (aligns with memory_update supersede path).
-                        const newMeta = buildSmartMetadata({ text, category: category, importance: safeImportance }, {
+                        const newMeta = buildSmartMetadata({ text, category: storageCategory, importance: safeImportance }, {
                             l0_abstract: text,
                             l1_overview: oldMeta.l1_overview || `- ${text}`,
                             l2_content: text,
@@ -771,7 +769,7 @@ export function registerMemoryStoreTool(api, context) {
                             tier: oldMeta.tier,
                             source: "manual",
                             state: "confirmed",
-                            memory_layer: deriveManualMemoryLayer(category),
+                            memory_layer: deriveManualMemoryLayer(oldMeta.memory_category),
                             last_confirmed_use_at: now,
                             bad_recall_count: 0,
                             suppressed_until_turn: 0,
@@ -787,7 +785,7 @@ export function registerMemoryStoreTool(api, context) {
                             text,
                             vector,
                             importance: safeImportance,
-                            category: category,
+                            category: storageCategory,
                             scope: targetScope,
                             metadata: stringifySmartMetadata(newMeta),
                         });
@@ -809,7 +807,7 @@ export function registerMemoryStoreTool(api, context) {
                         }
                         // Dual-write to Markdown mirror if enabled
                         if (context.mdMirror) {
-                            await context.mdMirror({ text, category: category, scope: targetScope, timestamp: newEntry.timestamp }, { source: "memory_store", agentId });
+                            await context.mdMirror({ text, category: storageCategory, scope: targetScope, timestamp: newEntry.timestamp }, { source: "memory_store", agentId });
                         }
                         return {
                             content: [
@@ -823,7 +821,8 @@ export function registerMemoryStoreTool(api, context) {
                                 id: newEntry.id,
                                 supersededId: oldEntry.id,
                                 scope: newEntry.scope,
-                                category: newEntry.category,
+                                category: memoryCategory,
+                                rawCategory: newEntry.category,
                                 importance: newEntry.importance,
                                 similarity: supersedeCandidate.score,
                             },
@@ -833,19 +832,20 @@ export function registerMemoryStoreTool(api, context) {
                         text,
                         vector,
                         importance: safeImportance,
-                        category: category,
+                        category: storageCategory,
                         scope: targetScope,
                         metadata: stringifySmartMetadata(buildSmartMetadata({
                             text,
-                            category: category,
+                            category: storageCategory,
                             importance: safeImportance,
                         }, {
                             l0_abstract: text,
                             l1_overview: `- ${text}`,
                             l2_content: text,
+                            memory_category: memoryCategory,
                             source: "manual",
                             state: "confirmed",
-                            memory_layer: deriveManualMemoryLayer(category),
+                            memory_layer: deriveManualMemoryLayer(memoryCategory),
                             last_confirmed_use_at: Date.now(),
                             bad_recall_count: 0,
                             suppressed_until_turn: 0,
@@ -855,7 +855,7 @@ export function registerMemoryStoreTool(api, context) {
                     });
                     // Dual-write to Markdown mirror if enabled
                     if (context.mdMirror) {
-                        await context.mdMirror({ text, category: category, scope: targetScope, timestamp: entry.timestamp }, { source: "memory_store", agentId });
+                        await context.mdMirror({ text, category: storageCategory, scope: targetScope, timestamp: entry.timestamp }, { source: "memory_store", agentId });
                     }
                     return {
                         content: [
@@ -868,7 +868,8 @@ export function registerMemoryStoreTool(api, context) {
                             action: "created",
                             id: entry.id,
                             scope: entry.scope,
-                            category: entry.category,
+                            category: memoryCategory,
+                            rawCategory: entry.category,
                             importance: entry.importance,
                             ...(duplicateCandidate && force
                                 ? { duplicateOverride: {
@@ -1057,6 +1058,9 @@ export function registerMemoryUpdateTool(api, context) {
                             details: { error: "no_updates" },
                         };
                     }
+                    const categoryResolution = category
+                        ? resolveToolMemoryCategory(category)
+                        : undefined;
                     // Determine accessible scopes
                     const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
                     const scopeFilter = resolveScopeFilter(runtimeContext.scopeManager, agentId);
@@ -1122,7 +1126,7 @@ export function registerMemoryUpdateTool(api, context) {
                     // importance-only change that still needs metadata sync). Shared by
                     // the temporal supersede guard and the normal-path metadata rebuild.
                     let existing = null;
-                    if (text || importance !== undefined) {
+                    if (text || importance !== undefined || categoryResolution) {
                         existing = await context.store.getById(resolvedId, scopeFilter);
                     }
                     // --- Temporal supersede guard ---
@@ -1131,14 +1135,16 @@ export function registerMemoryUpdateTool(api, context) {
                     if (text && newVector && existing) {
                         const meta = parseSmartMetadata(existing.metadata, existing);
                         if (TEMPORAL_VERSIONED_CATEGORIES.has(meta.memory_category)) {
+                            const effectiveMemoryCategory = categoryResolution?.memoryCategory ?? meta.memory_category;
+                            const effectiveStorageCategory = categoryResolution?.storageCategory ?? existing.category;
                             const now = Date.now();
-                            const factKey = meta.fact_key ?? deriveFactKey(meta.memory_category, text);
+                            const factKey = meta.fact_key ?? deriveFactKey(effectiveMemoryCategory, text);
                             // Create new superseding record
-                            const newMeta = buildSmartMetadata({ text, category: existing.category }, {
+                            const newMeta = buildSmartMetadata({ text, category: effectiveStorageCategory }, {
                                 l0_abstract: text,
                                 l1_overview: meta.l1_overview,
                                 l2_content: text,
-                                memory_category: meta.memory_category,
+                                memory_category: effectiveMemoryCategory,
                                 tier: meta.tier,
                                 access_count: 0,
                                 confidence: importance !== undefined ? clamp01(importance, 0.7) : meta.confidence,
@@ -1153,7 +1159,7 @@ export function registerMemoryUpdateTool(api, context) {
                             const newEntry = await context.store.store({
                                 text,
                                 vector: newVector,
-                                category: category ? category : existing.category,
+                                category: effectiveStorageCategory,
                                 scope: existing.scope,
                                 importance: importance !== undefined
                                     ? clamp01(importance, 0.7)
@@ -1188,7 +1194,7 @@ export function registerMemoryUpdateTool(api, context) {
                                     action: "superseded",
                                     oldId: resolvedId,
                                     newId: newEntry.id,
-                                    category: meta.memory_category,
+                                    category: effectiveMemoryCategory,
                                 },
                             };
                         }
@@ -1201,16 +1207,17 @@ export function registerMemoryUpdateTool(api, context) {
                         updates.vector = newVector;
                     if (importance !== undefined)
                         updates.importance = clamp01(importance, 0.7);
-                    if (category)
-                        updates.category = category;
+                    if (categoryResolution)
+                        updates.category = categoryResolution.storageCategory;
                     // Rebuild smart metadata when text or importance changes (#544)
                     if (text && existing) {
                         const meta = parseSmartMetadata(existing.metadata, existing);
-                        const effectiveCategory = category ?? meta.memory_category;
+                        const effectiveCategory = categoryResolution?.memoryCategory ?? meta.memory_category;
                         const updatedMeta = buildSmartMetadata(existing, {
                             l0_abstract: text,
                             l1_overview: `- ${text}`,
                             l2_content: text,
+                            memory_category: effectiveCategory,
                             fact_key: deriveFactKey(effectiveCategory, text),
                             memory_temporal_type: classifyTemporal(text),
                             confidence: importance !== undefined
@@ -1223,10 +1230,15 @@ export function registerMemoryUpdateTool(api, context) {
                         updatedMeta.valid_until = inferExpiry(text);
                         updates.metadata = stringifySmartMetadata(updatedMeta);
                     }
-                    else if (importance !== undefined && existing) {
-                        // Sync confidence for importance-only changes
+                    else if ((importance !== undefined || categoryResolution) && existing) {
+                        // Sync metadata for importance/category-only changes
                         const updatedMeta = buildSmartMetadata(existing, {
-                            confidence: clamp01(importance, 0.7),
+                            ...(importance !== undefined
+                                ? { confidence: clamp01(importance, 0.7) }
+                                : {}),
+                            ...(categoryResolution
+                                ? { memory_category: categoryResolution.memoryCategory }
+                                : {}),
                         });
                         updates.metadata = stringifySmartMetadata(updatedMeta);
                     }

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -19,6 +19,7 @@ export const CI_TEST_MANIFEST = [
   { group: "storage-and-schema", runner: "node", file: "test/storage-path-normalization.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/store-list-stats-projection-fallback.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/recall-text-cleanup.test.mjs", args: ["--test"] },
+  { group: "core-regression", runner: "node", file: "test/category-filter-normalization.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/update-consistency-lancedb.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/strip-envelope-metadata.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/auto-recall-timeout.test.mjs", args: ["--test"] },

--- a/src/memory-categories.ts
+++ b/src/memory-categories.ts
@@ -14,6 +14,20 @@ export const MEMORY_CATEGORIES = [
   "patterns",
 ] as const;
 
+export const LEGACY_MEMORY_CATEGORIES = [
+  "preference",
+  "fact",
+  "decision",
+  "entity",
+  "reflection",
+  "other",
+] as const;
+
+export const TOOL_MEMORY_CATEGORIES = [
+  ...MEMORY_CATEGORIES,
+  ...LEGACY_MEMORY_CATEGORIES,
+] as const;
+
 export type MemoryCategory = (typeof MEMORY_CATEGORIES)[number];
 
 /** Categories that always merge (skip dedup entirely). */
@@ -79,8 +93,48 @@ export type ExtractionStats = {
 /** Validate and normalize a category string. */
 export function normalizeCategory(raw: string): MemoryCategory | null {
   const lower = raw.toLowerCase().trim();
-  if ((MEMORY_CATEGORIES as readonly string[]).includes(lower)) {
-    return lower as MemoryCategory;
+  const aliases: Record<string, MemoryCategory> = {
+    preference: "preferences",
+    entity: "entities",
+    event: "events",
+    case: "cases",
+    pattern: "patterns",
+  };
+  const normalized = aliases[lower] ?? lower;
+  if ((MEMORY_CATEGORIES as readonly string[]).includes(normalized)) {
+    return normalized as MemoryCategory;
   }
   return null;
+}
+
+export function matchesMemoryCategoryFilter(
+  entryCategory: string,
+  requestedCategory: string,
+): boolean {
+  const rawEntryCategory = entryCategory.toLowerCase().trim();
+  const rawRequestedCategory = requestedCategory.toLowerCase().trim();
+  if (rawEntryCategory === rawRequestedCategory) return true;
+
+  const normalizedEntryCategory = normalizeCategory(rawEntryCategory);
+  const normalizedRequestedCategory = normalizeCategory(rawRequestedCategory);
+  return normalizedEntryCategory !== null &&
+    normalizedRequestedCategory !== null &&
+    normalizedEntryCategory === normalizedRequestedCategory;
+}
+
+export function resolveCategoryFilterCandidates(requestedCategory: string): string[] {
+  const rawRequestedCategory = requestedCategory.toLowerCase().trim();
+  const normalizedRequestedCategory = normalizeCategory(rawRequestedCategory);
+  const candidates = new Set<string>([rawRequestedCategory]);
+
+  if (normalizedRequestedCategory) {
+    candidates.add(normalizedRequestedCategory);
+    for (const category of TOOL_MEMORY_CATEGORIES) {
+      if (normalizeCategory(category) === normalizedRequestedCategory) {
+        candidates.add(category);
+      }
+    }
+  }
+
+  return [...candidates];
 }

--- a/src/memory-categories.ts
+++ b/src/memory-categories.ts
@@ -29,6 +29,25 @@ export const TOOL_MEMORY_CATEGORIES = [
 ] as const;
 
 export type MemoryCategory = (typeof MEMORY_CATEGORIES)[number];
+export type LegacyMemoryCategory = (typeof LEGACY_MEMORY_CATEGORIES)[number];
+
+const SMART_TO_STORAGE_CATEGORY: Record<MemoryCategory, LegacyMemoryCategory> = {
+  profile: "fact",
+  preferences: "preference",
+  entities: "entity",
+  events: "decision",
+  cases: "fact",
+  patterns: "other",
+};
+
+const LEGACY_TO_SMART_CATEGORY: Record<LegacyMemoryCategory, MemoryCategory> = {
+  preference: "preferences",
+  fact: "cases",
+  decision: "events",
+  entity: "entities",
+  reflection: "patterns",
+  other: "patterns",
+};
 
 /** Categories that always merge (skip dedup entirely). */
 export const ALWAYS_MERGE_CATEGORIES = new Set<MemoryCategory>(["profile"]);
@@ -110,16 +129,27 @@ export function normalizeCategory(raw: string): MemoryCategory | null {
 export function matchesMemoryCategoryFilter(
   entryCategory: string,
   requestedCategory: string,
+  entryMetadata?: string,
 ): boolean {
   const rawEntryCategory = entryCategory.toLowerCase().trim();
   const rawRequestedCategory = requestedCategory.toLowerCase().trim();
   if (rawEntryCategory === rawRequestedCategory) return true;
 
+  const metadataCategory = extractMetadataMemoryCategory(entryMetadata);
   const normalizedEntryCategory = normalizeCategory(rawEntryCategory);
   const normalizedRequestedCategory = normalizeCategory(rawRequestedCategory);
-  return normalizedEntryCategory !== null &&
-    normalizedRequestedCategory !== null &&
-    normalizedEntryCategory === normalizedRequestedCategory;
+  if (metadataCategory && normalizedRequestedCategory) {
+    return metadataCategory === normalizedRequestedCategory;
+  }
+  if (normalizedEntryCategory && normalizedRequestedCategory) {
+    return normalizedEntryCategory === normalizedRequestedCategory;
+  }
+
+  if (normalizedRequestedCategory && isLegacyMemoryCategory(rawEntryCategory)) {
+    return LEGACY_TO_SMART_CATEGORY[rawEntryCategory] === normalizedRequestedCategory;
+  }
+
+  return false;
 }
 
 export function resolveCategoryFilterCandidates(requestedCategory: string): string[] {
@@ -129,6 +159,7 @@ export function resolveCategoryFilterCandidates(requestedCategory: string): stri
 
   if (normalizedRequestedCategory) {
     candidates.add(normalizedRequestedCategory);
+    candidates.add(SMART_TO_STORAGE_CATEGORY[normalizedRequestedCategory]);
     for (const category of TOOL_MEMORY_CATEGORIES) {
       if (normalizeCategory(category) === normalizedRequestedCategory) {
         candidates.add(category);
@@ -137,4 +168,51 @@ export function resolveCategoryFilterCandidates(requestedCategory: string): stri
   }
 
   return [...candidates];
+}
+
+export function getStorageCategoryForMemoryCategory(
+  category: MemoryCategory,
+): LegacyMemoryCategory {
+  return SMART_TO_STORAGE_CATEGORY[category];
+}
+
+export function resolveToolMemoryCategory(rawCategory: string): {
+  memoryCategory: MemoryCategory;
+  storageCategory: LegacyMemoryCategory;
+} {
+  const raw = rawCategory.toLowerCase().trim();
+  const normalized = normalizeCategory(raw);
+  if (normalized) {
+    return {
+      memoryCategory: normalized,
+      storageCategory: SMART_TO_STORAGE_CATEGORY[normalized],
+    };
+  }
+
+  if (isLegacyMemoryCategory(raw)) {
+    return {
+      memoryCategory: LEGACY_TO_SMART_CATEGORY[raw],
+      storageCategory: raw,
+    };
+  }
+
+  return {
+    memoryCategory: "patterns",
+    storageCategory: "other",
+  };
+}
+
+function isLegacyMemoryCategory(value: string): value is LegacyMemoryCategory {
+  return (LEGACY_MEMORY_CATEGORIES as readonly string[]).includes(value);
+}
+
+function extractMetadataMemoryCategory(rawMetadata?: string): MemoryCategory | null {
+  if (!rawMetadata) return null;
+  try {
+    const parsed = JSON.parse(rawMetadata) as { memory_category?: unknown };
+    if (typeof parsed.memory_category !== "string") return null;
+    return normalizeCategory(parsed.memory_category);
+  } catch {
+    return null;
+  }
 }

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -768,7 +768,7 @@ export class MemoryRetriever {
       );
 
       const filtered = category
-        ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
+        ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category, r.entry.metadata))
         : results;
 
       // Filter expired memories early — before scoring — so they don't
@@ -851,7 +851,7 @@ export class MemoryRetriever {
       { excludeInactive: true },
     );
     const categoryFiltered = category
-      ? bm25Results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
+      ? bm25Results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category, r.entry.metadata))
       : bm25Results;
     const mustContainFiltered = categoryFiltered.filter((r) => {
       const textLower = r.entry.text.toLowerCase();
@@ -1142,7 +1142,7 @@ export class MemoryRetriever {
 
     // Filter by category if specified
     const filtered = category
-      ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
+      ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category, r.entry.metadata))
       : results;
 
     return filtered.map((result, index) => ({
@@ -1161,7 +1161,7 @@ export class MemoryRetriever {
 
     // Filter by category if specified
     const filtered = category
-      ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
+      ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category, r.entry.metadata))
       : results;
 
     return filtered.map((result, index) => ({

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -20,6 +20,7 @@ import {
   parseSmartMetadata,
   toLifecycleMemory,
 } from "./smart-metadata.js";
+import { matchesMemoryCategoryFilter } from "./memory-categories.js";
 import { TraceCollector, type RetrievalTrace } from "./retrieval-trace.js";
 import { RetrievalStatsCollector } from "./retrieval-stats.js";
 
@@ -767,7 +768,7 @@ export class MemoryRetriever {
       );
 
       const filtered = category
-        ? results.filter((r) => r.entry.category === category)
+        ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
         : results;
 
       // Filter expired memories early — before scoring — so they don't
@@ -850,7 +851,7 @@ export class MemoryRetriever {
       { excludeInactive: true },
     );
     const categoryFiltered = category
-      ? bm25Results.filter((r) => r.entry.category === category)
+      ? bm25Results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
       : bm25Results;
     const mustContainFiltered = categoryFiltered.filter((r) => {
       const textLower = r.entry.text.toLowerCase();
@@ -1141,7 +1142,7 @@ export class MemoryRetriever {
 
     // Filter by category if specified
     const filtered = category
-      ? results.filter((r) => r.entry.category === category)
+      ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
       : results;
 
     return filtered.map((result, index) => ({
@@ -1160,7 +1161,7 @@ export class MemoryRetriever {
 
     // Filter by category if specified
     const filtered = category
-      ? results.filter((r) => r.entry.category === category)
+      ? results.filter((r) => matchesMemoryCategoryFilter(r.entry.category, category))
       : results;
 
     return filtered.map((result, index) => ({

--- a/src/store.ts
+++ b/src/store.ts
@@ -27,7 +27,7 @@ import {
 } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { resolveCategoryFilterCandidates } from "./memory-categories.js";
+import { matchesMemoryCategoryFilter, resolveCategoryFilterCandidates } from "./memory-categories.js";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
 
 // ============================================================================
@@ -1757,7 +1757,7 @@ export class MemoryStore {
       ],
     );
 
-    return results
+    const entries = results
       .map(
         (row): MemoryEntry => ({
           id: row.id as string,
@@ -1769,7 +1769,13 @@ export class MemoryStore {
           timestamp: normalizeMemoryTimestamp(row.timestamp, 0),
           metadata: (row.metadata as string) || "{}",
         }),
-      )
+      );
+
+    return (category
+      ? entries.filter((entry) =>
+          matchesMemoryCategoryFilter(entry.category, category, entry.metadata),
+        )
+      : entries)
       .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))
       .slice(offset, offset + limit);
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -27,6 +27,7 @@ import {
 } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveCategoryFilterCandidates } from "./memory-categories.js";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
 
 // ============================================================================
@@ -1733,7 +1734,10 @@ export class MemoryStore {
     }
 
     if (category) {
-      conditions.push(`category = '${escapeSqlLiteral(category)}'`);
+      const categoryConditions = resolveCategoryFilterCandidates(category)
+        .map((candidate) => `category = '${escapeSqlLiteral(candidate)}'`)
+        .join(" OR ");
+      conditions.push(`(${categoryConditions})`);
     }
 
     const applyConditions = (query: any) =>

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -22,7 +22,10 @@ import {
   stringifySmartMetadata,
 } from "./smart-metadata.js";
 import { classifyTemporal, inferExpiry } from "./temporal-classifier.js";
-import { TEMPORAL_VERSIONED_CATEGORIES } from "./memory-categories.js";
+import {
+  TEMPORAL_VERSIONED_CATEGORIES,
+  TOOL_MEMORY_CATEGORIES,
+} from "./memory-categories.js";
 import {
   appendSelfImprovementEntry,
   countSelfImprovementEntries,
@@ -41,14 +44,7 @@ import {
 // Types
 // ============================================================================
 
-export const MEMORY_CATEGORIES = [
-  "preference",
-  "fact",
-  "decision",
-  "entity",
-  "reflection",
-  "other",
-] as const;
+export const MEMORY_CATEGORIES = TOOL_MEMORY_CATEGORIES;
 
 function stringEnum<T extends readonly [string, ...string[]]>(values: T) {
   return Type.Unsafe<T[number]>({

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -23,8 +23,11 @@ import {
 } from "./smart-metadata.js";
 import { classifyTemporal, inferExpiry } from "./temporal-classifier.js";
 import {
+  matchesMemoryCategoryFilter,
+  resolveToolMemoryCategory,
   TEMPORAL_VERSIONED_CATEGORIES,
   TOOL_MEMORY_CATEGORIES,
+  type MemoryCategory,
 } from "./memory-categories.js";
 import {
   appendSelfImprovementEntry,
@@ -99,8 +102,8 @@ function truncateText(text: string, maxChars: number): string {
   return `${clipped}…`;
 }
 
-function deriveManualMemoryLayer(category: string): "durable" | "working" {
-  if (category === "preference" || category === "decision" || category === "fact") {
+function deriveManualMemoryLayer(category: MemoryCategory): "durable" | "working" {
+  if (category === "profile" || category === "preferences" || category === "events") {
     return "durable";
   }
   return "working";
@@ -945,6 +948,8 @@ export function registerMemoryStoreTool(
           }
 
           const safeImportance = clamp01(importance, 0.7);
+          const { memoryCategory, storageCategory } =
+            resolveToolMemoryCategory(category);
           const vector = await runtimeContext.embedder.embedPassage(stripped);
 
           // Temporal awareness: classify and infer expiry
@@ -954,12 +959,9 @@ export function registerMemoryStoreTool(
           // (bypasses importance/recency weighting).
           // Fail-open by design: dedup must never block a legitimate memory write.
           // excludeInactive: superseded historical records must not block new writes.
-          // Align with TEMPORAL_VERSIONED_CATEGORIES: only preference and entity
-          // are semantically version-controlled. "fact"/"other" can reverse-map
-          // to unrelated semantic categories, risking cross-supersede.
-          const SUPERSEDE_ELIGIBLE: ReadonlySet<string> = new Set([
-            "preference", "entity",
-          ]);
+          // Align with TEMPORAL_VERSIONED_CATEGORIES at the smart-category
+          // layer so legacy storage categories like "fact" don't cross-match
+          // unrelated profile/case memories.
           let existing: Awaited<ReturnType<MemoryStore["vectorSearch"]>> = [];
           try {
             existing = await runtimeContext.store.vectorSearch(vector, 3, 0.1, [
@@ -997,8 +999,8 @@ export function registerMemoryStoreTool(
             (r) =>
               r.score > 0.95 &&
               r.score <= 0.98 &&
-              r.entry.category === category &&
-              SUPERSEDE_ELIGIBLE.has(r.entry.category),
+              TEMPORAL_VERSIONED_CATEGORIES.has(memoryCategory) &&
+              matchesMemoryCategoryFilter(r.entry.category, memoryCategory, r.entry.metadata),
           );
 
           if (supersedeCandidate) {
@@ -1011,7 +1013,7 @@ export function registerMemoryStoreTool(
             // Store new memory with supersedes link, preserving canonical fields
             // from the old entry (aligns with memory_update supersede path).
             const newMeta = buildSmartMetadata(
-              { text, category: category as any, importance: safeImportance },
+              { text, category: storageCategory, importance: safeImportance },
               {
                 l0_abstract: text,
                 l1_overview: oldMeta.l1_overview || `- ${text}`,
@@ -1020,7 +1022,7 @@ export function registerMemoryStoreTool(
                 tier: oldMeta.tier,
                 source: "manual",
                 state: "confirmed",
-                memory_layer: deriveManualMemoryLayer(category as string),
+                memory_layer: deriveManualMemoryLayer(oldMeta.memory_category),
                 last_confirmed_use_at: now,
                 bad_recall_count: 0,
                 suppressed_until_turn: 0,
@@ -1038,7 +1040,7 @@ export function registerMemoryStoreTool(
               text,
               vector,
               importance: safeImportance,
-              category: category as any,
+              category: storageCategory,
               scope: targetScope,
               metadata: stringifySmartMetadata(newMeta),
             });
@@ -1068,7 +1070,7 @@ export function registerMemoryStoreTool(
             // Dual-write to Markdown mirror if enabled
             if (context.mdMirror) {
               await context.mdMirror(
-                { text, category: category as string, scope: targetScope, timestamp: newEntry.timestamp },
+                { text, category: storageCategory, scope: targetScope, timestamp: newEntry.timestamp },
                 { source: "memory_store", agentId },
               );
             }
@@ -1085,7 +1087,8 @@ export function registerMemoryStoreTool(
                 id: newEntry.id,
                 supersededId: oldEntry.id,
                 scope: newEntry.scope,
-                category: newEntry.category,
+                category: memoryCategory,
+                rawCategory: newEntry.category,
                 importance: newEntry.importance,
                 similarity: supersedeCandidate.score,
               },
@@ -1096,22 +1099,23 @@ export function registerMemoryStoreTool(
             text,
             vector,
             importance: safeImportance,
-            category: category as any,
+            category: storageCategory,
             scope: targetScope,
             metadata: stringifySmartMetadata(
               buildSmartMetadata(
                 {
                   text,
-                  category: category as any,
+                  category: storageCategory,
                   importance: safeImportance,
                 },
                 {
                   l0_abstract: text,
                   l1_overview: `- ${text}`,
                   l2_content: text,
+                  memory_category: memoryCategory,
                   source: "manual",
                   state: "confirmed",
-                  memory_layer: deriveManualMemoryLayer(category as string),
+                  memory_layer: deriveManualMemoryLayer(memoryCategory),
                   last_confirmed_use_at: Date.now(),
                   bad_recall_count: 0,
                   suppressed_until_turn: 0,
@@ -1125,7 +1129,7 @@ export function registerMemoryStoreTool(
           // Dual-write to Markdown mirror if enabled
           if (context.mdMirror) {
             await context.mdMirror(
-              { text, category: category as string, scope: targetScope, timestamp: entry.timestamp },
+              { text, category: storageCategory, scope: targetScope, timestamp: entry.timestamp },
               { source: "memory_store", agentId },
             );
           }
@@ -1141,7 +1145,8 @@ export function registerMemoryStoreTool(
               action: "created",
               id: entry.id,
               scope: entry.scope,
-              category: entry.category,
+              category: memoryCategory,
+              rawCategory: entry.category,
               importance: entry.importance,
               ...(duplicateCandidate && force
                 ? { duplicateOverride: {
@@ -1378,6 +1383,9 @@ export function registerMemoryUpdateTool(
               details: { error: "no_updates" },
             };
           }
+          const categoryResolution = category
+            ? resolveToolMemoryCategory(category)
+            : undefined;
 
           // Determine accessible scopes
           const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
@@ -1449,7 +1457,7 @@ export function registerMemoryUpdateTool(
           // importance-only change that still needs metadata sync). Shared by
           // the temporal supersede guard and the normal-path metadata rebuild.
           let existing: MemoryEntry | null = null;
-          if (text || importance !== undefined) {
+          if (text || importance !== undefined || categoryResolution) {
             existing = await context.store.getById(resolvedId, scopeFilter);
           }
 
@@ -1459,18 +1467,22 @@ export function registerMemoryUpdateTool(
           if (text && newVector && existing) {
             const meta = parseSmartMetadata(existing.metadata, existing);
             if (TEMPORAL_VERSIONED_CATEGORIES.has(meta.memory_category)) {
+                const effectiveMemoryCategory =
+                  categoryResolution?.memoryCategory ?? meta.memory_category;
+                const effectiveStorageCategory =
+                  categoryResolution?.storageCategory ?? existing.category;
                 const now = Date.now();
                 const factKey =
-                  meta.fact_key ?? deriveFactKey(meta.memory_category, text);
+                  meta.fact_key ?? deriveFactKey(effectiveMemoryCategory, text);
 
                 // Create new superseding record
                 const newMeta = buildSmartMetadata(
-                  { text, category: existing.category },
+                  { text, category: effectiveStorageCategory },
                   {
                     l0_abstract: text,
                     l1_overview: meta.l1_overview,
                     l2_content: text,
-                    memory_category: meta.memory_category,
+                    memory_category: effectiveMemoryCategory,
                     tier: meta.tier,
                     access_count: 0,
                     confidence: importance !== undefined ? clamp01(importance, 0.7) : meta.confidence,
@@ -1487,7 +1499,7 @@ export function registerMemoryUpdateTool(
                 const newEntry = await context.store.store({
                   text,
                   vector: newVector,
-                  category: category ? (category as any) : existing.category,
+                  category: effectiveStorageCategory,
                   scope: existing.scope,
                   importance:
                     importance !== undefined
@@ -1530,7 +1542,7 @@ export function registerMemoryUpdateTool(
                     action: "superseded",
                     oldId: resolvedId,
                     newId: newEntry.id,
-                    category: meta.memory_category,
+                    category: effectiveMemoryCategory,
                   },
                 };
             }
@@ -1542,16 +1554,18 @@ export function registerMemoryUpdateTool(
           if (newVector) updates.vector = newVector;
           if (importance !== undefined)
             updates.importance = clamp01(importance, 0.7);
-          if (category) updates.category = category;
+          if (categoryResolution) updates.category = categoryResolution.storageCategory;
 
           // Rebuild smart metadata when text or importance changes (#544)
           if (text && existing) {
             const meta = parseSmartMetadata(existing.metadata, existing);
-            const effectiveCategory = (category as any) ?? meta.memory_category;
+            const effectiveCategory =
+              categoryResolution?.memoryCategory ?? meta.memory_category;
             const updatedMeta = buildSmartMetadata(existing, {
               l0_abstract: text,
               l1_overview: `- ${text}`,
               l2_content: text,
+              memory_category: effectiveCategory,
               fact_key: deriveFactKey(effectiveCategory, text),
               memory_temporal_type: classifyTemporal(text),
               confidence:
@@ -1564,10 +1578,15 @@ export function registerMemoryUpdateTool(
             // clears any stale value inherited from the previous text.
             updatedMeta.valid_until = inferExpiry(text);
             updates.metadata = stringifySmartMetadata(updatedMeta);
-          } else if (importance !== undefined && existing) {
-            // Sync confidence for importance-only changes
+          } else if ((importance !== undefined || categoryResolution) && existing) {
+            // Sync metadata for importance/category-only changes
             const updatedMeta = buildSmartMetadata(existing, {
-              confidence: clamp01(importance, 0.7),
+              ...(importance !== undefined
+                ? { confidence: clamp01(importance, 0.7) }
+                : {}),
+              ...(categoryResolution
+                ? { memory_category: categoryResolution.memoryCategory }
+                : {}),
             });
             updates.metadata = stringifySmartMetadata(updatedMeta);
           }

--- a/test/category-filter-normalization.test.mjs
+++ b/test/category-filter-normalization.test.mjs
@@ -1,6 +1,17 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import Module from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, it } from "node:test";
 import jitiFactory from "jiti";
+
+process.env.NODE_PATH = [
+  process.env.NODE_PATH,
+  "/opt/homebrew/lib/node_modules/openclaw/node_modules",
+  "/opt/homebrew/lib/node_modules",
+].filter(Boolean).join(":");
+Module._initPaths();
 
 const jiti = jitiFactory(import.meta.url, { interopDefault: true });
 const {
@@ -9,8 +20,21 @@ const {
   resolveCategoryFilterCandidates,
 } = jiti("../src/memory-categories.ts");
 const { createRetriever } = jiti("../src/retriever.ts");
+const { MemoryStore } = jiti("../src/store.ts");
+const { SmartExtractor } = jiti("../src/smart-extractor.ts");
+const {
+  buildSmartMetadata,
+  parseSmartMetadata,
+  stringifySmartMetadata,
+} = jiti("../src/smart-metadata.ts");
+const {
+  registerMemoryStoreTool,
+  registerMemoryUpdateTool,
+} = jiti("../src/tools.ts");
 
-function buildResult(id, category) {
+const VECTOR_DIM = 3;
+
+function buildResult(id, category, metadata = "{}") {
   return {
     entry: {
       id,
@@ -20,10 +44,107 @@ function buildResult(id, category) {
       scope: "global",
       importance: 0.7,
       timestamp: Date.now(),
-      metadata: "{}",
+      metadata,
     },
     score: 0.9,
   };
+}
+
+function makeVector(text) {
+  if (/profile|name|alice/i.test(text)) return [1, 0, 0];
+  if (/case|outage|postgres/i.test(text)) return [0, 1, 0];
+  if (/event|conference|incident/i.test(text)) return [0, 0, 1];
+  return [0.5, 0.25, 0.25];
+}
+
+function createTool(registerFn, context) {
+  let captured = null;
+  const api = {
+    registerTool(factory) {
+      captured = factory;
+    },
+    logger: { info() {}, warn() {}, debug() {} },
+  };
+  registerFn(api, context);
+  assert.equal(typeof captured, "function");
+  return captured({});
+}
+
+function makeToolContext(store) {
+  return {
+    agentId: "test-agent",
+    workspaceDir: "/tmp",
+    mdMirror: null,
+    store,
+    retriever: {
+      async retrieve() {
+        return [];
+      },
+      getConfig() {
+        return { mode: "hybrid" };
+      },
+      getStatsCollector() {
+        return { count: 0 };
+      },
+    },
+    embedder: {
+      async embedPassage(text) {
+        return makeVector(text);
+      },
+    },
+    scopeManager: {
+      getAccessibleScopes: () => ["global"],
+      getScopeFilter: () => ["global"],
+      getDefaultScope: () => "global",
+      isAccessible: (scope) => scope === "global",
+    },
+  };
+}
+
+function makeSmartExtractor(store) {
+  return new SmartExtractor(
+    store,
+    {
+      async embed(text) {
+        return makeVector(text);
+      },
+      async embedBatch(texts) {
+        return texts.map(makeVector);
+      },
+    },
+    {
+      async completeJson(_prompt, mode) {
+        if (mode === "extract-candidates") {
+          return {
+            memories: [
+              {
+                category: "profile",
+                abstract: "Profile: Alice is the release owner",
+                overview: "- Alice owns releases",
+                content: "Alice is the release owner.",
+              },
+              {
+                category: "cases",
+                abstract: "Case: postgres outage runbook",
+                overview: "- Postgres outage runbook",
+                content: "Use the postgres outage runbook for recovery.",
+              },
+            ],
+          };
+        }
+        if (mode === "dedup-memory") {
+          return { decision: "create", reason: "new memory" };
+        }
+        throw new Error(`unexpected mode: ${mode}`);
+      },
+    },
+    {
+      extractMinMessages: 1,
+      defaultScope: "global",
+      log() {},
+      debugLog() {},
+    },
+  );
 }
 
 describe("category filter normalization", () => {
@@ -75,5 +196,202 @@ describe("category filter normalization", () => {
     });
 
     assert.deepEqual(results.map((result) => result.entry.id), ["smart-preference"]);
+  });
+
+  it("applies metadata-aware smart category filters during retrieval", async () => {
+    const profileMeta = JSON.stringify({ memory_category: "profile" });
+    const casesMeta = JSON.stringify({ memory_category: "cases" });
+    const retriever = createRetriever(
+      {
+        hasFtsSupport: true,
+        async refreshFtsSupport() {
+          return true;
+        },
+        async vectorSearch() {
+          return [];
+        },
+        async bm25Search() {
+          return [
+            buildResult("profile-fact", "fact", profileMeta),
+            buildResult("case-fact", "fact", casesMeta),
+          ];
+        },
+        async hasId() {
+          return true;
+        },
+      },
+      {
+        async embedQuery() {
+          return [0.1, 0.2, 0.3];
+        },
+      },
+      { rerank: "none", hardMinScore: 0, filterNoise: false },
+    );
+
+    const results = await retriever.retrieve({
+      query: "coffee",
+      limit: 5,
+      category: "profile",
+      source: "manual",
+    });
+
+    assert.deepEqual(results.map((result) => result.entry.id), ["profile-fact"]);
+  });
+
+  it("filters real smart-extractor rows by metadata category through store.list", async () => {
+    const workDir = mkdtempSync(path.join(tmpdir(), "category-filter-"));
+    const store = new MemoryStore({
+      dbPath: path.join(workDir, "db"),
+      vectorDim: VECTOR_DIM,
+    });
+
+    try {
+      const extractor = makeSmartExtractor(store);
+      const stats = await extractor.extractAndPersist(
+        "Alice owns releases. Use the postgres outage runbook.",
+        "session-1",
+        { scope: "global" },
+      );
+
+      assert.equal(stats.created, 2);
+
+      const profile = await store.list(["global"], "profile", 10, 0);
+      const cases = await store.list(["global"], "cases", 10, 0);
+
+      assert.deepEqual(profile.map((entry) => entry.text), [
+        "Profile: Alice is the release owner",
+      ]);
+      assert.equal(profile[0].category, "fact");
+      assert.equal(parseSmartMetadata(profile[0].metadata, profile[0]).memory_category, "profile");
+
+      assert.deepEqual(cases.map((entry) => entry.text), [
+        "Case: postgres outage runbook",
+      ]);
+      assert.equal(cases[0].category, "fact");
+      assert.equal(parseSmartMetadata(cases[0].metadata, cases[0]).memory_category, "cases");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps SQL list category filtering equivalent to the metadata predicate", async () => {
+    const workDir = mkdtempSync(path.join(tmpdir(), "category-list-"));
+    const store = new MemoryStore({
+      dbPath: path.join(workDir, "db"),
+      vectorDim: VECTOR_DIM,
+    });
+
+    try {
+      const profileText = "Profile: Alice prefers short release notes";
+      const caseText = "Case: postgres outage recovery";
+      await store.store({
+        text: profileText,
+        vector: makeVector(profileText),
+        category: "fact",
+        scope: "global",
+        importance: 0.9,
+        metadata: stringifySmartMetadata(
+          buildSmartMetadata(
+            { text: profileText, category: "fact", importance: 0.9 },
+            { memory_category: "profile", l0_abstract: profileText },
+          ),
+        ),
+      });
+      await store.store({
+        text: caseText,
+        vector: makeVector(caseText),
+        category: "fact",
+        scope: "global",
+        importance: 0.7,
+        metadata: stringifySmartMetadata(
+          buildSmartMetadata(
+            { text: caseText, category: "fact", importance: 0.7 },
+            { memory_category: "cases", l0_abstract: caseText },
+          ),
+        ),
+      });
+
+      const profile = await store.list(["global"], "profile", 10, 0);
+      const cases = await store.list(["global"], "cases", 10, 0);
+
+      assert.deepEqual(profile.map((entry) => entry.text), [profileText]);
+      assert.deepEqual(cases.map((entry) => entry.text), [caseText]);
+      for (const entry of [...profile, ...cases]) {
+        assert.equal(
+          matchesMemoryCategoryFilter(entry.category, parseSmartMetadata(entry.metadata, entry).memory_category, entry.metadata),
+          true,
+        );
+      }
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("normalizes smart categories in manual memory_store writes", async () => {
+    const workDir = mkdtempSync(path.join(tmpdir(), "category-store-tool-"));
+    const store = new MemoryStore({
+      dbPath: path.join(workDir, "db"),
+      vectorDim: VECTOR_DIM,
+    });
+
+    try {
+      const tool = createTool(registerMemoryStoreTool, makeToolContext(store));
+      const result = await tool.execute(null, {
+        text: "Event: attended the 2026 release conference",
+        category: "events",
+        scope: "global",
+        force: true,
+      });
+
+      assert.equal(result.details.category, "events");
+      assert.equal(result.details.rawCategory, "decision");
+
+      const entries = await store.list(["global"], "events", 10, 0);
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].category, "decision");
+      assert.equal(parseSmartMetadata(entries[0].metadata, entries[0]).memory_category, "events");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("normalizes smart categories in manual memory_update writes", async () => {
+    const workDir = mkdtempSync(path.join(tmpdir(), "category-update-tool-"));
+    const store = new MemoryStore({
+      dbPath: path.join(workDir, "db"),
+      vectorDim: VECTOR_DIM,
+    });
+
+    try {
+      const text = "Case: postgres outage recovery";
+      const entry = await store.store({
+        text,
+        vector: makeVector(text),
+        category: "fact",
+        scope: "global",
+        importance: 0.7,
+        metadata: stringifySmartMetadata(
+          buildSmartMetadata(
+            { text, category: "fact", importance: 0.7 },
+            { memory_category: "cases", l0_abstract: text },
+          ),
+        ),
+      });
+
+      const tool = createTool(registerMemoryUpdateTool, makeToolContext(store));
+      const result = await tool.execute(null, {
+        memoryId: entry.id,
+        category: "events",
+      });
+
+      assert.equal(result.details.action, "updated");
+      const updated = await store.getById(entry.id, ["global"]);
+      assert.equal(updated.category, "decision");
+      assert.equal(parseSmartMetadata(updated.metadata, updated).memory_category, "events");
+      assert.deepEqual((await store.list(["global"], "events", 10, 0)).map((e) => e.id), [entry.id]);
+      assert.deepEqual(await store.list(["global"], "cases", 10, 0), []);
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/category-filter-normalization.test.mjs
+++ b/test/category-filter-normalization.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const {
+  matchesMemoryCategoryFilter,
+  normalizeCategory,
+  resolveCategoryFilterCandidates,
+} = jiti("../src/memory-categories.ts");
+const { createRetriever } = jiti("../src/retriever.ts");
+
+function buildResult(id, category) {
+  return {
+    entry: {
+      id,
+      text: `${category} memory about coffee`,
+      vector: [0.1, 0.2, 0.3],
+      category,
+      scope: "global",
+      importance: 0.7,
+      timestamp: Date.now(),
+      metadata: "{}",
+    },
+    score: 0.9,
+  };
+}
+
+describe("category filter normalization", () => {
+  it("maps legacy singular category filters to smart-extractor categories", () => {
+    assert.equal(normalizeCategory("preference"), "preferences");
+    assert.equal(normalizeCategory("entity"), "entities");
+    assert.equal(matchesMemoryCategoryFilter("preferences", "preference"), true);
+    assert.equal(matchesMemoryCategoryFilter("preference", "preferences"), true);
+    assert.equal(matchesMemoryCategoryFilter("other", "preferences"), false);
+    assert.deepEqual(
+      resolveCategoryFilterCandidates("preference"),
+      ["preference", "preferences"],
+    );
+  });
+
+  it("applies normalized category filters during retrieval", async () => {
+    const retriever = createRetriever(
+      {
+        hasFtsSupport: true,
+        async refreshFtsSupport() {
+          return true;
+        },
+        async vectorSearch() {
+          return [];
+        },
+        async bm25Search() {
+          return [
+            buildResult("smart-preference", "preferences"),
+            buildResult("event", "events"),
+          ];
+        },
+        async hasId() {
+          return true;
+        },
+      },
+      {
+        async embedQuery() {
+          return [0.1, 0.2, 0.3];
+        },
+      },
+      { rerank: "none", hardMinScore: 0, filterNoise: false },
+    );
+
+    const results = await retriever.retrieve({
+      query: "coffee",
+      limit: 5,
+      category: "preference",
+      source: "manual",
+    });
+
+    assert.deepEqual(results.map((result) => result.entry.id), ["smart-preference"]);
+  });
+});


### PR DESCRIPTION
## Summary
- expose both smart-extractor and legacy memory categories in tool schemas
- normalize category filters so legacy singular filters match smart category rows
- apply category candidate matching to memory_list and add CI regression coverage

Fixes #873

## Verification
- node --test test/category-filter-normalization.test.mjs
- npm run build
- npm run test:packaging-and-workflow
- npm run test:core-regression