### PR TITLE
docs: add release readiness checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,6 +896,7 @@ openclaw doctor --fix # resolve any stale config after upgrade
 | [OpenClaw Integration Playbook](docs/openclaw-integration-playbook.md) | Deployment modes, verification, regression matrix |
 | [Memory Architecture Analysis](docs/memory_architecture_analysis.md) | Full architecture deep-dive |
 | [CHANGELOG v1.1.0](docs/CHANGELOG-v1.1.0.md) | v1.1.0 behavior changes and upgrade rationale |
+| [Release Checklist](docs/release-checklist.md) | Package preflight, publish dry run, and post-publish smoke checks |
 | [Long-Context Chunking](docs/long-context-chunking.md) | Chunking strategy for long documents |
 
 ---

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,71 @@
+# Release Checklist
+
+Use this checklist before publishing a new `memory-lancedb-pro` package. It is
+intended for the release tracked in #812 and future beta/stable cuts.
+
+## Release Target
+
+- Current package version: `1.1.0-beta.11`
+- Recommended first publish: beta dist-tag
+- Stable channel decision: maintainer-owned after beta smoke testing
+
+The current release driver is that npm users are still behind repository
+`master`: merged fixes are not available from the published `latest` package,
+and the `beta` dist-tag still points at an older beta package.
+
+## Preflight
+
+Run these from a clean checkout:
+
+```bash
+npm ci
+npm run test:packaging-and-workflow
+npm run build
+npm pack --dry-run
+```
+
+Confirm:
+
+- `package.json` and `openclaw.plugin.json` versions match
+- `package.json main` points at `dist/index.js`
+- `package.json openclaw.extensions` points at `./dist/index.js`
+- `package.json files` includes `dist/**/*`
+- `CHANGELOG.md` and `CHANGELOG-v1.1.0.md` start with the package version
+- `npm pack --dry-run` includes compiled `dist` output and excludes test files
+
+## Publish Dry Run
+
+```bash
+npm publish --tag beta --dry-run
+```
+
+Review the file list and package metadata before publishing.
+
+## Publish
+
+```bash
+npm publish --tag beta
+```
+
+After publish, verify the public registry state:
+
+```bash
+npm view memory-lancedb-pro dist-tags version versions --json
+npm view memory-lancedb-pro@beta version main openclaw files --json
+```
+
+The `beta` dist-tag should point at the newly published version, and the package
+runtime entries should point at compiled JavaScript under `dist/`.
+
+## Post-Publish Smoke
+
+On a machine with a current OpenClaw install:
+
+```bash
+openclaw plugins registry --refresh
+openclaw plugins install memory-lancedb-pro@beta
+openclaw plugins doctor
+```
+
+Confirm OpenClaw installs the package without falling back to TypeScript source
+entrypoints.

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -34,6 +34,7 @@ export const CI_TEST_MANIFEST = [
   { group: "core-regression", runner: "node", file: "test/corpus-indexer.test.mjs" },
   { group: "packaging-and-workflow", runner: "node", file: "test/plugin-manifest-regression.mjs" },
   { group: "packaging-and-workflow", runner: "node", file: "test/package-runtime.test.mjs" },
+  { group: "packaging-and-workflow", runner: "node", file: "test/release-readiness.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/session-summary-before-reset.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/self-improvement-reset-note.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/self-improvement.test.mjs", args: ["--test"] },

--- a/test/release-readiness.test.mjs
+++ b/test/release-readiness.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { CI_TEST_MANIFEST } from "../scripts/ci-test-manifest.mjs";
+
+function readText(path) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+}
+
+function readJson(path) {
+  return JSON.parse(readText(path));
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const pkg = readJson("package.json");
+const manifest = readJson("openclaw.plugin.json");
+const releaseChecklist = readText("docs/release-checklist.md");
+
+assert.equal(pkg.version, manifest.version, "package and plugin manifest versions must match before release");
+assert.match(pkg.version, /^1\.1\.0-beta\.\d+$/, "current release target should remain an explicit v1.1.0 beta");
+
+for (const changelogPath of ["CHANGELOG.md", "CHANGELOG-v1.1.0.md"]) {
+  const changelog = readText(changelogPath);
+  assert.match(
+    changelog,
+    new RegExp(`^## ${escapeRegExp(pkg.version)}\\b`),
+    `${changelogPath} should start with the package version`,
+  );
+}
+
+assert.equal(pkg.main, "dist/index.js");
+assert.deepEqual(pkg.openclaw?.extensions, ["./dist/index.js"]);
+assert.ok(pkg.files?.includes("dist/**/*"), "published files should include compiled dist output");
+assert.ok(pkg.files?.includes("docs/**/*.md"), "release checklist should be included in package docs");
+
+assert.match(releaseChecklist, /npm run test:packaging-and-workflow/);
+assert.match(releaseChecklist, /npm pack --dry-run/);
+assert.match(releaseChecklist, /npm publish --tag beta --dry-run/);
+assert.match(releaseChecklist, /npm view memory-lancedb-pro@beta version main openclaw files --json/);
+
+assert.ok(
+  CI_TEST_MANIFEST.some((entry) => entry.file === "test/release-readiness.test.mjs"),
+  "release readiness test should run in CI packaging workflow",
+);


### PR DESCRIPTION
## Summary
- add a release checklist for beta/stable package preflight and post-publish smoke checks
- add CI-backed release readiness checks for changelog/package/runtime alignment
- link the checklist from README docs

Refs #812

## Verification
- node test/release-readiness.test.mjs
- npm run test:packaging-and-workflow
- npm pack --dry-run