### PR TITLE
fix: fail soft for read-only recall scopes

### DIFF
--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -159,17 +159,22 @@ function resolveReadableToolScopeFilter(scopeManager, agentId, scope) {
         if (scopeManager.isAccessible(scope, agentId)) {
             return { scopeFilter: [scope] };
         }
+        const accessibleScopes = scopeManager.getAccessibleScopes(agentId);
         return {
-            error: {
-                content: [{ type: "text", text: `Access denied to scope: ${scope}` }],
-                details: {
-                    error: "scope_access_denied",
-                    requestedScope: scope,
-                },
-            },
+            scopeFilter: resolveScopeFilter(scopeManager, agentId),
+            ignoredScope: scope,
+            accessibleScopes,
         };
     }
     return { scopeFilter: resolveScopeFilter(scopeManager, agentId) };
+}
+function formatIgnoredScopeNotice(resolvedScopes) {
+    if (!resolvedScopes.ignoredScope)
+        return undefined;
+    const scopes = resolvedScopes.accessibleScopes?.length
+        ? resolvedScopes.accessibleScopes.join(", ")
+        : "(none)";
+    return `Ignored inaccessible scope "${resolvedScopes.ignoredScope}" and searched accessible scopes instead: ${scopes}.`;
 }
 async function resolveMemoryId(context, memoryRef, scopeFilter) {
     const trimmed = memoryRef.trim();
@@ -494,24 +499,9 @@ function createMemoryRecallTool(runtimeContext, options) {
                     : clampInt(limit, 1, 6);
                 const safeCharsPerItem = clampInt(maxCharsPerItem, 60, 1000);
                 const agentId = runtimeContext.agentId;
-                // Determine accessible scopes
-                let scopeFilter = resolveScopeFilter(runtimeContext.scopeManager, agentId);
-                if (scope) {
-                    if (runtimeContext.scopeManager.isAccessible(scope, agentId)) {
-                        scopeFilter = [scope];
-                    }
-                    else {
-                        return {
-                            content: [
-                                { type: "text", text: `Access denied to scope: ${scope}` },
-                            ],
-                            details: {
-                                error: "scope_access_denied",
-                                requestedScope: scope,
-                            },
-                        };
-                    }
-                }
+                const resolvedScopes = resolveReadableToolScopeFilter(runtimeContext.scopeManager, agentId, scope);
+                const { scopeFilter } = resolvedScopes;
+                const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
                 const results = filterUserMdExclusiveRecallResults(await retrieveWithRetry(runtimeContext.retriever, {
                     query,
                     limit: safeLimit,
@@ -521,8 +511,14 @@ function createMemoryRecallTool(runtimeContext, options) {
                 }, () => runtimeContext.store.count()), runtimeContext.workspaceBoundary);
                 if (results.length === 0) {
                     return {
-                        content: [{ type: "text", text: "No relevant memories found." }],
-                        details: { count: 0, query, scopes: scopeFilter },
+                        content: [{ type: "text", text: [ignoredScopeNotice, "No relevant memories found."].filter(Boolean).join("\n") }],
+                        details: {
+                            count: 0,
+                            query,
+                            scopes: scopeFilter,
+                            ignoredScope: resolvedScopes.ignoredScope,
+                            accessibleScopes: resolvedScopes.accessibleScopes,
+                        },
                     };
                 }
                 const now = Date.now();
@@ -568,7 +564,10 @@ function createMemoryRecallTool(runtimeContext, options) {
                     content: [
                         {
                             type: "text",
-                            text: `<relevant-memories>\n<mode:${includeFullText ? "full" : "summary"}>\nFound ${results.length} memories:\n\n${text}\n</relevant-memories>`,
+                            text: [
+                                ignoredScopeNotice,
+                                `<relevant-memories>\n<mode:${includeFullText ? "full" : "summary"}>\nFound ${results.length} memories:\n\n${text}\n</relevant-memories>`,
+                            ].filter(Boolean).join("\n"),
                         },
                     ],
                     details: {
@@ -576,6 +575,8 @@ function createMemoryRecallTool(runtimeContext, options) {
                         memories: serializedMemories,
                         query,
                         scopes: scopeFilter,
+                        ignoredScope: resolvedScopes.ignoredScope,
+                        accessibleScopes: resolvedScopes.accessibleScopes,
                         retrievalMode: runtimeContext.retriever.getConfig().mode,
                         recallMode: includeFullText ? "full" : "summary",
                     },
@@ -1301,9 +1302,8 @@ export function registerMemoryStatsTool(api, context) {
                 try {
                     const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
                     const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
-                    if ("error" in resolvedScopes)
-                        return resolvedScopes.error;
                     const { scopeFilter } = resolvedScopes;
+                    const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
                     const stats = await context.store.stats(scopeFilter);
                     const scopeManagerStats = context.scopeManager.getStats();
                     const retrievalConfig = context.retriever.getConfig();
@@ -1333,13 +1333,15 @@ export function registerMemoryStatsTool(api, context) {
                             }
                         }
                     }
-                    const text = textLines.join("\n");
+                    const text = [ignoredScopeNotice, textLines.join("\n")].filter(Boolean).join("\n");
                     return {
                         content: [{ type: "text", text }],
                         details: {
                             stats,
                             scopeManagerStats,
                             scopes: scopeFilter,
+                            ignoredScope: resolvedScopes.ignoredScope,
+                            accessibleScopes: resolvedScopes.accessibleScopes,
                             retrievalConfig: {
                                 ...retrievalConfig,
                                 rerankApiKey: retrievalConfig.rerankApiKey ? "***" : undefined,
@@ -1380,22 +1382,14 @@ export function registerMemoryDebugTool(api, context) {
                 const { query, limit = 5, scope } = params;
                 try {
                     const safeLimit = clampInt(limit, 1, 20);
-                    let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
-                    if (scope) {
-                        if (context.scopeManager.isAccessible(scope, agentId)) {
-                            scopeFilter = [scope];
-                        }
-                        else {
-                            return {
-                                content: [{ type: "text", text: `Access denied to scope: ${scope}` }],
-                                details: { error: "scope_access_denied", requestedScope: scope },
-                            };
-                        }
-                    }
+                    const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
+                    const { scopeFilter } = resolvedScopes;
+                    const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
                     const { results, trace } = await context.retriever.retrieveWithTrace({
                         query, limit: safeLimit, scopeFilter, source: "manual",
                     });
                     const traceLines = [
+                        ...(ignoredScopeNotice ? [ignoredScopeNotice, ""] : []),
                         `Retrieval Debug Trace:`,
                         `  Mode: ${trace.mode}`,
                         `  Total: ${trace.totalMs}ms`,
@@ -1422,7 +1416,13 @@ export function registerMemoryDebugTool(api, context) {
                         traceLines.push(``, `No results survived the pipeline.`);
                         return {
                             content: [{ type: "text", text: traceLines.join("\n") }],
-                            details: { count: 0, query, trace },
+                            details: {
+                                count: 0,
+                                query,
+                                trace,
+                                ignoredScope: resolvedScopes.ignoredScope,
+                                accessibleScopes: resolvedScopes.accessibleScopes,
+                            },
                         };
                     }
                     const resultLines = results.map((r, i) => {
@@ -1444,6 +1444,8 @@ export function registerMemoryDebugTool(api, context) {
                             memories: sanitizeMemoryForSerialization(results),
                             query,
                             trace,
+                            ignoredScope: resolvedScopes.ignoredScope,
+                            accessibleScopes: resolvedScopes.accessibleScopes,
                         },
                     };
                 }
@@ -1484,18 +1486,19 @@ export function registerMemoryListTool(api, context) {
                     const safeOffset = clampInt(offset, 0, 1000);
                     const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
                     const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
-                    if ("error" in resolvedScopes)
-                        return resolvedScopes.error;
                     const { scopeFilter } = resolvedScopes;
+                    const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
                     const entries = await context.store.list(scopeFilter, category, safeLimit, safeOffset);
                     if (entries.length === 0) {
                         return {
-                            content: [{ type: "text", text: "No memories found." }],
+                            content: [{ type: "text", text: [ignoredScopeNotice, "No memories found."].filter(Boolean).join("\n") }],
                             details: {
                                 count: 0,
                                 filters: {
                                     scope,
                                     scopes: scopeFilter,
+                                    ignoredScope: resolvedScopes.ignoredScope,
+                                    accessibleScopes: resolvedScopes.accessibleScopes,
                                     category,
                                     limit: safeLimit,
                                     offset: safeOffset,
@@ -1516,7 +1519,7 @@ export function registerMemoryListTool(api, context) {
                         content: [
                             {
                                 type: "text",
-                                text: `Recent memories (showing ${entries.length}):\n\n${text}`,
+                                text: [ignoredScopeNotice, `Recent memories (showing ${entries.length}):\n\n${text}`].filter(Boolean).join("\n"),
                             },
                         ],
                         details: {
@@ -1533,6 +1536,8 @@ export function registerMemoryListTool(api, context) {
                             filters: {
                                 scope,
                                 scopes: scopeFilter,
+                                ignoredScope: resolvedScopes.ignoredScope,
+                                accessibleScopes: resolvedScopes.accessibleScopes,
                                 category,
                                 limit: safeLimit,
                                 offset: safeOffset,
@@ -1972,16 +1977,9 @@ export function registerMemoryExplainRankTool(api, context) {
                 const { query, limit = 5, scope } = params;
                 const safeLimit = clampInt(limit, 1, 20);
                 const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
-                let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
-                if (scope) {
-                    if (!context.scopeManager.isAccessible(scope, agentId)) {
-                        return {
-                            content: [{ type: "text", text: `Access denied to scope: ${scope}` }],
-                            details: { error: "scope_access_denied", requestedScope: scope },
-                        };
-                    }
-                    scopeFilter = [scope];
-                }
+                const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
+                const { scopeFilter } = resolvedScopes;
+                const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
                 const results = await retrieveWithRetry(runtimeContext.retriever, {
                     query,
                     limit: safeLimit,
@@ -1990,8 +1988,14 @@ export function registerMemoryExplainRankTool(api, context) {
                 }, () => runtimeContext.store.count());
                 if (results.length === 0) {
                     return {
-                        content: [{ type: "text", text: "No relevant memories found." }],
-                        details: { action: "empty", query, scopeFilter },
+                        content: [{ type: "text", text: [ignoredScopeNotice, "No relevant memories found."].filter(Boolean).join("\n") }],
+                        details: {
+                            action: "empty",
+                            query,
+                            scopeFilter,
+                            ignoredScope: resolvedScopes.ignoredScope,
+                            accessibleScopes: resolvedScopes.accessibleScopes,
+                        },
                     };
                 }
                 const lines = results.map((r, idx) => {
@@ -2011,11 +2015,13 @@ export function registerMemoryExplainRankTool(api, context) {
                     ].join("\n");
                 });
                 return {
-                    content: [{ type: "text", text: lines.join("\n") }],
+                    content: [{ type: "text", text: [ignoredScopeNotice, lines.join("\n")].filter(Boolean).join("\n") }],
                     details: {
                         action: "explain_rank",
                         query,
                         count: results.length,
+                        ignoredScope: resolvedScopes.ignoredScope,
+                        accessibleScopes: resolvedScopes.accessibleScopes,
                         results: sanitizeMemoryForSerialization(results),
                     },
                 };

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -31,6 +31,7 @@ export const CI_TEST_MANIFEST = [
   { group: "core-regression", runner: "node", file: "test/smart-extractor-branches.mjs" },
   { group: "core-regression", runner: "node", file: "test/smart-extractor-batch-embed.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/memory-capability-runtime.test.mjs" },
+  { group: "core-regression", runner: "node", file: "test/memory-governance-tools.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/corpus-indexer.test.mjs" },
   { group: "packaging-and-workflow", runner: "node", file: "test/plugin-manifest-regression.mjs" },
   { group: "packaging-and-workflow", runner: "node", file: "test/package-runtime.test.mjs" },

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -233,28 +233,35 @@ function resolveReadableToolScopeFilter(
   scopeManager: MemoryScopeManager,
   agentId: string | undefined,
   scope?: string,
-): { scopeFilter: string[] | undefined } | {
-  error: {
-    content: Array<{ type: "text"; text: string }>;
-    details: { error: "scope_access_denied"; requestedScope: string };
-  };
+): {
+  scopeFilter: string[] | undefined;
+  ignoredScope?: string;
+  accessibleScopes?: string[];
 } {
   if (scope) {
     if (scopeManager.isAccessible(scope, agentId)) {
       return { scopeFilter: [scope] };
     }
+    const accessibleScopes = scopeManager.getAccessibleScopes(agentId);
     return {
-      error: {
-        content: [{ type: "text", text: `Access denied to scope: ${scope}` }],
-        details: {
-          error: "scope_access_denied",
-          requestedScope: scope,
-        },
-      },
+      scopeFilter: resolveScopeFilter(scopeManager, agentId),
+      ignoredScope: scope,
+      accessibleScopes,
     };
   }
 
   return { scopeFilter: resolveScopeFilter(scopeManager, agentId) };
+}
+
+function formatIgnoredScopeNotice(resolvedScopes: {
+  ignoredScope?: string;
+  accessibleScopes?: string[];
+}): string | undefined {
+  if (!resolvedScopes.ignoredScope) return undefined;
+  const scopes = resolvedScopes.accessibleScopes?.length
+    ? resolvedScopes.accessibleScopes.join(", ")
+    : "(none)";
+  return `Ignored inaccessible scope "${resolvedScopes.ignoredScope}" and searched accessible scopes instead: ${scopes}.`;
 }
 
 async function resolveMemoryId(
@@ -666,23 +673,13 @@ function createMemoryRecallTool(
           const safeCharsPerItem = clampInt(maxCharsPerItem, 60, 1000);
           const agentId = runtimeContext.agentId;
 
-          // Determine accessible scopes
-          let scopeFilter = resolveScopeFilter(runtimeContext.scopeManager, agentId);
-          if (scope) {
-            if (runtimeContext.scopeManager.isAccessible(scope, agentId)) {
-              scopeFilter = [scope];
-            } else {
-              return {
-                content: [
-                  { type: "text", text: `Access denied to scope: ${scope}` },
-                ],
-                details: {
-                  error: "scope_access_denied",
-                  requestedScope: scope,
-                },
-              };
-            }
-          }
+          const resolvedScopes = resolveReadableToolScopeFilter(
+            runtimeContext.scopeManager,
+            agentId,
+            scope,
+          );
+          const { scopeFilter } = resolvedScopes;
+          const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
 
           const results = filterUserMdExclusiveRecallResults(await retrieveWithRetry(runtimeContext.retriever, {
             query,
@@ -694,8 +691,14 @@ function createMemoryRecallTool(
 
           if (results.length === 0) {
             return {
-              content: [{ type: "text", text: "No relevant memories found." }],
-              details: { count: 0, query, scopes: scopeFilter },
+              content: [{ type: "text", text: [ignoredScopeNotice, "No relevant memories found."].filter(Boolean).join("\n") }],
+              details: {
+                count: 0,
+                query,
+                scopes: scopeFilter,
+                ignoredScope: resolvedScopes.ignoredScope,
+                accessibleScopes: resolvedScopes.accessibleScopes,
+              },
             };
           }
 
@@ -751,7 +754,10 @@ function createMemoryRecallTool(
             content: [
               {
                 type: "text",
-                text: `<relevant-memories>\n<mode:${includeFullText ? "full" : "summary"}>\nFound ${results.length} memories:\n\n${text}\n</relevant-memories>`,
+                text: [
+                  ignoredScopeNotice,
+                  `<relevant-memories>\n<mode:${includeFullText ? "full" : "summary"}>\nFound ${results.length} memories:\n\n${text}\n</relevant-memories>`,
+                ].filter(Boolean).join("\n"),
               },
             ],
             details: {
@@ -759,6 +765,8 @@ function createMemoryRecallTool(
               memories: serializedMemories,
               query,
               scopes: scopeFilter,
+              ignoredScope: resolvedScopes.ignoredScope,
+              accessibleScopes: resolvedScopes.accessibleScopes,
               retrievalMode: runtimeContext.retriever.getConfig().mode,
               recallMode: includeFullText ? "full" : "summary",
             },
@@ -1656,8 +1664,8 @@ export function registerMemoryStatsTool(
         try {
           const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
           const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
-          if ("error" in resolvedScopes) return resolvedScopes.error;
           const { scopeFilter } = resolvedScopes;
+          const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
 
           const stats = await context.store.stats(scopeFilter);
           const scopeManagerStats = context.scopeManager.getStats();
@@ -1704,7 +1712,7 @@ export function registerMemoryStatsTool(
             }
           }
 
-          const text = textLines.join("\n");
+          const text = [ignoredScopeNotice, textLines.join("\n")].filter(Boolean).join("\n");
 
           return {
             content: [{ type: "text", text }],
@@ -1712,6 +1720,8 @@ export function registerMemoryStatsTool(
               stats,
               scopeManagerStats,
               scopes: scopeFilter,
+              ignoredScope: resolvedScopes.ignoredScope,
+              accessibleScopes: resolvedScopes.accessibleScopes,
               retrievalConfig: {
                 ...retrievalConfig,
                 rerankApiKey: retrievalConfig.rerankApiKey ? "***" : undefined,
@@ -1765,23 +1775,16 @@ export function registerMemoryDebugTool(
           };
           try {
             const safeLimit = clampInt(limit, 1, 20);
-            let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
-            if (scope) {
-              if (context.scopeManager.isAccessible(scope, agentId)) {
-                scopeFilter = [scope];
-              } else {
-                return {
-                  content: [{ type: "text", text: `Access denied to scope: ${scope}` }],
-                  details: { error: "scope_access_denied", requestedScope: scope },
-                };
-              }
-            }
+            const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
+            const { scopeFilter } = resolvedScopes;
+            const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
 
             const { results, trace } = await context.retriever.retrieveWithTrace({
               query, limit: safeLimit, scopeFilter, source: "manual",
             });
 
             const traceLines: string[] = [
+              ...(ignoredScopeNotice ? [ignoredScopeNotice, ""] : []),
               `Retrieval Debug Trace:`,
               `  Mode: ${trace.mode}`,
               `  Total: ${trace.totalMs}ms`,
@@ -1812,7 +1815,13 @@ export function registerMemoryDebugTool(
               traceLines.push(``, `No results survived the pipeline.`);
               return {
                 content: [{ type: "text", text: traceLines.join("\n") }],
-                details: { count: 0, query, trace },
+                details: {
+                  count: 0,
+                  query,
+                  trace,
+                  ignoredScope: resolvedScopes.ignoredScope,
+                  accessibleScopes: resolvedScopes.accessibleScopes,
+                },
               };
             }
 
@@ -1833,6 +1842,8 @@ export function registerMemoryDebugTool(
                 memories: sanitizeMemoryForSerialization(results),
                 query,
                 trace,
+                ignoredScope: resolvedScopes.ignoredScope,
+                accessibleScopes: resolvedScopes.accessibleScopes,
               },
             };
           } catch (error) {
@@ -1898,8 +1909,8 @@ export function registerMemoryListTool(
           const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
 
           const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
-          if ("error" in resolvedScopes) return resolvedScopes.error;
           const { scopeFilter } = resolvedScopes;
+          const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
 
           const entries = await context.store.list(
             scopeFilter,
@@ -1910,12 +1921,14 @@ export function registerMemoryListTool(
 
           if (entries.length === 0) {
             return {
-              content: [{ type: "text", text: "No memories found." }],
+              content: [{ type: "text", text: [ignoredScopeNotice, "No memories found."].filter(Boolean).join("\n") }],
               details: {
                 count: 0,
                 filters: {
                   scope,
                   scopes: scopeFilter,
+                  ignoredScope: resolvedScopes.ignoredScope,
+                  accessibleScopes: resolvedScopes.accessibleScopes,
                   category,
                   limit: safeLimit,
                   offset: safeOffset,
@@ -1938,7 +1951,7 @@ export function registerMemoryListTool(
             content: [
               {
                 type: "text",
-                text: `Recent memories (showing ${entries.length}):\n\n${text}`,
+                text: [ignoredScopeNotice, `Recent memories (showing ${entries.length}):\n\n${text}`].filter(Boolean).join("\n"),
               },
             ],
             details: {
@@ -1955,6 +1968,8 @@ export function registerMemoryListTool(
               filters: {
                 scope,
                 scopes: scopeFilter,
+                ignoredScope: resolvedScopes.ignoredScope,
+                accessibleScopes: resolvedScopes.accessibleScopes,
                 category,
                 limit: safeLimit,
                 offset: safeOffset,
@@ -2516,16 +2531,9 @@ export function registerMemoryExplainRankTool(
 
           const safeLimit = clampInt(limit, 1, 20);
           const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
-          let scopeFilter = resolveScopeFilter(context.scopeManager, agentId);
-          if (scope) {
-            if (!context.scopeManager.isAccessible(scope, agentId)) {
-              return {
-                content: [{ type: "text", text: `Access denied to scope: ${scope}` }],
-                details: { error: "scope_access_denied", requestedScope: scope },
-              };
-            }
-            scopeFilter = [scope];
-          }
+          const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
+          const { scopeFilter } = resolvedScopes;
+          const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
 
           const results = await retrieveWithRetry(runtimeContext.retriever, {
             query,
@@ -2535,8 +2543,14 @@ export function registerMemoryExplainRankTool(
           }, () => runtimeContext.store.count());
           if (results.length === 0) {
             return {
-              content: [{ type: "text", text: "No relevant memories found." }],
-              details: { action: "empty", query, scopeFilter },
+              content: [{ type: "text", text: [ignoredScopeNotice, "No relevant memories found."].filter(Boolean).join("\n") }],
+              details: {
+                action: "empty",
+                query,
+                scopeFilter,
+                ignoredScope: resolvedScopes.ignoredScope,
+                accessibleScopes: resolvedScopes.accessibleScopes,
+              },
             };
           }
 
@@ -2555,11 +2569,13 @@ export function registerMemoryExplainRankTool(
           });
 
           return {
-            content: [{ type: "text", text: lines.join("\n") }],
+            content: [{ type: "text", text: [ignoredScopeNotice, lines.join("\n")].filter(Boolean).join("\n") }],
             details: {
               action: "explain_rank",
               query,
               count: results.length,
+              ignoredScope: resolvedScopes.ignoredScope,
+              accessibleScopes: resolvedScopes.accessibleScopes,
               results: sanitizeMemoryForSerialization(results),
             },
           };

--- a/test/memory-governance-tools.test.mjs
+++ b/test/memory-governance-tools.test.mjs
@@ -24,6 +24,101 @@ function createToolSet(context) {
 }
 
 describe("memory governance tools", () => {
+  it("fails soft for inaccessible read-only recall scopes", async () => {
+    const recallScopeFilters = [];
+    const patchCalls = [];
+    const context = {
+      agentId: "main",
+      workspaceDir: "/tmp",
+      mdMirror: null,
+      scopeManager: {
+        getAccessibleScopes: (agentId) => ["global", `agent:${agentId}`, `reflection:agent:${agentId}`],
+        getScopeFilter: (agentId) => ["global", `agent:${agentId}`, `reflection:agent:${agentId}`],
+        isAccessible: (scope, agentId) => ["global", `agent:${agentId}`, `reflection:agent:${agentId}`].includes(scope),
+        getDefaultScope: (agentId) => `agent:${agentId}`,
+      },
+      retriever: {
+        async retrieve({ scopeFilter }) {
+          recallScopeFilters.push(scopeFilter);
+          return [{
+            entry: {
+              id: "recall-memory-1",
+              text: "coffee preference",
+              category: "preference",
+              scope: "agent:main",
+              importance: 0.7,
+              timestamp: Date.now(),
+              metadata: "{}",
+            },
+            score: 0.91,
+            sources: { vector: { score: 0.91, rank: 1 } },
+          }];
+        },
+        getConfig() {
+          return { mode: "hybrid" };
+        },
+      },
+      store: {
+        async count() {
+          return 1;
+        },
+        async patchMetadata(id, patch, scopeFilter) {
+          patchCalls.push({ id, patch, scopeFilter });
+          return null;
+        },
+      },
+      embedder: { async embedPassage() { return [0.1, 0.2, 0.3]; } },
+    };
+
+    const tools = createToolSet(context);
+    const recall = tools.get("memory_recall");
+
+    const res = await recall.execute(null, {
+      query: "coffee",
+      scope: "current_conversation",
+    });
+
+    const expectedScopes = ["global", "agent:main", "reflection:agent:main"];
+    assert.deepEqual(recallScopeFilters[0], expectedScopes);
+    assert.match(res.content[0].text, /Ignored inaccessible scope "current_conversation"/);
+    assert.equal(res.details.ignoredScope, "current_conversation");
+    assert.deepEqual(res.details.accessibleScopes, expectedScopes);
+    assert.equal(res.details.count, 1);
+    assert.deepEqual(patchCalls[0].scopeFilter, expectedScopes);
+  });
+
+  it("keeps inaccessible write scopes hard-denied", async () => {
+    const context = {
+      agentId: "main",
+      workspaceDir: "/tmp",
+      mdMirror: null,
+      scopeManager: {
+        getAccessibleScopes: (agentId) => ["global", `agent:${agentId}`],
+        getScopeFilter: (agentId) => ["global", `agent:${agentId}`],
+        isAccessible: (scope, agentId) => ["global", `agent:${agentId}`].includes(scope),
+        getDefaultScope: (agentId) => `agent:${agentId}`,
+      },
+      retriever: {
+        getConfig() {
+          return { mode: "hybrid" };
+        },
+      },
+      store: {},
+      embedder: { async embedPassage() { return [0.1, 0.2, 0.3]; } },
+    };
+
+    const tools = createToolSet(context);
+    const store = tools.get("memory_store");
+
+    const res = await store.execute(null, {
+      text: "remember this",
+      scope: "current_conversation",
+    });
+
+    assert.equal(res.details.error, "scope_access_denied");
+    assert.equal(res.details.requestedScope, "current_conversation");
+  });
+
   it("defaults stats and list to the caller's accessible scopes", async () => {
     const statsScopeFilters = [];
     const listScopeFilters = [];


### PR DESCRIPTION
## Summary
- make read-only memory tools ignore inaccessible scope filters and search accessible scopes instead
- include ignored scope and accessible scopes in text/details so tool callers can retry correctly
- keep write/delete/mutation tools hard-denied for inaccessible scopes

Fixes #874

## Verification
- node --test test/memory-governance-tools.test.mjs
- npm run build
- npm run test:packaging-and-workflow
- npm run test:core-regression