### PR TITLE
feat: add optional Redis write lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,10 +689,12 @@ OAuth login flow:
 enough for one gateway process, multiple agents through that gateway, and local
 processes that share the same database directory.
 
-Redis is not required for those deployments, and the current plugin does not
-automatically enable Redis locking. For multi-machine or multi-container
-writers, read [Lock Management](docs/lock-management.md) before sharing a
-LanceDB directory across processes.
+Redis is not required for those deployments. Redis locking is enabled when
+`locking.redis.enabled` is true, when `redisUrl`/`locking.redis.url` is set, or
+when `MEMORY_LANCEDB_REDIS_URL` is present in that process environment. For
+multi-machine or multi-container writers, read
+[Lock Management](docs/lock-management.md) before sharing a LanceDB directory
+across processes, and make sure every writer uses the same lock configuration.
 
 </details>
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -139,6 +139,10 @@ function resolveFirstApiKey(api, apiKey) {
     }
     return resolveSecretCredential(api, key, "embedding.apiKey");
 }
+function resolveOptionalEnvString(value) {
+    const raw = asNonEmptyString(value);
+    return raw ? resolveEnvVars(raw) : undefined;
+}
 function resolveOptionalPathWithEnv(api, value, fallback) {
     const raw = typeof value === "string" && value.trim().length > 0 ? value.trim() : fallback;
     return api.resolvePath(resolveEnvVars(raw));
@@ -1662,7 +1666,9 @@ function _initPluginState(api) {
         dbPath: resolvedDbPath,
         vectorDim,
         disableNativeCosine: config.retrieval?.disableNativeCosine === true,
+        redisLock: config.locking?.redis,
         onStoragePathWarning: (message) => api.logger.warn(message),
+        onLockWarning: (message) => api.logger.warn(message),
     });
     const embedder = createEmbedder({
         provider: "openai-compatible",
@@ -4220,6 +4226,18 @@ export function parsePluginConfig(value) {
     const storageAutoCleanupRaw = typeof storageMaintenanceRaw?.autoCleanup === "object" && storageMaintenanceRaw.autoCleanup !== null
         ? storageMaintenanceRaw.autoCleanup
         : null;
+    const lockingRaw = typeof cfg.locking === "object" && cfg.locking !== null
+        ? cfg.locking
+        : null;
+    const redisLockRaw = typeof lockingRaw?.redis === "object" && lockingRaw.redis !== null
+        ? lockingRaw.redis
+        : null;
+    const redisLockUrl = resolveOptionalEnvString(redisLockRaw?.url) ??
+        resolveOptionalEnvString(cfg.redisUrl) ??
+        asNonEmptyString(process.env.MEMORY_LANCEDB_REDIS_URL);
+    const redisLockExplicitlyDisabled = redisLockRaw?.enabled === false;
+    const redisLockEnabled = !redisLockExplicitlyDisabled &&
+        (redisLockRaw?.enabled === true || Boolean(redisLockUrl));
     const userMdExclusiveRaw = typeof workspaceBoundaryRaw?.userMdExclusive === "object" && workspaceBoundaryRaw.userMdExclusive !== null
         ? workspaceBoundaryRaw.userMdExclusive
         : null;
@@ -4280,6 +4298,20 @@ export function parsePluginConfig(value) {
                     intervalHours: parsePositiveInt(storageAutoCleanupRaw.intervalHours) ?? 24,
                     retentionDays: parsePositiveInt(storageAutoCleanupRaw.retentionDays) ?? 7,
                     initialDelayMs: parseNonNegativeInt(storageAutoCleanupRaw.initialDelayMs) ?? 300_000,
+                },
+            }
+            : undefined,
+        redisUrl: resolveOptionalEnvString(cfg.redisUrl),
+        locking: redisLockRaw || redisLockUrl
+            ? {
+                redis: {
+                    enabled: redisLockEnabled,
+                    url: redisLockUrl,
+                    keyPrefix: asNonEmptyString(redisLockRaw?.keyPrefix),
+                    ttlMs: parsePositiveInt(redisLockRaw?.ttlMs) ?? 60_000,
+                    acquireTimeoutMs: parsePositiveInt(redisLockRaw?.acquireTimeoutMs) ?? 5_000,
+                    retryDelayMs: parsePositiveInt(redisLockRaw?.retryDelayMs) ?? 50,
+                    connectTimeoutMs: parsePositiveInt(redisLockRaw?.connectTimeoutMs) ?? 1_000,
                 },
             }
             : undefined,

--- a/dist/index.js
+++ b/dist/index.js
@@ -4155,6 +4155,12 @@ const memoryLanceDBProPlugin = {
                     clearInterval(storageMaintenanceTimer);
                     storageMaintenanceTimer = null;
                 }
+                try {
+                    await store.destroy();
+                }
+                catch (err) {
+                    api.logger.warn(`memory-lancedb-pro: stop cleanup failed: ${String(err)}`);
+                }
                 api.logger.info("memory-lancedb-pro: stopped");
             },
         });

--- a/dist/index.js
+++ b/dist/index.js
@@ -4161,6 +4161,13 @@ const memoryLanceDBProPlugin = {
                 catch (err) {
                     api.logger.warn(`memory-lancedb-pro: stop cleanup failed: ${String(err)}`);
                 }
+                finally {
+                    if (_singletonState?.store === store) {
+                        _singletonState = null;
+                    }
+                    _registeredApis.delete(api);
+                    _registeredApisMap.delete(api);
+                }
                 api.logger.info("memory-lancedb-pro: stopped");
             },
         });
@@ -4238,10 +4245,15 @@ export function parsePluginConfig(value) {
     const redisLockRaw = typeof lockingRaw?.redis === "object" && lockingRaw.redis !== null
         ? lockingRaw.redis
         : null;
-    const redisLockUrl = resolveOptionalEnvString(redisLockRaw?.url) ??
-        resolveOptionalEnvString(cfg.redisUrl) ??
-        asNonEmptyString(process.env.MEMORY_LANCEDB_REDIS_URL);
     const redisLockExplicitlyDisabled = redisLockRaw?.enabled === false;
+    const legacyRedisUrl = redisLockExplicitlyDisabled
+        ? undefined
+        : resolveOptionalEnvString(cfg.redisUrl);
+    const redisLockUrl = redisLockExplicitlyDisabled
+        ? undefined
+        : (resolveOptionalEnvString(redisLockRaw?.url) ??
+            legacyRedisUrl ??
+            asNonEmptyString(process.env.MEMORY_LANCEDB_REDIS_URL));
     const redisLockEnabled = !redisLockExplicitlyDisabled &&
         (redisLockRaw?.enabled === true || Boolean(redisLockUrl));
     const userMdExclusiveRaw = typeof workspaceBoundaryRaw?.userMdExclusive === "object" && workspaceBoundaryRaw.userMdExclusive !== null
@@ -4307,7 +4319,7 @@ export function parsePluginConfig(value) {
                 },
             }
             : undefined,
-        redisUrl: resolveOptionalEnvString(cfg.redisUrl),
+        redisUrl: legacyRedisUrl,
         locking: redisLockRaw || redisLockUrl
             ? {
                 redis: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1907,6 +1907,7 @@ const memoryLanceDBProPlugin = {
         // ========================================================================
         _registeredApis.add(api); // claim before init (Phase 2 singleton guard)
         _registeredApisMap.set(api, true); // dual-track: explicit claim for rollback
+        let registrationStopped = false;
         let singleton;
         try {
             if (!_singletonState) {
@@ -4143,6 +4144,12 @@ const memoryLanceDBProPlugin = {
                 }
             },
             stop: async () => {
+                if (registrationStopped) {
+                    return;
+                }
+                registrationStopped = true;
+                _registeredApis.delete(api);
+                _registeredApisMap.delete(api);
                 if (backupTimer) {
                     clearInterval(backupTimer);
                     backupTimer = null;
@@ -4155,18 +4162,18 @@ const memoryLanceDBProPlugin = {
                     clearInterval(storageMaintenanceTimer);
                     storageMaintenanceTimer = null;
                 }
-                try {
-                    await store.destroy();
-                }
-                catch (err) {
-                    api.logger.warn(`memory-lancedb-pro: stop cleanup failed: ${String(err)}`);
-                }
-                finally {
-                    if (_singletonState?.store === store) {
-                        _singletonState = null;
+                if (_registeredApisMap.size === 0 && _singletonState?.store === store) {
+                    try {
+                        await store.destroy();
                     }
-                    _registeredApis.delete(api);
-                    _registeredApisMap.delete(api);
+                    catch (err) {
+                        api.logger.warn(`memory-lancedb-pro: stop cleanup failed: ${String(err)}`);
+                    }
+                    finally {
+                        if (_singletonState?.store === store) {
+                            _singletonState = null;
+                        }
+                    }
                 }
                 api.logger.info("memory-lancedb-pro: stopped");
             },

--- a/dist/index.js
+++ b/dist/index.js
@@ -4253,12 +4253,15 @@ export function parsePluginConfig(value) {
         ? lockingRaw.redis
         : null;
     const redisLockExplicitlyDisabled = redisLockRaw?.enabled === false;
-    const legacyRedisUrl = redisLockExplicitlyDisabled
+    const nestedRedisUrl = redisLockExplicitlyDisabled
+        ? undefined
+        : resolveOptionalEnvString(redisLockRaw?.url);
+    const legacyRedisUrl = redisLockExplicitlyDisabled || nestedRedisUrl
         ? undefined
         : resolveOptionalEnvString(cfg.redisUrl);
     const redisLockUrl = redisLockExplicitlyDisabled
         ? undefined
-        : (resolveOptionalEnvString(redisLockRaw?.url) ??
+        : (nestedRedisUrl ??
             legacyRedisUrl ??
             asNonEmptyString(process.env.MEMORY_LANCEDB_REDIS_URL));
     const redisLockEnabled = !redisLockExplicitlyDisabled &&

--- a/dist/src/redis-lock.js
+++ b/dist/src/redis-lock.js
@@ -190,7 +190,7 @@ export class RedisLockManager {
         }
         catch (err) {
             this.clientPromise = null;
-            this.config.onWarning?.(`memory-lancedb-pro: Redis lock connection failed; using file lock when available: ${String(err)}`);
+            this.config.onWarning?.(`memory-lancedb-pro: Redis lock connection failed; writes will fail closed until Redis locking is available: ${String(err)}`);
             throw new RedisLockUnavailableError(`Redis lock connection failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
         }
     }

--- a/dist/src/redis-lock.js
+++ b/dist/src/redis-lock.js
@@ -120,9 +120,9 @@ export class RedisLockManager {
         }, renewIntervalMs);
         if (typeof renewTimer.unref === "function")
             renewTimer.unref();
+        let callbackError;
         try {
             let result;
-            let callbackError;
             try {
                 result = await fn();
             }
@@ -143,9 +143,15 @@ export class RedisLockManager {
         finally {
             clearInterval(renewTimer);
             try {
-                await client.eval(RELEASE_SCRIPT, 1, key, token);
+                const releaseResult = await client.eval(RELEASE_SCRIPT, 1, key, token);
+                if (releaseResult !== 1) {
+                    throwPostWriteLeaseError(new RedisLockLeaseLostError(`Redis lock ${key} was no longer owned by this writer at release`), callbackError);
+                }
             }
             catch (err) {
+                if (err instanceof RedisLockLeaseIntegrityError) {
+                    throw err;
+                }
                 this.config.onWarning?.(`memory-lancedb-pro: Redis lock release failed for ${key}; lock will expire by TTL: ${String(err)}`);
             }
         }

--- a/dist/src/redis-lock.js
+++ b/dist/src/redis-lock.js
@@ -52,6 +52,7 @@ export class RedisLockManager {
     injectedClient;
     config;
     clientPromise = null;
+    isClosed = false;
     constructor(config, injectedClient) {
         this.injectedClient = injectedClient;
         this.config = {
@@ -66,9 +67,9 @@ export class RedisLockManager {
         };
     }
     async withLock(resource, fn) {
+        const key = this.makeKey(resource);
         const client = await this.getClient();
         this.assertClientSupportsLocking(client);
-        const key = this.makeKey(resource);
         const token = randomUUID();
         await this.acquire(client, key, token);
         let leaseLost = null;
@@ -81,7 +82,7 @@ export class RedisLockManager {
         const throwPostWriteLeaseError = (error) => {
             throw new RedisLockLeaseIntegrityError(`Redis lock ${key} was lost before the write settled; the write outcome is ambiguous and must not be retried automatically`, { cause: error });
         };
-        const renewIntervalMs = Math.max(1, Math.floor(this.config.ttlMs / 3));
+        const renewIntervalMs = Math.max(100, Math.floor(this.config.ttlMs / 5));
         const renewTimer = setInterval(() => {
             void this.renew(client, key, token).then((renewed) => {
                 if (renewed === false) {
@@ -120,6 +121,7 @@ export class RedisLockManager {
         }
     }
     async close() {
+        this.isClosed = true;
         if (!this.clientPromise)
             return;
         const client = await this.clientPromise.catch(() => null);
@@ -135,6 +137,9 @@ export class RedisLockManager {
         client.disconnect?.();
     }
     async getClient() {
+        if (this.isClosed) {
+            throw new RedisLockUnavailableError("Redis lock manager has been closed");
+        }
         if (this.injectedClient)
             return this.injectedClient;
         if (!this.config.url) {
@@ -166,11 +171,15 @@ export class RedisLockManager {
         }
         catch (err) {
             this.clientPromise = null;
+            this.config.onWarning?.(`memory-lancedb-pro: Redis lock connection failed; using file lock when available: ${String(err)}`);
             throw new RedisLockUnavailableError(`Redis lock connection failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
         }
     }
     makeKey(resource) {
-        const digest = createHash("sha256").update(resource || "default").digest("hex");
+        if (typeof resource !== "string" || resource.length === 0) {
+            throw new RedisLockAcquisitionError("Redis lock resource must be a non-empty string");
+        }
+        const digest = createHash("sha256").update(resource).digest("hex");
         return `${this.config.keyPrefix}:${digest}`;
     }
     assertClientSupportsLocking(client) {
@@ -191,7 +200,8 @@ export class RedisLockManager {
             catch (err) {
                 lastError = err;
             }
-            const delayMs = Math.min(this.config.retryDelayMs * 2 ** attempt, Math.max(this.config.retryDelayMs, 1_000));
+            const maxDelayMs = Math.max(this.config.retryDelayMs, 100);
+            const delayMs = Math.min(this.config.retryDelayMs * 2 ** attempt, maxDelayMs);
             attempt += 1;
             await sleep(Math.min(delayMs, Math.max(0, deadline - Date.now())));
         }

--- a/dist/src/redis-lock.js
+++ b/dist/src/redis-lock.js
@@ -17,6 +17,12 @@ export class RedisLockLeaseLostError extends Error {
         this.name = "RedisLockLeaseLostError";
     }
 }
+export class RedisLockLeaseIntegrityError extends Error {
+    constructor(message, options) {
+        super(message, options);
+        this.name = "RedisLockLeaseIntegrityError";
+    }
+}
 const DEFAULT_KEY_PREFIX = "memory-lancedb-pro:write-lock";
 const DEFAULT_TTL_MS = 60_000;
 const DEFAULT_ACQUIRE_TIMEOUT_MS = 5_000;
@@ -66,32 +72,42 @@ export class RedisLockManager {
         const token = randomUUID();
         await this.acquire(client, key, token);
         let leaseLost = null;
-        let rejectLeaseLost = () => { };
-        const leaseLostPromise = new Promise((_resolve, reject) => {
-            rejectLeaseLost = reject;
-        });
+        let leaseExpiresAt = Date.now() + this.config.ttlMs;
         const markLeaseLost = (error) => {
             if (leaseLost)
                 return;
             leaseLost = error;
-            rejectLeaseLost(error);
         };
-        const renewIntervalMs = Math.max(1, Math.floor(this.config.ttlMs / 2));
+        const throwPostWriteLeaseError = (error) => {
+            throw new RedisLockLeaseIntegrityError(`Redis lock ${key} was lost before the write settled; the write outcome is ambiguous and must not be retried automatically`, { cause: error });
+        };
+        const renewIntervalMs = Math.max(1, Math.floor(this.config.ttlMs / 3));
         const renewTimer = setInterval(() => {
-            void this.renew(client, key, token).catch((err) => {
-                markLeaseLost(new RedisLockLeaseLostError(`Redis lock renewal failed for ${key}: ${err instanceof Error ? err.message : String(err)}`, { cause: err }));
-            }).then((renewed) => {
+            void this.renew(client, key, token).then((renewed) => {
                 if (renewed === false) {
                     markLeaseLost(new RedisLockLeaseLostError(`Redis lock ${key} is no longer owned by this writer`));
+                    return;
                 }
+                leaseExpiresAt = Date.now() + this.config.ttlMs;
+            }).catch((err) => {
+                if (Date.now() >= leaseExpiresAt) {
+                    markLeaseLost(new RedisLockLeaseLostError(`Redis lock renewal failed for ${key} before the lease could be extended: ${err instanceof Error ? err.message : String(err)}`, { cause: err }));
+                    return;
+                }
+                this.config.onWarning?.(`memory-lancedb-pro: transient Redis lock renewal failure for ${key}; retrying before TTL expiry: ${String(err)}`);
             });
         }, renewIntervalMs);
         if (typeof renewTimer.unref === "function")
             renewTimer.unref();
         try {
-            const operation = fn();
-            operation.catch(() => { });
-            return await Promise.race([operation, leaseLostPromise]);
+            const result = await fn();
+            if (leaseLost) {
+                throwPostWriteLeaseError(leaseLost);
+            }
+            if (Date.now() >= leaseExpiresAt) {
+                throwPostWriteLeaseError(new RedisLockLeaseLostError(`Redis lock ${key} expired before the write settled`));
+            }
+            return result;
         }
         finally {
             clearInterval(renewTimer);

--- a/dist/src/redis-lock.js
+++ b/dist/src/redis-lock.js
@@ -53,6 +53,7 @@ export class RedisLockManager {
     config;
     clientPromise = null;
     isClosed = false;
+    activeLocks = new Set();
     constructor(config, injectedClient) {
         this.injectedClient = injectedClient;
         this.config = {
@@ -67,11 +68,24 @@ export class RedisLockManager {
         };
     }
     async withLock(resource, fn) {
+        if (this.isClosed) {
+            throw new RedisLockUnavailableError("Redis lock manager has been closed");
+        }
         const key = this.makeKey(resource);
         const client = await this.getClient();
         this.assertClientSupportsLocking(client);
         const token = randomUUID();
         await this.acquire(client, key, token);
+        const activeLock = this.runLockedCallback(client, key, token, fn);
+        this.activeLocks.add(activeLock);
+        try {
+            return await activeLock;
+        }
+        finally {
+            this.activeLocks.delete(activeLock);
+        }
+    }
+    async runLockedCallback(client, key, token, fn) {
         let leaseLost = null;
         let leaseExpiresAt = Date.now() + this.config.ttlMs;
         const markLeaseLost = (error) => {
@@ -122,10 +136,15 @@ export class RedisLockManager {
     }
     async close() {
         this.isClosed = true;
-        if (!this.clientPromise)
+        if (this.activeLocks.size > 0) {
+            await Promise.allSettled([...this.activeLocks]);
+        }
+        if (!this.injectedClient && !this.clientPromise)
             return;
-        const client = await this.clientPromise.catch(() => null);
-        this.clientPromise = null;
+        const client = this.injectedClient ?? (await this.clientPromise?.catch(() => null));
+        if (!this.injectedClient) {
+            this.clientPromise = null;
+        }
         if (!client)
             return;
         if (typeof client.quit === "function") {

--- a/dist/src/redis-lock.js
+++ b/dist/src/redis-lock.js
@@ -1,0 +1,191 @@
+import { createHash, randomUUID } from "node:crypto";
+export class RedisLockUnavailableError extends Error {
+    constructor(message, options) {
+        super(message, options);
+        this.name = "RedisLockUnavailableError";
+    }
+}
+export class RedisLockAcquisitionError extends Error {
+    constructor(message, options) {
+        super(message, options);
+        this.name = "RedisLockAcquisitionError";
+    }
+}
+export class RedisLockLeaseLostError extends Error {
+    constructor(message, options) {
+        super(message, options);
+        this.name = "RedisLockLeaseLostError";
+    }
+}
+const DEFAULT_KEY_PREFIX = "memory-lancedb-pro:write-lock";
+const DEFAULT_TTL_MS = 60_000;
+const DEFAULT_ACQUIRE_TIMEOUT_MS = 5_000;
+const DEFAULT_RETRY_DELAY_MS = 50;
+const DEFAULT_CONNECT_TIMEOUT_MS = 1_000;
+const RELEASE_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+end
+return 0
+`;
+const RENEW_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("pexpire", KEYS[1], ARGV[2])
+end
+return 0
+`;
+function clampPositiveInt(value, fallback) {
+    if (!Number.isFinite(value) || value === undefined || value <= 0)
+        return fallback;
+    return Math.floor(value);
+}
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+export class RedisLockManager {
+    injectedClient;
+    config;
+    clientPromise = null;
+    constructor(config, injectedClient) {
+        this.injectedClient = injectedClient;
+        this.config = {
+            enabled: config.enabled ?? true,
+            url: config.url,
+            keyPrefix: config.keyPrefix || DEFAULT_KEY_PREFIX,
+            ttlMs: clampPositiveInt(config.ttlMs, DEFAULT_TTL_MS),
+            acquireTimeoutMs: clampPositiveInt(config.acquireTimeoutMs, DEFAULT_ACQUIRE_TIMEOUT_MS),
+            retryDelayMs: clampPositiveInt(config.retryDelayMs, DEFAULT_RETRY_DELAY_MS),
+            connectTimeoutMs: clampPositiveInt(config.connectTimeoutMs, DEFAULT_CONNECT_TIMEOUT_MS),
+            onWarning: config.onWarning,
+        };
+    }
+    async withLock(resource, fn) {
+        const client = await this.getClient();
+        this.assertClientSupportsLocking(client);
+        const key = this.makeKey(resource);
+        const token = randomUUID();
+        await this.acquire(client, key, token);
+        let leaseLost = null;
+        let rejectLeaseLost = () => { };
+        const leaseLostPromise = new Promise((_resolve, reject) => {
+            rejectLeaseLost = reject;
+        });
+        const markLeaseLost = (error) => {
+            if (leaseLost)
+                return;
+            leaseLost = error;
+            rejectLeaseLost(error);
+        };
+        const renewIntervalMs = Math.max(1, Math.floor(this.config.ttlMs / 2));
+        const renewTimer = setInterval(() => {
+            void this.renew(client, key, token).catch((err) => {
+                markLeaseLost(new RedisLockLeaseLostError(`Redis lock renewal failed for ${key}: ${err instanceof Error ? err.message : String(err)}`, { cause: err }));
+            }).then((renewed) => {
+                if (renewed === false) {
+                    markLeaseLost(new RedisLockLeaseLostError(`Redis lock ${key} is no longer owned by this writer`));
+                }
+            });
+        }, renewIntervalMs);
+        if (typeof renewTimer.unref === "function")
+            renewTimer.unref();
+        try {
+            const operation = fn();
+            operation.catch(() => { });
+            return await Promise.race([operation, leaseLostPromise]);
+        }
+        finally {
+            clearInterval(renewTimer);
+            try {
+                await client.eval(RELEASE_SCRIPT, 1, key, token);
+            }
+            catch (err) {
+                this.config.onWarning?.(`memory-lancedb-pro: Redis lock release failed for ${key}; lock will expire by TTL: ${String(err)}`);
+            }
+        }
+    }
+    async close() {
+        if (!this.clientPromise)
+            return;
+        const client = await this.clientPromise.catch(() => null);
+        this.clientPromise = null;
+        if (!client)
+            return;
+        if (typeof client.quit === "function") {
+            await client.quit().catch(() => {
+                client.disconnect?.();
+            });
+            return;
+        }
+        client.disconnect?.();
+    }
+    async getClient() {
+        if (this.injectedClient)
+            return this.injectedClient;
+        if (!this.config.url) {
+            throw new RedisLockUnavailableError("Redis lock is enabled but no Redis URL was configured");
+        }
+        if (!this.clientPromise) {
+            this.clientPromise = this.createClient();
+        }
+        return this.clientPromise;
+    }
+    async createClient() {
+        try {
+            const mod = await import("ioredis");
+            const redisModule = mod;
+            const Redis = redisModule.default ?? redisModule.Redis;
+            if (!Redis) {
+                throw new Error("ioredis did not export a Redis constructor");
+            }
+            const client = new Redis(this.config.url, {
+                connectTimeout: this.config.connectTimeoutMs,
+                enableOfflineQueue: false,
+                lazyConnect: true,
+                maxRetriesPerRequest: 1,
+            });
+            if (typeof client.connect === "function") {
+                await client.connect();
+            }
+            return client;
+        }
+        catch (err) {
+            this.clientPromise = null;
+            throw new RedisLockUnavailableError(`Redis lock connection failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
+        }
+    }
+    makeKey(resource) {
+        const digest = createHash("sha256").update(resource || "default").digest("hex");
+        return `${this.config.keyPrefix}:${digest}`;
+    }
+    assertClientSupportsLocking(client) {
+        if (typeof client.set !== "function" || typeof client.eval !== "function") {
+            throw new RedisLockUnavailableError("Redis lock client does not provide required SET/EVAL commands");
+        }
+    }
+    async acquire(client, key, token) {
+        const deadline = Date.now() + this.config.acquireTimeoutMs;
+        let attempt = 0;
+        let lastError;
+        while (Date.now() <= deadline) {
+            try {
+                const result = await client.set(key, token, "PX", this.config.ttlMs, "NX");
+                if (result === "OK")
+                    return;
+            }
+            catch (err) {
+                lastError = err;
+            }
+            const delayMs = Math.min(this.config.retryDelayMs * 2 ** attempt, Math.max(this.config.retryDelayMs, 1_000));
+            attempt += 1;
+            await sleep(Math.min(delayMs, Math.max(0, deadline - Date.now())));
+        }
+        if (lastError) {
+            throw new RedisLockAcquisitionError(`Timed out acquiring Redis lock ${key} after ${this.config.acquireTimeoutMs}ms; last Redis error: ${lastError instanceof Error ? lastError.message : String(lastError)}`, { cause: lastError });
+        }
+        throw new RedisLockAcquisitionError(`Timed out acquiring Redis lock ${key} after ${this.config.acquireTimeoutMs}ms`);
+    }
+    async renew(client, key, token) {
+        const result = await client.eval(RENEW_SCRIPT, 1, key, token, String(this.config.ttlMs));
+        return result === 1;
+    }
+}

--- a/dist/src/redis-lock.js
+++ b/dist/src/redis-lock.js
@@ -71,12 +71,7 @@ export class RedisLockManager {
         if (this.isClosed) {
             throw new RedisLockUnavailableError("Redis lock manager has been closed");
         }
-        const key = this.makeKey(resource);
-        const client = await this.getClient();
-        this.assertClientSupportsLocking(client);
-        const token = randomUUID();
-        await this.acquire(client, key, token);
-        const activeLock = this.runLockedCallback(client, key, token, fn);
+        const activeLock = this.runLockLifecycle(resource, fn);
         this.activeLocks.add(activeLock);
         try {
             return await activeLock;
@@ -84,6 +79,14 @@ export class RedisLockManager {
         finally {
             this.activeLocks.delete(activeLock);
         }
+    }
+    async runLockLifecycle(resource, fn) {
+        const key = this.makeKey(resource);
+        const client = await this.getClient();
+        this.assertClientSupportsLocking(client);
+        const token = randomUUID();
+        await this.acquire(client, key, token);
+        return this.runLockedCallback(client, key, token, fn);
     }
     async runLockedCallback(client, key, token, fn) {
         let leaseLost = null;
@@ -93,8 +96,11 @@ export class RedisLockManager {
                 return;
             leaseLost = error;
         };
-        const throwPostWriteLeaseError = (error) => {
-            throw new RedisLockLeaseIntegrityError(`Redis lock ${key} was lost before the write settled; the write outcome is ambiguous and must not be retried automatically`, { cause: error });
+        const throwPostWriteLeaseError = (error, callbackError) => {
+            const callbackDetail = callbackError
+                ? `; callback also failed: ${callbackError instanceof Error ? callbackError.message : String(callbackError)}`
+                : "";
+            throw new RedisLockLeaseIntegrityError(`Redis lock ${key} was lost before the write settled; the write outcome is ambiguous and must not be retried automatically${callbackDetail}`, { cause: error });
         };
         const renewIntervalMs = Math.max(100, Math.floor(this.config.ttlMs / 5));
         const renewTimer = setInterval(() => {
@@ -115,12 +121,22 @@ export class RedisLockManager {
         if (typeof renewTimer.unref === "function")
             renewTimer.unref();
         try {
-            const result = await fn();
+            let result;
+            let callbackError;
+            try {
+                result = await fn();
+            }
+            catch (err) {
+                callbackError = err;
+            }
             if (leaseLost) {
-                throwPostWriteLeaseError(leaseLost);
+                throwPostWriteLeaseError(leaseLost, callbackError);
             }
             if (Date.now() >= leaseExpiresAt) {
-                throwPostWriteLeaseError(new RedisLockLeaseLostError(`Redis lock ${key} expired before the write settled`));
+                throwPostWriteLeaseError(new RedisLockLeaseLostError(`Redis lock ${key} expired before the write settled`), callbackError);
+            }
+            if (callbackError) {
+                throw callbackError;
             }
             return result;
         }

--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -341,7 +341,8 @@ export class MemoryRetriever {
         const { query, limit, scopeFilter, category, source, signal, rerankTimeoutMs, rerankDeadlineMs } = context;
         const safeLimit = clampInt(limit, 1, 20);
         this.lastDiagnostics = null;
-        // FLEET-PATCH(#884): resolve lazy store init BEFORE routing reads hasFtsSupport.
+        // FLEET-PATCH(#884): resolve lazy store init BEFORE routing reads hasFtsSupport,
+        // otherwise the first retrieve() in a fresh process silently routes vector-only.
         await this.store.ensureInitialized?.();
         const diagnostics = {
             source,

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -8,6 +8,7 @@ import { access as accessAsync, lstat as lstatAsync, mkdir as mkdirAsync, realpa
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { matchesMemoryCategoryFilter, resolveCategoryFilterCandidates } from "./memory-categories.js";
+import { RedisLockManager, RedisLockUnavailableError, } from "./redis-lock.js";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
 // ============================================================================
 // LanceDB Dynamic Import
@@ -404,6 +405,7 @@ export class MemoryStore {
     static INDEX_FOLD_OP_THRESHOLD = 20;
     config;
     disableNativeCosine;
+    redisLock = null;
     constructor(config) {
         const envDisablesNativeCosine = parseBooleanEnvFlag(process.env.MEMORY_LANCEDB_DISABLE_NATIVE_COSINE);
         this.config = {
@@ -411,6 +413,17 @@ export class MemoryStore {
             dbPath: normalizeStoragePath(config.dbPath),
         };
         this.disableNativeCosine = config.disableNativeCosine === true || envDisablesNativeCosine;
+        if (config.redisLock?.enabled === true) {
+            if (config.redisLock.url) {
+                this.redisLock = new RedisLockManager({
+                    ...config.redisLock,
+                    onWarning: config.onLockWarning,
+                });
+            }
+            else {
+                config.onLockWarning?.("memory-lancedb-pro: Redis lock is enabled but no Redis URL is configured; using file lock");
+            }
+        }
     }
     async runWithFileLock(fn) {
         const lockfile = await loadLockfile();
@@ -535,6 +548,31 @@ export class MemoryStore {
                 console.warn(`[memory-lancedb-pro] Returning successful result despite compromised lock at "${lockPath}". ` +
                     `Callers must not retry this operation automatically.`);
             }
+        }
+    }
+    async runWithWriteLock(fn) {
+        if (!this.redisLock) {
+            return this.runWithFileLock(fn);
+        }
+        try {
+            return await this.redisLock.withLock(this.config.dbPath, fn);
+        }
+        catch (err) {
+            if (!(err instanceof RedisLockUnavailableError)) {
+                throw err;
+            }
+            this.config.onLockWarning?.(`memory-lancedb-pro: Redis write lock unavailable; falling back to file lock: ${err.message}`);
+            return this.runWithFileLock(fn);
+        }
+    }
+    async closeLockResources() {
+        if (!this.redisLock)
+            return;
+        try {
+            await this.redisLock.close();
+        }
+        catch (err) {
+            this.config.onLockWarning?.(`memory-lancedb-pro: failed to close Redis lock client: ${String(err)}`);
         }
     }
     get dbPath() {
@@ -743,7 +781,7 @@ export class MemoryStore {
     async backfillLegacySecondTimestamps(table) {
         try {
             let normalizedCount = 0;
-            await this.runWithFileLock(async () => {
+            await this.runWithWriteLock(async () => {
                 const candidateRows = await table.query()
                     .where(`(timestamp > 0 AND timestamp < ${LEGACY_SECONDS_TIMESTAMP_MAX}) OR ` +
                     `(metadata IS NOT NULL AND metadata != '{}' AND metadata != '')`)
@@ -855,7 +893,7 @@ export class MemoryStore {
     }
     async upsert(entry) {
         await this.ensureInitialized();
-        const result = await this.runWithFileLock(() => this.runSerializedUpdate(async () => {
+        const result = await this.runWithWriteLock(() => this.runSerializedUpdate(async () => {
             const safeId = escapeSqlLiteral(entry.id);
             await this.table.delete(`id = '${safeId}'`).catch(() => undefined);
             const normalizedEntry = {
@@ -1008,7 +1046,7 @@ export class MemoryStore {
                 const chunk = allEntries.slice(i, i + MemoryStore.MAX_BATCH_SIZE);
                 const chunkIdx = Math.floor(i / MemoryStore.MAX_BATCH_SIZE);
                 try {
-                    await this.runWithFileLock(async () => {
+                    await this.runWithWriteLock(async () => {
                         await this.table.add(chunk);
                     });
                     this.noteDataModification();
@@ -1156,6 +1194,7 @@ export class MemoryStore {
         // 1. destroy() 自己有錯 + lastBackgroundError 也有值 → composite error（兩個都保留）
         // 2. 只有 destroy() 自己有錯 → 只 throw destroy 的錯誤
         // 3. 只有 lastBackgroundError 有值 → throw timer 歷史錯誤
+        let destroyError = null;
         if (result.hasError && result.lastError) {
             if (this.lastBackgroundError?.hasError) {
                 // 情境 1：兩個錯誤都保留，包成 composite error
@@ -1164,17 +1203,23 @@ export class MemoryStore {
                 // throw destroy 自己錯誤，因為更新、更直接
                 // timer 歷史錯誤放在 message 裡讓 caller 知道（cause chain 保留）
                 const compositeError = new Error(`destroy flush failed (${result.lastError.message}); background flush also failed: ${timerError.message}`, { cause: result.lastError });
-                throw compositeError;
+                destroyError = compositeError;
             }
-            // 情境 2：只有 destroy 自己有錯
-            throw result.lastError;
+            else {
+                // 情境 2：只有 destroy 自己有錯
+                destroyError = result.lastError;
+            }
         }
         // 【F1 fix】檢查 lastBackgroundError（timers 錯誤的最後堡壘）
         // 情境 3：只有 lastBackgroundError 有值
-        if (this.lastBackgroundError?.hasError) {
+        if (!destroyError && this.lastBackgroundError?.hasError) {
             const err = this.lastBackgroundError.lastError ?? new Error("background flush failed");
             this.lastBackgroundError = null;
-            throw err;
+            destroyError = err;
+        }
+        await this.closeLockResources();
+        if (destroyError) {
+            throw destroyError;
         }
     }
     /**
@@ -1198,7 +1243,7 @@ export class MemoryStore {
             timestamp: normalizeMemoryTimestamp(entry.timestamp),
             metadata: entry.metadata || "{}",
         };
-        return this.runWithFileLock(async () => {
+        return this.runWithWriteLock(async () => {
             await this.table.add([full]);
             return full;
         });
@@ -1275,7 +1320,7 @@ export class MemoryStore {
         if (scopeFilter && scopeFilter.length > 0 && !scopeFilter.includes(rowScope)) {
             throw new Error(`Memory ${id} is outside accessible scopes`);
         }
-        return this.runWithFileLock(async () => {
+        return this.runWithWriteLock(async () => {
             await this.table.delete(`id = '${safeId}'`);
             return true;
         });
@@ -1523,7 +1568,7 @@ export class MemoryStore {
             !scopeFilter.includes(rowScope)) {
             throw new Error(`Memory ${resolvedId} is outside accessible scopes`);
         }
-        return this.runWithFileLock(async () => {
+        return this.runWithWriteLock(async () => {
             await this.table.delete(`id = '${resolvedId}'`);
             return true;
         });
@@ -1637,7 +1682,7 @@ export class MemoryStore {
                 error: `Memory ${id} is outside accessible scopes`,
             }));
         }
-        return this.runWithFileLock(() => this.runSerializedUpdate(async () => {
+        return this.runWithWriteLock(() => this.runSerializedUpdate(async () => {
             const results = new Map();
             const pending = [];
             const seenIds = new Set();
@@ -1799,7 +1844,7 @@ export class MemoryStore {
         if (isExplicitDenyAllScopeFilter(scopeFilter)) {
             throw new Error(`Memory ${id} is outside accessible scopes`);
         }
-        return this.runWithFileLock(() => this.runSerializedUpdate(async () => {
+        return this.runWithWriteLock(() => this.runSerializedUpdate(async () => {
             // Support full UUID, short hex prefixes, and constrained exact legacy IDs imported
             // from older stores (for example "mem-md-..." or "data-pointer-...").
             const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -1939,7 +1984,7 @@ export class MemoryStore {
             throw new Error("Bulk delete requires at least scope or timestamp filter for safety");
         }
         const whereClause = conditions.join(" AND ");
-        return this.runWithFileLock(async () => {
+        return this.runWithWriteLock(async () => {
             // Count first
             const countResults = await this.table.query().where(whereClause).toArray();
             const deleteCount = countResults.length;

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -585,7 +585,7 @@ export class MemoryStore {
         await this.ensureInitialized();
         const safeRetentionDays = clampInt(retentionDays, 1, 3650);
         const cleanupOlderThan = new Date(Date.now() - safeRetentionDays * 24 * 60 * 60 * 1000);
-        return this.runWithFileLock(async () => {
+        return this.runWithWriteLock(async () => {
             if (!this.table || typeof this.table.optimize !== "function") {
                 throw new Error("LanceDB table.optimize() is not available in this runtime");
             }

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -8,7 +8,7 @@ import { access as accessAsync, lstat as lstatAsync, mkdir as mkdirAsync, realpa
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { matchesMemoryCategoryFilter, resolveCategoryFilterCandidates } from "./memory-categories.js";
-import { RedisLockManager, } from "./redis-lock.js";
+import { RedisLockAcquisitionError, RedisLockLeaseIntegrityError, RedisLockManager, RedisLockUnavailableError, } from "./redis-lock.js";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
 // ============================================================================
 // LanceDB Dynamic Import
@@ -672,70 +672,7 @@ export class MemoryStore {
             throw new Error(`Failed to open LanceDB at "${this.config.dbPath}": ${code} ${message}\n` +
                 `  Fix: Verify the path exists and is writable. Check parent directory permissions.`);
         }
-        let table;
-        // Idempotent table init: try openTable first, create only if missing,
-        // and handle the race where tableNames() misses an existing table but
-        // createTable then sees it (LanceDB eventual consistency).
-        try {
-            table = await db.openTable(TABLE_NAME);
-            // Migrate legacy tables: add missing columns for backward compatibility
-            try {
-                const schema = await table.schema();
-                const fieldNames = new Set(schema.fields.map((f) => f.name));
-                const missingColumns = [];
-                if (!fieldNames.has("scope")) {
-                    missingColumns.push({ name: "scope", valueSql: "'global'" });
-                }
-                if (!fieldNames.has("timestamp")) {
-                    missingColumns.push({ name: "timestamp", valueSql: "CAST(0 AS DOUBLE)" });
-                }
-                if (!fieldNames.has("metadata")) {
-                    missingColumns.push({ name: "metadata", valueSql: "'{}'" });
-                }
-                if (missingColumns.length > 0) {
-                    console.warn(`memory-lancedb-pro: migrating legacy table — adding columns: ${missingColumns.map((c) => c.name).join(", ")}`);
-                    await table.addColumns(missingColumns);
-                    console.log(`memory-lancedb-pro: migration complete — ${missingColumns.length} column(s) added`);
-                }
-            }
-            catch (err) {
-                const msg = String(err);
-                if (msg.includes("already exists")) {
-                    // Concurrent initialization race — another process already added the columns
-                    console.log("memory-lancedb-pro: migration columns already exist (concurrent init)");
-                }
-                else {
-                    console.warn("memory-lancedb-pro: could not check/migrate table schema:", err);
-                }
-            }
-        }
-        catch (_openErr) {
-            // Table doesn't exist yet — create it
-            const schemaEntry = {
-                id: "__schema__",
-                text: "",
-                vector: Array.from({ length: this.config.vectorDim }).fill(0),
-                category: "other",
-                scope: "global",
-                importance: 0,
-                timestamp: 0,
-                metadata: "{}",
-            };
-            try {
-                table = await db.createTable(TABLE_NAME, [schemaEntry]);
-                await table.delete('id = "__schema__"');
-            }
-            catch (createErr) {
-                // Race: another caller (or eventual consistency) created the table
-                // between our failed openTable and this createTable — just open it.
-                if (String(createErr).includes("already exists")) {
-                    table = await db.openTable(TABLE_NAME);
-                }
-                else {
-                    throw createErr;
-                }
-            }
-        }
+        const table = await this.openOrCreateMemoryTable(db);
         await this.backfillLegacySecondTimestamps(table);
         // Validate vector dimensions
         // Note: LanceDB returns Arrow Vector objects, not plain JS arrays.
@@ -749,7 +686,7 @@ export class MemoryStore {
         }
         // Create FTS index for BM25 search (graceful fallback if unavailable)
         try {
-            await this.createFtsIndex(table);
+            await this.createFtsIndexWithWriteLock(table);
             this.ftsIndexCreated = true;
             this._lastFtsError = null;
         }
@@ -763,6 +700,111 @@ export class MemoryStore {
         // Fold any unindexed backlog accumulated while no maintenance ran
         // (best-effort, runs in the background, never blocks initialization).
         void this.scheduleStartupIndexCatchUp();
+    }
+    isRedisLockCoordinationError(err) {
+        return err instanceof RedisLockUnavailableError ||
+            err instanceof RedisLockAcquisitionError ||
+            err instanceof RedisLockLeaseIntegrityError;
+    }
+    getMissingLegacyColumns(fieldNames) {
+        const missingColumns = [];
+        if (!fieldNames.has("scope")) {
+            missingColumns.push({ name: "scope", valueSql: "'global'" });
+        }
+        if (!fieldNames.has("timestamp")) {
+            missingColumns.push({ name: "timestamp", valueSql: "CAST(0 AS DOUBLE)" });
+        }
+        if (!fieldNames.has("metadata")) {
+            missingColumns.push({ name: "metadata", valueSql: "'{}'" });
+        }
+        return missingColumns;
+    }
+    async readMissingLegacyColumns(table) {
+        const schema = await table.schema();
+        const fieldNames = new Set(schema.fields.map((f) => f.name));
+        return this.getMissingLegacyColumns(fieldNames);
+    }
+    async migrateLegacyTableColumns(table, alreadyLocked = false) {
+        try {
+            const missingColumns = await this.readMissingLegacyColumns(table);
+            if (missingColumns.length === 0)
+                return;
+            const applyMigration = async () => {
+                const currentMissingColumns = await this.readMissingLegacyColumns(table);
+                if (currentMissingColumns.length === 0)
+                    return;
+                console.warn(`memory-lancedb-pro: migrating legacy table — adding columns: ${currentMissingColumns.map((c) => c.name).join(", ")}`);
+                await table.addColumns(currentMissingColumns);
+                console.log(`memory-lancedb-pro: migration complete — ${currentMissingColumns.length} column(s) added`);
+            };
+            if (alreadyLocked) {
+                await applyMigration();
+            }
+            else {
+                await this.runWithWriteLock(applyMigration);
+            }
+        }
+        catch (err) {
+            const msg = String(err);
+            if (msg.includes("already exists")) {
+                // Concurrent initialization race — another process already added the columns
+                console.log("memory-lancedb-pro: migration columns already exist (concurrent init)");
+            }
+            else if (this.isRedisLockCoordinationError(err)) {
+                throw err;
+            }
+            else {
+                console.warn("memory-lancedb-pro: could not check/migrate table schema:", err);
+            }
+        }
+    }
+    async openOrCreateMemoryTable(db) {
+        // Idempotent table init: try openTable first, create only if missing,
+        // and handle the race where tableNames() misses an existing table but
+        // createTable then sees it (LanceDB eventual consistency).
+        let table;
+        try {
+            table = await db.openTable(TABLE_NAME);
+        }
+        catch (_openErr) {
+            return this.runWithWriteLock(async () => {
+                let lockedTable;
+                try {
+                    lockedTable = await db.openTable(TABLE_NAME);
+                }
+                catch {
+                    // Table doesn't exist yet — create it
+                    const schemaEntry = {
+                        id: "__schema__",
+                        text: "",
+                        vector: Array.from({ length: this.config.vectorDim }).fill(0),
+                        category: "other",
+                        scope: "global",
+                        importance: 0,
+                        timestamp: 0,
+                        metadata: "{}",
+                    };
+                    try {
+                        lockedTable = await db.createTable(TABLE_NAME, [schemaEntry]);
+                        await lockedTable.delete('id = "__schema__"');
+                    }
+                    catch (createErr) {
+                        // Race: another caller (or eventual consistency) created the table
+                        // between our failed openTable and this createTable — just open it.
+                        if (String(createErr).includes("already exists")) {
+                            lockedTable = await db.openTable(TABLE_NAME);
+                        }
+                        else {
+                            throw createErr;
+                        }
+                    }
+                }
+                await this.migrateLegacyTableColumns(lockedTable, true);
+                return lockedTable;
+            });
+        }
+        await this.migrateLegacyTableColumns(table);
+        return table;
     }
     async backfillLegacySecondTimestamps(table) {
         try {
@@ -869,6 +911,9 @@ export class MemoryStore {
         catch (err) {
             throw new Error(`FTS index creation failed: ${err instanceof Error ? err.message : String(err)}`);
         }
+    }
+    async createFtsIndexWithWriteLock(table) {
+        await this.runWithWriteLock(() => this.createFtsIndex(table));
     }
     async store(entry) {
         // F1 fix: store() now routes through bulkStore() accumulator
@@ -2019,20 +2064,22 @@ export class MemoryStore {
     async rebuildFtsIndex() {
         await this.ensureInitialized();
         try {
-            // Drop existing FTS index if any
-            const indices = await this.table.listIndices();
-            for (const idx of indices) {
-                if (idx.indexType === "FTS" || idx.columns?.includes("text")) {
-                    try {
-                        await this.table.dropIndex(idx.name || "text");
-                    }
-                    catch (err) {
-                        console.warn(`memory-lancedb-pro: dropIndex(${idx.name || "text"}) failed:`, err);
+            await this.runWithWriteLock(async () => {
+                // Drop existing FTS index if any
+                const indices = await this.table.listIndices();
+                for (const idx of indices) {
+                    if (idx.indexType === "FTS" || idx.columns?.includes("text")) {
+                        try {
+                            await this.table.dropIndex(idx.name || "text");
+                        }
+                        catch (err) {
+                            console.warn(`memory-lancedb-pro: dropIndex(${idx.name || "text"}) failed:`, err);
+                        }
                     }
                 }
-            }
-            // Recreate
-            await this.createFtsIndex(this.table);
+                // Recreate
+                await this.createFtsIndex(this.table);
+            });
             this.ftsIndexCreated = true;
             this._lastFtsError = null;
             return { success: true };

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -558,11 +558,10 @@ export class MemoryStore {
             return await this.redisLock.withLock(this.config.dbPath, fn);
         }
         catch (err) {
-            if (!(err instanceof RedisLockUnavailableError)) {
-                throw err;
+            if (err instanceof RedisLockUnavailableError) {
+                this.config.onLockWarning?.(`memory-lancedb-pro: Redis write lock unavailable; write failed closed to preserve Redis lock-domain isolation: ${err.message}`);
             }
-            this.config.onLockWarning?.(`memory-lancedb-pro: Redis write lock unavailable; falling back to file lock: ${err.message}`);
-            return this.runWithFileLock(fn);
+            throw err;
         }
     }
     async closeLockResources() {
@@ -614,7 +613,7 @@ export class MemoryStore {
         const mods = this.dataModsSinceIndexFold;
         this.dataModsSinceIndexFold = 0;
         try {
-            await this.runWithFileLock(async () => {
+            await this.runWithWriteLock(async () => {
                 await this.table.optimize({ cleanupOlderThan: new Date(0) });
             });
             console.log(`[memory-lancedb-pro] index fold completed (reason=${reason}, modsSinceLast=${mods})`);

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -8,7 +8,7 @@ import { access as accessAsync, lstat as lstatAsync, mkdir as mkdirAsync, realpa
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { matchesMemoryCategoryFilter, resolveCategoryFilterCandidates } from "./memory-categories.js";
-import { RedisLockManager, RedisLockUnavailableError, } from "./redis-lock.js";
+import { RedisLockManager, } from "./redis-lock.js";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
 // ============================================================================
 // LanceDB Dynamic Import
@@ -414,15 +414,10 @@ export class MemoryStore {
         };
         this.disableNativeCosine = config.disableNativeCosine === true || envDisablesNativeCosine;
         if (config.redisLock?.enabled === true) {
-            if (config.redisLock.url) {
-                this.redisLock = new RedisLockManager({
-                    ...config.redisLock,
-                    onWarning: config.onLockWarning,
-                });
-            }
-            else {
-                config.onLockWarning?.("memory-lancedb-pro: Redis lock is enabled but no Redis URL is configured; using file lock");
-            }
+            this.redisLock = new RedisLockManager({
+                ...config.redisLock,
+                onWarning: config.onLockWarning,
+            });
         }
     }
     async runWithFileLock(fn) {
@@ -554,16 +549,7 @@ export class MemoryStore {
         if (!this.redisLock) {
             return this.runWithFileLock(fn);
         }
-        try {
-            return await this.redisLock.withLock(this.config.dbPath, fn);
-        }
-        catch (err) {
-            if (!(err instanceof RedisLockUnavailableError)) {
-                throw err;
-            }
-            this.config.onLockWarning?.(`memory-lancedb-pro: Redis write lock unavailable; falling back to file lock: ${err.message}`);
-            return this.runWithFileLock(fn);
-        }
+        return this.redisLock.withLock(this.config.dbPath, fn);
     }
     async closeLockResources() {
         if (!this.redisLock)
@@ -614,7 +600,7 @@ export class MemoryStore {
         const mods = this.dataModsSinceIndexFold;
         this.dataModsSinceIndexFold = 0;
         try {
-            await this.runWithFileLock(async () => {
+            await this.runWithWriteLock(async () => {
                 await this.table.optimize({ cleanupOlderThan: new Date(0) });
             });
             console.log(`[memory-lancedb-pro] index fold completed (reason=${reason}, modsSinceLast=${mods})`);

--- a/docs/lock-management.md
+++ b/docs/lock-management.md
@@ -34,8 +34,13 @@ across those processes because they are not writing to the same LanceDB store.
 ## Redis Status
 
 Redis is not required for single-gateway or same-filesystem deployments, and the
-current plugin does not enable a Redis lock automatically. If you operate
-multiple independent writers, prefer one of these approaches:
+plugin does not enable a Redis lock automatically. If you enable Redis locking
+with `locking.redis.enabled` or a Redis URL, every LanceDB write and index
+maintenance mutation uses the Redis lock domain. Redis connection or lock-client
+availability failures fail writes closed instead of falling back to a local file
+lock.
+
+If you operate multiple independent writers, prefer one of these approaches:
 
 - route writes through one OpenClaw gateway
 - place the LanceDB directory on a filesystem whose lock-directory behavior is
@@ -43,8 +48,8 @@ multiple independent writers, prefer one of these approaches:
 - add an explicit external write coordinator before enabling multiple writers
 
 Do not use a no-op lock fallback for write paths. If an external coordinator is
-unavailable, fall back to the built-in file lock so failed Redis setup does not
-silently remove write protection.
+required but unavailable, fail the write and retry after the coordinator is
+healthy rather than switching that writer into a separate local lock domain.
 
 ## Troubleshooting Lock Contention
 

--- a/docs/lock-management.md
+++ b/docs/lock-management.md
@@ -33,10 +33,15 @@ across those processes because they are not writing to the same LanceDB store.
 
 ## Redis Status
 
-Redis is not required for single-gateway or same-filesystem deployments, and the
-plugin does not enable a Redis lock automatically. If you enable Redis locking
-with `locking.redis.enabled` or a Redis URL, every LanceDB write and index
-maintenance mutation uses the Redis lock domain. Redis connection or lock-client
+Redis is not required for single-gateway or same-filesystem deployments. The
+plugin enables Redis locking when `locking.redis.enabled` is true, when
+`redisUrl`/`locking.redis.url` is set, or when `MEMORY_LANCEDB_REDIS_URL` is
+present in that process environment. Every writer that shares a LanceDB store
+must use the same Redis lock configuration; mixing Redis-locked writers with
+writers that only use the local file lock creates separate lock domains.
+
+When Redis locking is enabled, every LanceDB write and index-maintenance
+mutation uses the Redis lock domain. Redis connection or lock-client
 availability failures fail writes closed instead of falling back to a local file
 lock.
 

--- a/index.ts
+++ b/index.ts
@@ -5279,6 +5279,11 @@ const memoryLanceDBProPlugin = {
           clearInterval(storageMaintenanceTimer);
           storageMaintenanceTimer = null;
         }
+        try {
+          await store.destroy();
+        } catch (err) {
+          api.logger.warn(`memory-lancedb-pro: stop cleanup failed: ${String(err)}`);
+        }
         api.logger.info("memory-lancedb-pro: stopped");
       },
     });

--- a/index.ts
+++ b/index.ts
@@ -5283,6 +5283,12 @@ const memoryLanceDBProPlugin = {
           await store.destroy();
         } catch (err) {
           api.logger.warn(`memory-lancedb-pro: stop cleanup failed: ${String(err)}`);
+        } finally {
+          if (_singletonState?.store === store) {
+            _singletonState = null;
+          }
+          _registeredApis.delete(api);
+          _registeredApisMap.delete(api);
         }
         api.logger.info("memory-lancedb-pro: stopped");
       },
@@ -5374,11 +5380,17 @@ export function parsePluginConfig(value: unknown): PluginConfig {
   const redisLockRaw = typeof lockingRaw?.redis === "object" && lockingRaw.redis !== null
     ? lockingRaw.redis as Record<string, unknown>
     : null;
-  const redisLockUrl =
-    resolveOptionalEnvString(redisLockRaw?.url) ??
-    resolveOptionalEnvString(cfg.redisUrl) ??
-    asNonEmptyString(process.env.MEMORY_LANCEDB_REDIS_URL);
   const redisLockExplicitlyDisabled = redisLockRaw?.enabled === false;
+  const legacyRedisUrl = redisLockExplicitlyDisabled
+    ? undefined
+    : resolveOptionalEnvString(cfg.redisUrl);
+  const redisLockUrl = redisLockExplicitlyDisabled
+    ? undefined
+    : (
+        resolveOptionalEnvString(redisLockRaw?.url) ??
+        legacyRedisUrl ??
+        asNonEmptyString(process.env.MEMORY_LANCEDB_REDIS_URL)
+      );
   const redisLockEnabled =
     !redisLockExplicitlyDisabled &&
     (redisLockRaw?.enabled === true || Boolean(redisLockUrl));
@@ -5456,7 +5468,7 @@ export function parsePluginConfig(value: unknown): PluginConfig {
         },
       }
       : undefined,
-    redisUrl: resolveOptionalEnvString(cfg.redisUrl),
+    redisUrl: legacyRedisUrl,
     locking: redisLockRaw || redisLockUrl
       ? {
         redis: {

--- a/index.ts
+++ b/index.ts
@@ -129,6 +129,18 @@ interface PluginConfig {
       initialDelayMs?: number;
     };
   };
+  redisUrl?: string;
+  locking?: {
+    redis?: {
+      enabled?: boolean;
+      url?: string;
+      keyPrefix?: string;
+      ttlMs?: number;
+      acquireTimeoutMs?: number;
+      retryDelayMs?: number;
+      connectTimeoutMs?: number;
+    };
+  };
   autoCapture?: boolean;
   autoRecall?: boolean;
   autoRecallMinLength?: number;
@@ -416,6 +428,11 @@ function resolveFirstApiKey(api: Pick<OpenClawPluginApi, "resolvePath">, apiKey:
     throw new Error("embedding.apiKey is empty");
   }
   return resolveSecretCredential(api, key, "embedding.apiKey");
+}
+
+function resolveOptionalEnvString(value: unknown): string | undefined {
+  const raw = asNonEmptyString(value);
+  return raw ? resolveEnvVars(raw) : undefined;
 }
 
 function resolveOptionalPathWithEnv(
@@ -2232,7 +2249,9 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
     dbPath: resolvedDbPath,
     vectorDim,
     disableNativeCosine: config.retrieval?.disableNativeCosine === true,
+    redisLock: config.locking?.redis,
     onStoragePathWarning: (message) => api.logger.warn(message),
+    onLockWarning: (message) => api.logger.warn(message),
   });
   const embedder = createEmbedder({
     provider: "openai-compatible",
@@ -5344,6 +5363,20 @@ export function parsePluginConfig(value: unknown): PluginConfig {
   const storageAutoCleanupRaw = typeof storageMaintenanceRaw?.autoCleanup === "object" && storageMaintenanceRaw.autoCleanup !== null
     ? storageMaintenanceRaw.autoCleanup as Record<string, unknown>
     : null;
+  const lockingRaw = typeof cfg.locking === "object" && cfg.locking !== null
+    ? cfg.locking as Record<string, unknown>
+    : null;
+  const redisLockRaw = typeof lockingRaw?.redis === "object" && lockingRaw.redis !== null
+    ? lockingRaw.redis as Record<string, unknown>
+    : null;
+  const redisLockUrl =
+    resolveOptionalEnvString(redisLockRaw?.url) ??
+    resolveOptionalEnvString(cfg.redisUrl) ??
+    asNonEmptyString(process.env.MEMORY_LANCEDB_REDIS_URL);
+  const redisLockExplicitlyDisabled = redisLockRaw?.enabled === false;
+  const redisLockEnabled =
+    !redisLockExplicitlyDisabled &&
+    (redisLockRaw?.enabled === true || Boolean(redisLockUrl));
   const userMdExclusiveRaw = typeof workspaceBoundaryRaw?.userMdExclusive === "object" && workspaceBoundaryRaw.userMdExclusive !== null
     ? workspaceBoundaryRaw.userMdExclusive as Record<string, unknown>
     : null;
@@ -5415,6 +5448,20 @@ export function parsePluginConfig(value: unknown): PluginConfig {
           intervalHours: parsePositiveInt(storageAutoCleanupRaw.intervalHours) ?? 24,
           retentionDays: parsePositiveInt(storageAutoCleanupRaw.retentionDays) ?? 7,
           initialDelayMs: parseNonNegativeInt(storageAutoCleanupRaw.initialDelayMs) ?? 300_000,
+        },
+      }
+      : undefined,
+    redisUrl: resolveOptionalEnvString(cfg.redisUrl),
+    locking: redisLockRaw || redisLockUrl
+      ? {
+        redis: {
+          enabled: redisLockEnabled,
+          url: redisLockUrl,
+          keyPrefix: asNonEmptyString(redisLockRaw?.keyPrefix),
+          ttlMs: parsePositiveInt(redisLockRaw?.ttlMs) ?? 60_000,
+          acquireTimeoutMs: parsePositiveInt(redisLockRaw?.acquireTimeoutMs) ?? 5_000,
+          retryDelayMs: parsePositiveInt(redisLockRaw?.retryDelayMs) ?? 50,
+          connectTimeoutMs: parsePositiveInt(redisLockRaw?.connectTimeoutMs) ?? 1_000,
         },
       }
       : undefined,

--- a/index.ts
+++ b/index.ts
@@ -5388,13 +5388,16 @@ export function parsePluginConfig(value: unknown): PluginConfig {
     ? lockingRaw.redis as Record<string, unknown>
     : null;
   const redisLockExplicitlyDisabled = redisLockRaw?.enabled === false;
-  const legacyRedisUrl = redisLockExplicitlyDisabled
+  const nestedRedisUrl = redisLockExplicitlyDisabled
+    ? undefined
+    : resolveOptionalEnvString(redisLockRaw?.url);
+  const legacyRedisUrl = redisLockExplicitlyDisabled || nestedRedisUrl
     ? undefined
     : resolveOptionalEnvString(cfg.redisUrl);
   const redisLockUrl = redisLockExplicitlyDisabled
     ? undefined
     : (
-        resolveOptionalEnvString(redisLockRaw?.url) ??
+        nestedRedisUrl ??
         legacyRedisUrl ??
         asNonEmptyString(process.env.MEMORY_LANCEDB_REDIS_URL)
       );

--- a/index.ts
+++ b/index.ts
@@ -2539,6 +2539,7 @@ const memoryLanceDBProPlugin = {
     // ========================================================================
     _registeredApis.add(api);    // claim before init (Phase 2 singleton guard)
     _registeredApisMap.set(api, true);  // dual-track: explicit claim for rollback
+    let registrationStopped = false;
     let singleton: typeof _singletonState;
     try {
       if (!_singletonState) { _singletonState = _initPluginState(api); }
@@ -5267,6 +5268,12 @@ const memoryLanceDBProPlugin = {
         }
       },
       stop: async () => {
+        if (registrationStopped) {
+          return;
+        }
+        registrationStopped = true;
+        _registeredApis.delete(api);
+        _registeredApisMap.delete(api);
         if (backupTimer) {
           clearInterval(backupTimer);
           backupTimer = null;
@@ -5279,16 +5286,16 @@ const memoryLanceDBProPlugin = {
           clearInterval(storageMaintenanceTimer);
           storageMaintenanceTimer = null;
         }
-        try {
-          await store.destroy();
-        } catch (err) {
-          api.logger.warn(`memory-lancedb-pro: stop cleanup failed: ${String(err)}`);
-        } finally {
-          if (_singletonState?.store === store) {
-            _singletonState = null;
+        if (_registeredApisMap.size === 0 && _singletonState?.store === store) {
+          try {
+            await store.destroy();
+          } catch (err) {
+            api.logger.warn(`memory-lancedb-pro: stop cleanup failed: ${String(err)}`);
+          } finally {
+            if (_singletonState?.store === store) {
+              _singletonState = null;
+            }
           }
-          _registeredApis.delete(api);
-          _registeredApisMap.delete(api);
         }
         api.logger.info("memory-lancedb-pro: stopped");
       },

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -258,7 +258,7 @@
                 "type": "integer",
                 "minimum": 1,
                 "default": 5000,
-                "description": "Maximum time to wait for the Redis lock before falling back to the file lock."
+                "description": "Maximum time to wait for the Redis lock before failing the write so the caller can retry later."
               },
               "retryDelayMs": {
                 "type": "integer",
@@ -1781,7 +1781,7 @@
     "locking.redis.acquireTimeoutMs": {
       "label": "Redis Lock Acquire Timeout",
       "placeholder": "5000",
-      "help": "Maximum time to wait for Redis lock acquisition before falling back to the file lock.",
+      "help": "Maximum time to wait for Redis lock acquisition before failing the write so the caller can retry later.",
       "advanced": true
     },
     "locking.redis.retryDelayMs": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -221,6 +221,61 @@
           }
         }
       },
+      "redisUrl": {
+        "type": "string",
+        "description": "Optional shortcut for enabling Redis distributed write locking. Prefer locking.redis.url for new configs."
+      },
+      "locking": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Optional external locking configuration for high-concurrency or multi-instance deployments.",
+        "properties": {
+          "redis": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Use Redis SET NX PX write locks before mutating LanceDB. Falls back to file lock when Redis is unavailable."
+              },
+              "url": {
+                "type": "string",
+                "description": "Redis connection URL. May include ${ENV_VAR} placeholders."
+              },
+              "keyPrefix": {
+                "type": "string",
+                "default": "memory-lancedb-pro:write-lock",
+                "description": "Prefix for Redis lock keys."
+              },
+              "ttlMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "default": 60000,
+                "description": "Redis lock TTL in milliseconds."
+              },
+              "acquireTimeoutMs": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 5000,
+                "description": "Maximum time to wait for the Redis lock before falling back to the file lock."
+              },
+              "retryDelayMs": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 50,
+                "description": "Initial Redis lock retry delay in milliseconds. Retries use exponential backoff."
+              },
+              "connectTimeoutMs": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 1000,
+                "description": "Redis connection timeout in milliseconds."
+              }
+            }
+          }
+        }
+      },
       "enableManagementTools": {
         "type": "boolean",
         "default": false,
@@ -1690,6 +1745,55 @@
       "label": "Storage Cleanup Initial Delay",
       "placeholder": "300000",
       "help": "Milliseconds to wait after startup before the first storage cleanup run.",
+      "advanced": true
+    },
+    "redisUrl": {
+      "label": "Redis Lock URL",
+      "placeholder": "redis://localhost:6379",
+      "help": "Shortcut for enabling Redis distributed write locking. Prefer locking.redis.url for new configs.",
+      "sensitive": true,
+      "advanced": true
+    },
+    "locking.redis.enabled": {
+      "label": "Redis Write Lock",
+      "help": "Use Redis distributed locks for LanceDB writes, with file-lock fallback if Redis is unavailable.",
+      "advanced": true
+    },
+    "locking.redis.url": {
+      "label": "Redis Lock URL",
+      "placeholder": "redis://localhost:6379",
+      "help": "Redis connection URL for distributed write locking. Supports ${ENV_VAR} placeholders.",
+      "sensitive": true,
+      "advanced": true
+    },
+    "locking.redis.keyPrefix": {
+      "label": "Redis Lock Key Prefix",
+      "placeholder": "memory-lancedb-pro:write-lock",
+      "help": "Prefix used for Redis lock keys. Change this when sharing Redis across unrelated deployments.",
+      "advanced": true
+    },
+    "locking.redis.ttlMs": {
+      "label": "Redis Lock TTL",
+      "placeholder": "60000",
+      "help": "Redis write lock TTL in milliseconds.",
+      "advanced": true
+    },
+    "locking.redis.acquireTimeoutMs": {
+      "label": "Redis Lock Acquire Timeout",
+      "placeholder": "5000",
+      "help": "Maximum time to wait for Redis lock acquisition before falling back to the file lock.",
+      "advanced": true
+    },
+    "locking.redis.retryDelayMs": {
+      "label": "Redis Lock Retry Delay",
+      "placeholder": "50",
+      "help": "Initial Redis lock retry delay in milliseconds; retries use exponential backoff.",
+      "advanced": true
+    },
+    "locking.redis.connectTimeoutMs": {
+      "label": "Redis Lock Connect Timeout",
+      "placeholder": "1000",
+      "help": "Redis connection timeout in milliseconds before falling back to the file lock.",
       "advanced": true
     },
     "smartExtraction": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -237,7 +237,7 @@
               "enabled": {
                 "type": "boolean",
                 "default": false,
-                "description": "Use Redis SET NX PX write locks before mutating LanceDB. Falls back to file lock when Redis is unavailable."
+                "description": "Use Redis SET NX PX write locks before mutating LanceDB. When enabled, Redis lock failures fail writes closed instead of falling back to local file locks."
               },
               "url": {
                 "type": "string",
@@ -1756,7 +1756,7 @@
     },
     "locking.redis.enabled": {
       "label": "Redis Write Lock",
-      "help": "Use Redis distributed locks for LanceDB writes, with file-lock fallback if Redis is unavailable.",
+      "help": "Use Redis distributed locks for LanceDB writes. When enabled, Redis lock failures fail writes closed instead of falling back to local file locks.",
       "advanced": true
     },
     "locking.redis.url": {
@@ -1793,7 +1793,7 @@
     "locking.redis.connectTimeoutMs": {
       "label": "Redis Lock Connect Timeout",
       "placeholder": "1000",
-      "help": "Redis connection timeout in milliseconds before falling back to the file lock.",
+      "help": "Redis connection timeout in milliseconds before Redis-locked writes fail closed.",
       "advanced": true
     },
     "smartExtraction": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@lancedb/lancedb": "^0.26.2",
         "@sinclair/typebox": "0.34.48",
         "apache-arrow": "18.1.0",
-        "ioredis": "^5.11.1",
         "json5": "^2.2.3",
         "openai": "^6.21.0",
         "proper-lockfile": "^4.1.2"
@@ -27,14 +26,16 @@
         "@lancedb/lancedb-darwin-x64": "^0.26.2",
         "@lancedb/lancedb-linux-arm64-gnu": "^0.26.2",
         "@lancedb/lancedb-linux-x64-gnu": "^0.26.2",
-        "@lancedb/lancedb-win32-x64-msvc": "^0.26.2"
+        "@lancedb/lancedb-win32-x64-msvc": "^0.26.2",
+        "ioredis": "^5.11.1"
       }
     },
     "node_modules/@ioredis/commands": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
       "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@lancedb/lancedb": {
       "version": "0.26.2",
@@ -300,6 +301,7 @@
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
       "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -385,6 +387,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -402,6 +405,7 @@
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -444,6 +448,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
       "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ioredis/commands": "1.10.0",
         "cluster-key-slot": "1.1.1",
@@ -501,7 +506,8 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/openai": {
       "version": "6.22.0",
@@ -540,6 +546,7 @@
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -549,6 +556,7 @@
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "redis-errors": "^1.0.0"
       },
@@ -581,7 +589,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@lancedb/lancedb": "^0.26.2",
         "@sinclair/typebox": "0.34.48",
         "apache-arrow": "18.1.0",
+        "ioredis": "^5.11.1",
         "json5": "^2.2.3",
         "openai": "^6.21.0",
         "proper-lockfile": "^4.1.2"
@@ -28,6 +29,12 @@
         "@lancedb/lancedb-linux-x64-gnu": "^0.26.2",
         "@lancedb/lancedb-win32-x64-msvc": "^0.26.2"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "license": "MIT"
     },
     "node_modules/@lancedb/lancedb": {
       "version": "0.26.2",
@@ -288,6 +295,15 @@
         "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -364,6 +380,32 @@
         "node": ">=20"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/find-replace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
@@ -395,6 +437,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/jiti": {
@@ -433,6 +497,12 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/openai": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.22.0.tgz",
@@ -465,6 +535,27 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -485,6 +576,12 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@lancedb/lancedb": "^0.26.2",
     "@sinclair/typebox": "0.34.48",
     "apache-arrow": "18.1.0",
-    "ioredis": "^5.11.1",
     "json5": "^2.2.3",
     "openai": "^6.21.0",
     "proper-lockfile": "^4.1.2"
@@ -66,7 +65,8 @@
     "@lancedb/lancedb-darwin-x64": "^0.26.2",
     "@lancedb/lancedb-linux-arm64-gnu": "^0.26.2",
     "@lancedb/lancedb-linux-x64-gnu": "^0.26.2",
-    "@lancedb/lancedb-win32-x64-msvc": "^0.26.2"
+    "@lancedb/lancedb-win32-x64-msvc": "^0.26.2",
+    "ioredis": "^5.11.1"
   },
   "devDependencies": {
     "commander": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@lancedb/lancedb": "^0.26.2",
     "@sinclair/typebox": "0.34.48",
     "apache-arrow": "18.1.0",
+    "ioredis": "^5.11.1",
     "json5": "^2.2.3",
     "openai": "^6.21.0",
     "proper-lockfile": "^4.1.2"

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -57,6 +57,7 @@ export const CI_TEST_MANIFEST = [
   { group: "packaging-and-workflow", runner: "node", file: "test/workflow-fork-guards.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/clawteam-scope.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/cross-process-lock.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/redis-lock.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/lock-stress-test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/lock-release-on-error.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/preference-slots.test.mjs", args: ["--test"] },

--- a/src/redis-lock.ts
+++ b/src/redis-lock.ts
@@ -77,6 +77,7 @@ function sleep(ms: number): Promise<void> {
 export class RedisLockManager {
   private readonly config: Required<Omit<RedisLockConfig, "url" | "onWarning">> & Pick<RedisLockConfig, "url" | "onWarning">;
   private clientPromise: Promise<RedisClientLike> | null = null;
+  private isClosed = false;
 
   constructor(config: RedisLockConfig, private readonly injectedClient?: RedisClientLike) {
     this.config = {
@@ -92,9 +93,9 @@ export class RedisLockManager {
   }
 
   async withLock<T>(resource: string, fn: () => Promise<T>): Promise<T> {
+    const key = this.makeKey(resource);
     const client = await this.getClient();
     this.assertClientSupportsLocking(client);
-    const key = this.makeKey(resource);
     const token = randomUUID();
 
     await this.acquire(client, key, token);
@@ -111,7 +112,7 @@ export class RedisLockManager {
         { cause: error },
       );
     };
-    const renewIntervalMs = Math.max(1, Math.floor(this.config.ttlMs / 3));
+    const renewIntervalMs = Math.max(100, Math.floor(this.config.ttlMs / 5));
     const renewTimer = setInterval(() => {
       void this.renew(client, key, token).then((renewed) => {
         if (renewed === false) {
@@ -162,6 +163,7 @@ export class RedisLockManager {
   }
 
   async close(): Promise<void> {
+    this.isClosed = true;
     if (!this.clientPromise) return;
 
     const client = await this.clientPromise.catch(() => null);
@@ -178,6 +180,9 @@ export class RedisLockManager {
   }
 
   private async getClient(): Promise<RedisClientLike> {
+    if (this.isClosed) {
+      throw new RedisLockUnavailableError("Redis lock manager has been closed");
+    }
     if (this.injectedClient) return this.injectedClient;
     if (!this.config.url) {
       throw new RedisLockUnavailableError("Redis lock is enabled but no Redis URL was configured");
@@ -212,6 +217,9 @@ export class RedisLockManager {
       return client;
     } catch (err) {
       this.clientPromise = null;
+      this.config.onWarning?.(
+        `memory-lancedb-pro: Redis lock connection failed; using file lock when available: ${String(err)}`,
+      );
       throw new RedisLockUnavailableError(
         `Redis lock connection failed: ${err instanceof Error ? err.message : String(err)}`,
         { cause: err as Error },
@@ -220,7 +228,10 @@ export class RedisLockManager {
   }
 
   private makeKey(resource: string): string {
-    const digest = createHash("sha256").update(resource || "default").digest("hex");
+    if (typeof resource !== "string" || resource.length === 0) {
+      throw new RedisLockAcquisitionError("Redis lock resource must be a non-empty string");
+    }
+    const digest = createHash("sha256").update(resource).digest("hex");
     return `${this.config.keyPrefix}:${digest}`;
   }
 
@@ -245,10 +256,8 @@ export class RedisLockManager {
         lastError = err;
       }
 
-      const delayMs = Math.min(
-        this.config.retryDelayMs * 2 ** attempt,
-        Math.max(this.config.retryDelayMs, 1_000),
-      );
+      const maxDelayMs = Math.max(this.config.retryDelayMs, 100);
+      const delayMs = Math.min(this.config.retryDelayMs * 2 ** attempt, maxDelayMs);
       attempt += 1;
       await sleep(Math.min(delayMs, Math.max(0, deadline - Date.now())));
     }

--- a/src/redis-lock.ts
+++ b/src/redis-lock.ts
@@ -165,9 +165,9 @@ export class RedisLockManager {
     }, renewIntervalMs);
     if (typeof renewTimer.unref === "function") renewTimer.unref();
 
+    let callbackError: unknown;
     try {
       let result: T;
-      let callbackError: unknown;
       try {
         result = await fn();
       } catch (err) {
@@ -189,8 +189,17 @@ export class RedisLockManager {
     } finally {
       clearInterval(renewTimer);
       try {
-        await client.eval(RELEASE_SCRIPT, 1, key, token);
+        const releaseResult = await client.eval(RELEASE_SCRIPT, 1, key, token);
+        if (releaseResult !== 1) {
+          throwPostWriteLeaseError(
+            new RedisLockLeaseLostError(`Redis lock ${key} was no longer owned by this writer at release`),
+            callbackError,
+          );
+        }
       } catch (err) {
+        if (err instanceof RedisLockLeaseIntegrityError) {
+          throw err;
+        }
         this.config.onWarning?.(
           `memory-lancedb-pro: Redis lock release failed for ${key}; lock will expire by TTL: ${String(err)}`,
         );

--- a/src/redis-lock.ts
+++ b/src/redis-lock.ts
@@ -40,6 +40,13 @@ export class RedisLockLeaseLostError extends Error {
   }
 }
 
+export class RedisLockLeaseIntegrityError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RedisLockLeaseIntegrityError";
+  }
+}
+
 const DEFAULT_KEY_PREFIX = "memory-lancedb-pro:write-lock";
 const DEFAULT_TTL_MS = 60_000;
 const DEFAULT_ACQUIRE_TIMEOUT_MS = 5_000;
@@ -93,38 +100,55 @@ export class RedisLockManager {
     await this.acquire(client, key, token);
 
     let leaseLost: RedisLockLeaseLostError | null = null;
-    let rejectLeaseLost: (error: RedisLockLeaseLostError) => void = () => {};
-    const leaseLostPromise = new Promise<never>((_resolve, reject) => {
-      rejectLeaseLost = reject;
-    });
+    let leaseExpiresAt = Date.now() + this.config.ttlMs;
     const markLeaseLost = (error: RedisLockLeaseLostError) => {
       if (leaseLost) return;
       leaseLost = error;
-      rejectLeaseLost(error);
     };
-    const renewIntervalMs = Math.max(1, Math.floor(this.config.ttlMs / 2));
+    const throwPostWriteLeaseError = (error: RedisLockLeaseLostError): never => {
+      throw new RedisLockLeaseIntegrityError(
+        `Redis lock ${key} was lost before the write settled; the write outcome is ambiguous and must not be retried automatically`,
+        { cause: error },
+      );
+    };
+    const renewIntervalMs = Math.max(1, Math.floor(this.config.ttlMs / 3));
     const renewTimer = setInterval(() => {
-      void this.renew(client, key, token).catch((err) => {
-        markLeaseLost(
-          new RedisLockLeaseLostError(
-            `Redis lock renewal failed for ${key}: ${err instanceof Error ? err.message : String(err)}`,
-            { cause: err as Error },
-          ),
-        );
-      }).then((renewed) => {
+      void this.renew(client, key, token).then((renewed) => {
         if (renewed === false) {
           markLeaseLost(
             new RedisLockLeaseLostError(`Redis lock ${key} is no longer owned by this writer`),
           );
+          return;
         }
+        leaseExpiresAt = Date.now() + this.config.ttlMs;
+      }).catch((err) => {
+        if (Date.now() >= leaseExpiresAt) {
+          markLeaseLost(
+            new RedisLockLeaseLostError(
+              `Redis lock renewal failed for ${key} before the lease could be extended: ${err instanceof Error ? err.message : String(err)}`,
+              { cause: err as Error },
+            ),
+          );
+          return;
+        }
+        this.config.onWarning?.(
+          `memory-lancedb-pro: transient Redis lock renewal failure for ${key}; retrying before TTL expiry: ${String(err)}`,
+        );
       });
     }, renewIntervalMs);
     if (typeof renewTimer.unref === "function") renewTimer.unref();
 
     try {
-      const operation = fn();
-      operation.catch(() => {});
-      return await Promise.race([operation, leaseLostPromise]);
+      const result = await fn();
+      if (leaseLost) {
+        throwPostWriteLeaseError(leaseLost);
+      }
+      if (Date.now() >= leaseExpiresAt) {
+        throwPostWriteLeaseError(
+          new RedisLockLeaseLostError(`Redis lock ${key} expired before the write settled`),
+        );
+      }
+      return result;
     } finally {
       clearInterval(renewTimer);
       try {

--- a/src/redis-lock.ts
+++ b/src/redis-lock.ts
@@ -97,19 +97,23 @@ export class RedisLockManager {
     if (this.isClosed) {
       throw new RedisLockUnavailableError("Redis lock manager has been closed");
     }
-    const key = this.makeKey(resource);
-    const client = await this.getClient();
-    this.assertClientSupportsLocking(client);
-    const token = randomUUID();
-
-    await this.acquire(client, key, token);
-    const activeLock = this.runLockedCallback(client, key, token, fn);
+    const activeLock = this.runLockLifecycle(resource, fn);
     this.activeLocks.add(activeLock);
     try {
       return await activeLock;
     } finally {
       this.activeLocks.delete(activeLock);
     }
+  }
+
+  private async runLockLifecycle<T>(resource: string, fn: () => Promise<T>): Promise<T> {
+    const key = this.makeKey(resource);
+    const client = await this.getClient();
+    this.assertClientSupportsLocking(client);
+    const token = randomUUID();
+
+    await this.acquire(client, key, token);
+    return this.runLockedCallback(client, key, token, fn);
   }
 
   private async runLockedCallback<T>(
@@ -125,9 +129,12 @@ export class RedisLockManager {
       if (leaseLost) return;
       leaseLost = error;
     };
-    const throwPostWriteLeaseError = (error: RedisLockLeaseLostError): never => {
+    const throwPostWriteLeaseError = (error: RedisLockLeaseLostError, callbackError?: unknown): never => {
+      const callbackDetail = callbackError
+        ? `; callback also failed: ${callbackError instanceof Error ? callbackError.message : String(callbackError)}`
+        : "";
       throw new RedisLockLeaseIntegrityError(
-        `Redis lock ${key} was lost before the write settled; the write outcome is ambiguous and must not be retried automatically`,
+        `Redis lock ${key} was lost before the write settled; the write outcome is ambiguous and must not be retried automatically${callbackDetail}`,
         { cause: error },
       );
     };
@@ -159,14 +166,24 @@ export class RedisLockManager {
     if (typeof renewTimer.unref === "function") renewTimer.unref();
 
     try {
-      const result = await fn();
+      let result: T;
+      let callbackError: unknown;
+      try {
+        result = await fn();
+      } catch (err) {
+        callbackError = err;
+      }
       if (leaseLost) {
-        throwPostWriteLeaseError(leaseLost);
+        throwPostWriteLeaseError(leaseLost, callbackError);
       }
       if (Date.now() >= leaseExpiresAt) {
         throwPostWriteLeaseError(
           new RedisLockLeaseLostError(`Redis lock ${key} expired before the write settled`),
+          callbackError,
         );
+      }
+      if (callbackError) {
+        throw callbackError;
       }
       return result;
     } finally {

--- a/src/redis-lock.ts
+++ b/src/redis-lock.ts
@@ -78,6 +78,7 @@ export class RedisLockManager {
   private readonly config: Required<Omit<RedisLockConfig, "url" | "onWarning">> & Pick<RedisLockConfig, "url" | "onWarning">;
   private clientPromise: Promise<RedisClientLike> | null = null;
   private isClosed = false;
+  private readonly activeLocks = new Set<Promise<unknown>>();
 
   constructor(config: RedisLockConfig, private readonly injectedClient?: RedisClientLike) {
     this.config = {
@@ -93,12 +94,30 @@ export class RedisLockManager {
   }
 
   async withLock<T>(resource: string, fn: () => Promise<T>): Promise<T> {
+    if (this.isClosed) {
+      throw new RedisLockUnavailableError("Redis lock manager has been closed");
+    }
     const key = this.makeKey(resource);
     const client = await this.getClient();
     this.assertClientSupportsLocking(client);
     const token = randomUUID();
 
     await this.acquire(client, key, token);
+    const activeLock = this.runLockedCallback(client, key, token, fn);
+    this.activeLocks.add(activeLock);
+    try {
+      return await activeLock;
+    } finally {
+      this.activeLocks.delete(activeLock);
+    }
+  }
+
+  private async runLockedCallback<T>(
+    client: RedisClientLike,
+    key: string,
+    token: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
 
     let leaseLost: RedisLockLeaseLostError | null = null;
     let leaseExpiresAt = Date.now() + this.config.ttlMs;
@@ -164,10 +183,15 @@ export class RedisLockManager {
 
   async close(): Promise<void> {
     this.isClosed = true;
-    if (!this.clientPromise) return;
+    if (this.activeLocks.size > 0) {
+      await Promise.allSettled([...this.activeLocks]);
+    }
+    if (!this.injectedClient && !this.clientPromise) return;
 
-    const client = await this.clientPromise.catch(() => null);
-    this.clientPromise = null;
+    const client = this.injectedClient ?? (await this.clientPromise?.catch(() => null));
+    if (!this.injectedClient) {
+      this.clientPromise = null;
+    }
     if (!client) return;
 
     if (typeof client.quit === "function") {

--- a/src/redis-lock.ts
+++ b/src/redis-lock.ts
@@ -242,7 +242,7 @@ export class RedisLockManager {
     } catch (err) {
       this.clientPromise = null;
       this.config.onWarning?.(
-        `memory-lancedb-pro: Redis lock connection failed; using file lock when available: ${String(err)}`,
+        `memory-lancedb-pro: Redis lock connection failed; writes will fail closed until Redis locking is available: ${String(err)}`,
       );
       throw new RedisLockUnavailableError(
         `Redis lock connection failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/redis-lock.ts
+++ b/src/redis-lock.ts
@@ -1,0 +1,247 @@
+import { createHash, randomUUID } from "node:crypto";
+
+export interface RedisLockConfig {
+  enabled?: boolean;
+  url?: string;
+  keyPrefix?: string;
+  ttlMs?: number;
+  acquireTimeoutMs?: number;
+  retryDelayMs?: number;
+  connectTimeoutMs?: number;
+  onWarning?: (message: string) => void;
+}
+
+export interface RedisClientLike {
+  set(...args: unknown[]): Promise<unknown>;
+  eval(...args: unknown[]): Promise<unknown>;
+  connect?(): Promise<unknown>;
+  quit?(): Promise<unknown>;
+  disconnect?(): void;
+}
+
+export class RedisLockUnavailableError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RedisLockUnavailableError";
+  }
+}
+
+export class RedisLockAcquisitionError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RedisLockAcquisitionError";
+  }
+}
+
+export class RedisLockLeaseLostError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RedisLockLeaseLostError";
+  }
+}
+
+const DEFAULT_KEY_PREFIX = "memory-lancedb-pro:write-lock";
+const DEFAULT_TTL_MS = 60_000;
+const DEFAULT_ACQUIRE_TIMEOUT_MS = 5_000;
+const DEFAULT_RETRY_DELAY_MS = 50;
+const DEFAULT_CONNECT_TIMEOUT_MS = 1_000;
+const RELEASE_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+end
+return 0
+`;
+const RENEW_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("pexpire", KEYS[1], ARGV[2])
+end
+return 0
+`;
+
+function clampPositiveInt(value: number | undefined, fallback: number): number {
+  if (!Number.isFinite(value) || value === undefined || value <= 0) return fallback;
+  return Math.floor(value);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class RedisLockManager {
+  private readonly config: Required<Omit<RedisLockConfig, "url" | "onWarning">> & Pick<RedisLockConfig, "url" | "onWarning">;
+  private clientPromise: Promise<RedisClientLike> | null = null;
+
+  constructor(config: RedisLockConfig, private readonly injectedClient?: RedisClientLike) {
+    this.config = {
+      enabled: config.enabled ?? true,
+      url: config.url,
+      keyPrefix: config.keyPrefix || DEFAULT_KEY_PREFIX,
+      ttlMs: clampPositiveInt(config.ttlMs, DEFAULT_TTL_MS),
+      acquireTimeoutMs: clampPositiveInt(config.acquireTimeoutMs, DEFAULT_ACQUIRE_TIMEOUT_MS),
+      retryDelayMs: clampPositiveInt(config.retryDelayMs, DEFAULT_RETRY_DELAY_MS),
+      connectTimeoutMs: clampPositiveInt(config.connectTimeoutMs, DEFAULT_CONNECT_TIMEOUT_MS),
+      onWarning: config.onWarning,
+    };
+  }
+
+  async withLock<T>(resource: string, fn: () => Promise<T>): Promise<T> {
+    const client = await this.getClient();
+    this.assertClientSupportsLocking(client);
+    const key = this.makeKey(resource);
+    const token = randomUUID();
+
+    await this.acquire(client, key, token);
+
+    let leaseLost: RedisLockLeaseLostError | null = null;
+    let rejectLeaseLost: (error: RedisLockLeaseLostError) => void = () => {};
+    const leaseLostPromise = new Promise<never>((_resolve, reject) => {
+      rejectLeaseLost = reject;
+    });
+    const markLeaseLost = (error: RedisLockLeaseLostError) => {
+      if (leaseLost) return;
+      leaseLost = error;
+      rejectLeaseLost(error);
+    };
+    const renewIntervalMs = Math.max(1, Math.floor(this.config.ttlMs / 2));
+    const renewTimer = setInterval(() => {
+      void this.renew(client, key, token).catch((err) => {
+        markLeaseLost(
+          new RedisLockLeaseLostError(
+            `Redis lock renewal failed for ${key}: ${err instanceof Error ? err.message : String(err)}`,
+            { cause: err as Error },
+          ),
+        );
+      }).then((renewed) => {
+        if (renewed === false) {
+          markLeaseLost(
+            new RedisLockLeaseLostError(`Redis lock ${key} is no longer owned by this writer`),
+          );
+        }
+      });
+    }, renewIntervalMs);
+    if (typeof renewTimer.unref === "function") renewTimer.unref();
+
+    try {
+      const operation = fn();
+      operation.catch(() => {});
+      return await Promise.race([operation, leaseLostPromise]);
+    } finally {
+      clearInterval(renewTimer);
+      try {
+        await client.eval(RELEASE_SCRIPT, 1, key, token);
+      } catch (err) {
+        this.config.onWarning?.(
+          `memory-lancedb-pro: Redis lock release failed for ${key}; lock will expire by TTL: ${String(err)}`,
+        );
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    if (!this.clientPromise) return;
+
+    const client = await this.clientPromise.catch(() => null);
+    this.clientPromise = null;
+    if (!client) return;
+
+    if (typeof client.quit === "function") {
+      await client.quit().catch(() => {
+        client.disconnect?.();
+      });
+      return;
+    }
+    client.disconnect?.();
+  }
+
+  private async getClient(): Promise<RedisClientLike> {
+    if (this.injectedClient) return this.injectedClient;
+    if (!this.config.url) {
+      throw new RedisLockUnavailableError("Redis lock is enabled but no Redis URL was configured");
+    }
+    if (!this.clientPromise) {
+      this.clientPromise = this.createClient();
+    }
+    return this.clientPromise;
+  }
+
+  private async createClient(): Promise<RedisClientLike> {
+    try {
+      const mod = await import("ioredis");
+      type RedisConstructor = new (url: string, options?: Record<string, unknown>) => RedisClientLike;
+      const redisModule = mod as unknown as {
+        default?: RedisConstructor;
+        Redis?: RedisConstructor;
+      };
+      const Redis = redisModule.default ?? redisModule.Redis;
+      if (!Redis) {
+        throw new Error("ioredis did not export a Redis constructor");
+      }
+      const client = new Redis(this.config.url!, {
+        connectTimeout: this.config.connectTimeoutMs,
+        enableOfflineQueue: false,
+        lazyConnect: true,
+        maxRetriesPerRequest: 1,
+      });
+      if (typeof client.connect === "function") {
+        await client.connect();
+      }
+      return client;
+    } catch (err) {
+      this.clientPromise = null;
+      throw new RedisLockUnavailableError(
+        `Redis lock connection failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err as Error },
+      );
+    }
+  }
+
+  private makeKey(resource: string): string {
+    const digest = createHash("sha256").update(resource || "default").digest("hex");
+    return `${this.config.keyPrefix}:${digest}`;
+  }
+
+  private assertClientSupportsLocking(client: RedisClientLike): void {
+    if (typeof client.set !== "function" || typeof client.eval !== "function") {
+      throw new RedisLockUnavailableError(
+        "Redis lock client does not provide required SET/EVAL commands",
+      );
+    }
+  }
+
+  private async acquire(client: RedisClientLike, key: string, token: string): Promise<void> {
+    const deadline = Date.now() + this.config.acquireTimeoutMs;
+    let attempt = 0;
+    let lastError: unknown;
+
+    while (Date.now() <= deadline) {
+      try {
+        const result = await client.set(key, token, "PX", this.config.ttlMs, "NX");
+        if (result === "OK") return;
+      } catch (err) {
+        lastError = err;
+      }
+
+      const delayMs = Math.min(
+        this.config.retryDelayMs * 2 ** attempt,
+        Math.max(this.config.retryDelayMs, 1_000),
+      );
+      attempt += 1;
+      await sleep(Math.min(delayMs, Math.max(0, deadline - Date.now())));
+    }
+
+    if (lastError) {
+      throw new RedisLockAcquisitionError(
+        `Timed out acquiring Redis lock ${key} after ${this.config.acquireTimeoutMs}ms; last Redis error: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+        { cause: lastError as Error },
+      );
+    }
+    throw new RedisLockAcquisitionError(
+      `Timed out acquiring Redis lock ${key} after ${this.config.acquireTimeoutMs}ms`,
+    );
+  }
+
+  private async renew(client: RedisClientLike, key: string, token: string): Promise<boolean> {
+    const result = await client.eval(RENEW_SCRIPT, 1, key, token, String(this.config.ttlMs));
+    return result === 1;
+  }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -699,14 +699,12 @@ export class MemoryStore {
     try {
       return await this.redisLock.withLock(this.config.dbPath, fn);
     } catch (err) {
-      if (!(err instanceof RedisLockUnavailableError)) {
-        throw err;
+      if (err instanceof RedisLockUnavailableError) {
+        this.config.onLockWarning?.(
+          `memory-lancedb-pro: Redis write lock unavailable; write failed closed to preserve Redis lock-domain isolation: ${err.message}`,
+        );
       }
-
-      this.config.onLockWarning?.(
-        `memory-lancedb-pro: Redis write lock unavailable; falling back to file lock: ${err.message}`,
-      );
-      return this.runWithFileLock(fn);
+      throw err;
     }
   }
 
@@ -766,7 +764,7 @@ export class MemoryStore {
     const mods = this.dataModsSinceIndexFold;
     this.dataModsSinceIndexFold = 0;
     try {
-      await this.runWithFileLock(async () => {
+      await this.runWithWriteLock(async () => {
         await this.table!.optimize({ cleanupOlderThan: new Date(0) });
       });
       console.log(

--- a/src/store.ts
+++ b/src/store.ts
@@ -735,7 +735,7 @@ export class MemoryStore {
     const safeRetentionDays = clampInt(retentionDays, 1, 3650);
     const cleanupOlderThan = new Date(Date.now() - safeRetentionDays * 24 * 60 * 60 * 1000);
 
-    return this.runWithFileLock(async () => {
+    return this.runWithWriteLock(async () => {
       if (!this.table || typeof this.table.optimize !== "function") {
         throw new Error("LanceDB table.optimize() is not available in this runtime");
       }

--- a/src/store.ts
+++ b/src/store.ts
@@ -28,6 +28,11 @@ import {
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { matchesMemoryCategoryFilter, resolveCategoryFilterCandidates } from "./memory-categories.js";
+import {
+  RedisLockManager,
+  RedisLockUnavailableError,
+  type RedisLockConfig,
+} from "./redis-lock.js";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
 
 // ============================================================================
@@ -55,7 +60,9 @@ export interface StoreConfig {
   vectorDim: number;
   /** Disable LanceDB native vector search and rank scanned rows with JS cosine. */
   disableNativeCosine?: boolean;
+  redisLock?: RedisLockConfig;
   onStoragePathWarning?: (message: string) => void;
+  onLockWarning?: (message: string) => void;
 }
 
 export interface StorageMaintenanceResult {
@@ -544,6 +551,7 @@ export class MemoryStore {
 
   private readonly config: StoreConfig;
   private readonly disableNativeCosine: boolean;
+  private redisLock: RedisLockManager | null = null;
 
   constructor(config: StoreConfig) {
     const envDisablesNativeCosine = parseBooleanEnvFlag(process.env.MEMORY_LANCEDB_DISABLE_NATIVE_COSINE);
@@ -552,6 +560,18 @@ export class MemoryStore {
       dbPath: normalizeStoragePath(config.dbPath),
     };
     this.disableNativeCosine = config.disableNativeCosine === true || envDisablesNativeCosine;
+    if (config.redisLock?.enabled === true) {
+      if (config.redisLock.url) {
+        this.redisLock = new RedisLockManager({
+          ...config.redisLock,
+          onWarning: config.onLockWarning,
+        });
+      } else {
+        config.onLockWarning?.(
+          "memory-lancedb-pro: Redis lock is enabled but no Redis URL is configured; using file lock",
+        );
+      }
+    }
   }
 
   private async runWithFileLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -668,6 +688,36 @@ export class MemoryStore {
           `Callers must not retry this operation automatically.`,
         );
       }
+    }
+  }
+
+  private async runWithWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+    if (!this.redisLock) {
+      return this.runWithFileLock(fn);
+    }
+
+    try {
+      return await this.redisLock.withLock(this.config.dbPath, fn);
+    } catch (err) {
+      if (!(err instanceof RedisLockUnavailableError)) {
+        throw err;
+      }
+
+      this.config.onLockWarning?.(
+        `memory-lancedb-pro: Redis write lock unavailable; falling back to file lock: ${err.message}`,
+      );
+      return this.runWithFileLock(fn);
+    }
+  }
+
+  private async closeLockResources(): Promise<void> {
+    if (!this.redisLock) return;
+    try {
+      await this.redisLock.close();
+    } catch (err) {
+      this.config.onLockWarning?.(
+        `memory-lancedb-pro: failed to close Redis lock client: ${String(err)}`,
+      );
     }
   }
 
@@ -913,7 +963,7 @@ export class MemoryStore {
     try {
       let normalizedCount = 0;
 
-      await this.runWithFileLock(async () => {
+      await this.runWithWriteLock(async () => {
         const candidateRows = await table.query()
           .where(
             `(timestamp > 0 AND timestamp < ${LEGACY_SECONDS_TIMESTAMP_MAX}) OR ` +
@@ -1052,7 +1102,7 @@ export class MemoryStore {
   async upsert(entry: MemoryEntry): Promise<MemoryEntry> {
     await this.ensureInitialized();
 
-    const result = await this.runWithFileLock(() => this.runSerializedUpdate(async () => {
+    const result = await this.runWithWriteLock(() => this.runSerializedUpdate(async () => {
       const safeId = escapeSqlLiteral(entry.id);
       await this.table!.delete(`id = '${safeId}'`).catch(() => undefined);
       const normalizedEntry: MemoryEntry = {
@@ -1221,7 +1271,7 @@ export class MemoryStore {
         const chunk = allEntries.slice(i, i + MemoryStore.MAX_BATCH_SIZE);
         const chunkIdx = Math.floor(i / MemoryStore.MAX_BATCH_SIZE);
         try {
-          await this.runWithFileLock(async () => {
+          await this.runWithWriteLock(async () => {
             await this.table!.add(chunk);
           });
           this.noteDataModification();
@@ -1377,6 +1427,7 @@ export class MemoryStore {
     // 1. destroy() 自己有錯 + lastBackgroundError 也有值 → composite error（兩個都保留）
     // 2. 只有 destroy() 自己有錯 → 只 throw destroy 的錯誤
     // 3. 只有 lastBackgroundError 有值 → throw timer 歷史錯誤
+    let destroyError: Error | null = null;
     if (result.hasError && result.lastError) {
       if (this.lastBackgroundError?.hasError) {
         // 情境 1：兩個錯誤都保留，包成 composite error
@@ -1388,18 +1439,24 @@ export class MemoryStore {
           `destroy flush failed (${result.lastError.message}); background flush also failed: ${timerError.message}`,
           { cause: result.lastError }
         );
-        throw compositeError;
+        destroyError = compositeError;
+      } else {
+        // 情境 2：只有 destroy 自己有錯
+        destroyError = result.lastError;
       }
-      // 情境 2：只有 destroy 自己有錯
-      throw result.lastError;
     }
 
     // 【F1 fix】檢查 lastBackgroundError（timers 錯誤的最後堡壘）
     // 情境 3：只有 lastBackgroundError 有值
-    if (this.lastBackgroundError?.hasError) {
+    if (!destroyError && this.lastBackgroundError?.hasError) {
       const err = this.lastBackgroundError.lastError ?? new Error("background flush failed");
       this.lastBackgroundError = null;
-      throw err;
+      destroyError = err;
+    }
+
+    await this.closeLockResources();
+    if (destroyError) {
+      throw destroyError;
     }
   }
 
@@ -1430,7 +1487,7 @@ export class MemoryStore {
       metadata: entry.metadata || "{}",
     };
 
-    return this.runWithFileLock(async () => {
+    return this.runWithWriteLock(async () => {
       await this.table!.add([full]);
       return full;
     });
@@ -1520,7 +1577,7 @@ export class MemoryStore {
       throw new Error(`Memory ${id} is outside accessible scopes`);
     }
 
-    return this.runWithFileLock(async () => {
+    return this.runWithWriteLock(async () => {
       await this.table!.delete(`id = '${safeId}'`);
       return true;
     });
@@ -1827,7 +1884,7 @@ export class MemoryStore {
       throw new Error(`Memory ${resolvedId} is outside accessible scopes`);
     }
 
-    return this.runWithFileLock(async () => {
+    return this.runWithWriteLock(async () => {
       await this.table!.delete(`id = '${resolvedId}'`);
       return true;
     });
@@ -1991,7 +2048,7 @@ export class MemoryStore {
       }));
     }
 
-    return this.runWithFileLock(() => this.runSerializedUpdate(async () => {
+    return this.runWithWriteLock(() => this.runSerializedUpdate(async () => {
       const results = new Map<number, MemoryBulkUpdateResult>();
       const pending: Array<{ inputIndex: number; id: string; updates: MemoryUpdatePatch }> = [];
       const seenIds = new Set<string>();
@@ -2180,7 +2237,7 @@ export class MemoryStore {
       throw new Error(`Memory ${id} is outside accessible scopes`);
     }
 
-    return this.runWithFileLock(() => this.runSerializedUpdate(async () => {
+    return this.runWithWriteLock(() => this.runSerializedUpdate(async () => {
       // Support full UUID, short hex prefixes, and constrained exact legacy IDs imported
       // from older stores (for example "mem-md-..." or "data-pointer-...").
       const uuidRegex =
@@ -2358,7 +2415,7 @@ export class MemoryStore {
 
     const whereClause = conditions.join(" AND ");
 
-    return this.runWithFileLock(async () => {
+    return this.runWithWriteLock(async () => {
       // Count first
       const countResults = await this.table!.query().where(whereClause).toArray();
       const deleteCount = countResults.length;

--- a/src/store.ts
+++ b/src/store.ts
@@ -29,7 +29,10 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { matchesMemoryCategoryFilter, resolveCategoryFilterCandidates } from "./memory-categories.js";
 import {
+  RedisLockAcquisitionError,
+  RedisLockLeaseIntegrityError,
   RedisLockManager,
+  RedisLockUnavailableError,
   type RedisLockConfig,
 } from "./redis-lock.js";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
@@ -833,76 +836,7 @@ export class MemoryStore {
       );
     }
 
-    let table: LanceDB.Table;
-
-    // Idempotent table init: try openTable first, create only if missing,
-    // and handle the race where tableNames() misses an existing table but
-    // createTable then sees it (LanceDB eventual consistency).
-    try {
-      table = await db.openTable(TABLE_NAME);
-
-      // Migrate legacy tables: add missing columns for backward compatibility
-      try {
-        const schema = await table.schema();
-        const fieldNames = new Set(schema.fields.map((f: { name: string }) => f.name));
-
-        const missingColumns: Array<{ name: string; valueSql: string }> = [];
-        if (!fieldNames.has("scope")) {
-          missingColumns.push({ name: "scope", valueSql: "'global'" });
-        }
-        if (!fieldNames.has("timestamp")) {
-          missingColumns.push({ name: "timestamp", valueSql: "CAST(0 AS DOUBLE)" });
-        }
-        if (!fieldNames.has("metadata")) {
-          missingColumns.push({ name: "metadata", valueSql: "'{}'" });
-        }
-
-        if (missingColumns.length > 0) {
-          console.warn(
-            `memory-lancedb-pro: migrating legacy table — adding columns: ${missingColumns.map((c) => c.name).join(", ")}`,
-          );
-          await table.addColumns(missingColumns);
-          console.log(
-            `memory-lancedb-pro: migration complete — ${missingColumns.length} column(s) added`,
-          );
-        }
-      } catch (err) {
-        const msg = String(err);
-        if (msg.includes("already exists")) {
-          // Concurrent initialization race — another process already added the columns
-          console.log("memory-lancedb-pro: migration columns already exist (concurrent init)");
-        } else {
-          console.warn("memory-lancedb-pro: could not check/migrate table schema:", err);
-        }
-      }
-    } catch (_openErr) {
-      // Table doesn't exist yet — create it
-      const schemaEntry: MemoryEntry = {
-        id: "__schema__",
-        text: "",
-        vector: Array.from({ length: this.config.vectorDim }).fill(
-          0,
-        ) as number[],
-        category: "other",
-        scope: "global",
-        importance: 0,
-        timestamp: 0,
-        metadata: "{}",
-      };
-
-      try {
-        table = await db.createTable(TABLE_NAME, [schemaEntry]);
-        await table.delete('id = "__schema__"');
-      } catch (createErr) {
-        // Race: another caller (or eventual consistency) created the table
-        // between our failed openTable and this createTable — just open it.
-        if (String(createErr).includes("already exists")) {
-          table = await db.openTable(TABLE_NAME);
-        } else {
-          throw createErr;
-        }
-      }
-    }
+    const table = await this.openOrCreateMemoryTable(db);
 
     await this.backfillLegacySecondTimestamps(table);
 
@@ -921,7 +855,7 @@ export class MemoryStore {
 
     // Create FTS index for BM25 search (graceful fallback if unavailable)
     try {
-      await this.createFtsIndex(table);
+      await this.createFtsIndexWithWriteLock(table);
       this.ftsIndexCreated = true;
       this._lastFtsError = null;
     } catch (err) {
@@ -939,6 +873,117 @@ export class MemoryStore {
     // Fold any unindexed backlog accumulated while no maintenance ran
     // (best-effort, runs in the background, never blocks initialization).
     void this.scheduleStartupIndexCatchUp();
+  }
+
+  private isRedisLockCoordinationError(err: unknown): boolean {
+    return err instanceof RedisLockUnavailableError ||
+      err instanceof RedisLockAcquisitionError ||
+      err instanceof RedisLockLeaseIntegrityError;
+  }
+
+  private getMissingLegacyColumns(fieldNames: Set<string>): Array<{ name: string; valueSql: string }> {
+    const missingColumns: Array<{ name: string; valueSql: string }> = [];
+    if (!fieldNames.has("scope")) {
+      missingColumns.push({ name: "scope", valueSql: "'global'" });
+    }
+    if (!fieldNames.has("timestamp")) {
+      missingColumns.push({ name: "timestamp", valueSql: "CAST(0 AS DOUBLE)" });
+    }
+    if (!fieldNames.has("metadata")) {
+      missingColumns.push({ name: "metadata", valueSql: "'{}'" });
+    }
+    return missingColumns;
+  }
+
+  private async readMissingLegacyColumns(table: LanceDB.Table): Promise<Array<{ name: string; valueSql: string }>> {
+    const schema = await table.schema();
+    const fieldNames = new Set(schema.fields.map((f: { name: string }) => f.name));
+    return this.getMissingLegacyColumns(fieldNames);
+  }
+
+  private async migrateLegacyTableColumns(table: LanceDB.Table, alreadyLocked = false): Promise<void> {
+    try {
+      const missingColumns = await this.readMissingLegacyColumns(table);
+      if (missingColumns.length === 0) return;
+
+      const applyMigration = async () => {
+        const currentMissingColumns = await this.readMissingLegacyColumns(table);
+        if (currentMissingColumns.length === 0) return;
+
+        console.warn(
+          `memory-lancedb-pro: migrating legacy table — adding columns: ${currentMissingColumns.map((c) => c.name).join(", ")}`,
+        );
+        await table.addColumns(currentMissingColumns);
+        console.log(
+          `memory-lancedb-pro: migration complete — ${currentMissingColumns.length} column(s) added`,
+        );
+      };
+
+      if (alreadyLocked) {
+        await applyMigration();
+      } else {
+        await this.runWithWriteLock(applyMigration);
+      }
+    } catch (err) {
+      const msg = String(err);
+      if (msg.includes("already exists")) {
+        // Concurrent initialization race — another process already added the columns
+        console.log("memory-lancedb-pro: migration columns already exist (concurrent init)");
+      } else if (this.isRedisLockCoordinationError(err)) {
+        throw err;
+      } else {
+        console.warn("memory-lancedb-pro: could not check/migrate table schema:", err);
+      }
+    }
+  }
+
+  private async openOrCreateMemoryTable(db: LanceDB.Connection): Promise<LanceDB.Table> {
+    // Idempotent table init: try openTable first, create only if missing,
+    // and handle the race where tableNames() misses an existing table but
+    // createTable then sees it (LanceDB eventual consistency).
+    let table: LanceDB.Table;
+    try {
+      table = await db.openTable(TABLE_NAME);
+    } catch (_openErr) {
+      return this.runWithWriteLock(async () => {
+        let lockedTable: LanceDB.Table;
+        try {
+          lockedTable = await db.openTable(TABLE_NAME);
+        } catch {
+          // Table doesn't exist yet — create it
+          const schemaEntry: MemoryEntry = {
+            id: "__schema__",
+            text: "",
+            vector: Array.from({ length: this.config.vectorDim }).fill(
+              0,
+            ) as number[],
+            category: "other",
+            scope: "global",
+            importance: 0,
+            timestamp: 0,
+            metadata: "{}",
+          };
+
+          try {
+            lockedTable = await db.createTable(TABLE_NAME, [schemaEntry]);
+            await lockedTable.delete('id = "__schema__"');
+          } catch (createErr) {
+            // Race: another caller (or eventual consistency) created the table
+            // between our failed openTable and this createTable — just open it.
+            if (String(createErr).includes("already exists")) {
+              lockedTable = await db.openTable(TABLE_NAME);
+            } else {
+              throw createErr;
+            }
+          }
+        }
+        await this.migrateLegacyTableColumns(lockedTable, true);
+        return lockedTable;
+      });
+    }
+
+    await this.migrateLegacyTableColumns(table);
+    return table;
   }
 
   private async backfillLegacySecondTimestamps(table: LanceDB.Table): Promise<void> {
@@ -1069,6 +1114,10 @@ export class MemoryStore {
         `FTS index creation failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
+  }
+
+  private async createFtsIndexWithWriteLock(table: LanceDB.Table): Promise<void> {
+    await this.runWithWriteLock(() => this.createFtsIndex(table));
   }
 
   async store(
@@ -2452,19 +2501,21 @@ export class MemoryStore {
   async rebuildFtsIndex(): Promise<{ success: boolean; error?: string }> {
     await this.ensureInitialized();
     try {
-      // Drop existing FTS index if any
-      const indices = await this.table!.listIndices();
-      for (const idx of indices) {
-        if (idx.indexType === "FTS" || idx.columns?.includes("text")) {
-          try {
-            await this.table!.dropIndex((idx as any).name || "text");
-          } catch (err) {
-            console.warn(`memory-lancedb-pro: dropIndex(${(idx as any).name || "text"}) failed:`, err);
+      await this.runWithWriteLock(async () => {
+        // Drop existing FTS index if any
+        const indices = await this.table!.listIndices();
+        for (const idx of indices) {
+          if (idx.indexType === "FTS" || idx.columns?.includes("text")) {
+            try {
+              await this.table!.dropIndex((idx as any).name || "text");
+            } catch (err) {
+              console.warn(`memory-lancedb-pro: dropIndex(${(idx as any).name || "text"}) failed:`, err);
+            }
           }
         }
-      }
-      // Recreate
-      await this.createFtsIndex(this.table!);
+        // Recreate
+        await this.createFtsIndex(this.table!);
+      });
       this.ftsIndexCreated = true;
       this._lastFtsError = null;
       return { success: true };

--- a/src/store.ts
+++ b/src/store.ts
@@ -30,7 +30,6 @@ import { fileURLToPath } from "node:url";
 import { matchesMemoryCategoryFilter, resolveCategoryFilterCandidates } from "./memory-categories.js";
 import {
   RedisLockManager,
-  RedisLockUnavailableError,
   type RedisLockConfig,
 } from "./redis-lock.js";
 import { buildSmartMetadata, isMemoryActiveAt, parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
@@ -561,16 +560,10 @@ export class MemoryStore {
     };
     this.disableNativeCosine = config.disableNativeCosine === true || envDisablesNativeCosine;
     if (config.redisLock?.enabled === true) {
-      if (config.redisLock.url) {
-        this.redisLock = new RedisLockManager({
-          ...config.redisLock,
-          onWarning: config.onLockWarning,
-        });
-      } else {
-        config.onLockWarning?.(
-          "memory-lancedb-pro: Redis lock is enabled but no Redis URL is configured; using file lock",
-        );
-      }
+      this.redisLock = new RedisLockManager({
+        ...config.redisLock,
+        onWarning: config.onLockWarning,
+      });
     }
   }
 
@@ -696,18 +689,7 @@ export class MemoryStore {
       return this.runWithFileLock(fn);
     }
 
-    try {
-      return await this.redisLock.withLock(this.config.dbPath, fn);
-    } catch (err) {
-      if (!(err instanceof RedisLockUnavailableError)) {
-        throw err;
-      }
-
-      this.config.onLockWarning?.(
-        `memory-lancedb-pro: Redis write lock unavailable; falling back to file lock: ${err.message}`,
-      );
-      return this.runWithFileLock(fn);
-    }
+    return this.redisLock.withLock(this.config.dbPath, fn);
   }
 
   private async closeLockResources(): Promise<void> {
@@ -766,7 +748,7 @@ export class MemoryStore {
     const mods = this.dataModsSinceIndexFold;
     this.dataModsSinceIndexFold = 0;
     try {
-      await this.runWithFileLock(async () => {
+      await this.runWithWriteLock(async () => {
         await this.table!.optimize({ cleanupOlderThan: new Date(0) });
       });
       console.log(

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -407,6 +407,61 @@ try {
       [stopCleanupDbPath, reRegisterDbPath],
       "service stop should clear the cached singleton before re-registration",
     );
+
+    destroyCalls = 0;
+    destroyedDbPaths.length = 0;
+    const sharedDbPath = path.join(workDir, "db-stop-shared");
+    const firstSharedServices = [];
+    const secondSharedServices = [];
+    const firstSharedApi = createMockApi(
+      {
+        dbPath: sharedDbPath,
+        autoCapture: false,
+        autoRecall: false,
+        embedding: {
+          provider: "openai-compatible",
+          apiKey: "dummy",
+          model: "text-embedding-3-small",
+          baseURL: "http://127.0.0.1:9/v1",
+          dimensions: 1536,
+        },
+      },
+      { services: firstSharedServices },
+    );
+    const secondSharedApi = createMockApi(
+      {
+        dbPath: sharedDbPath,
+        autoCapture: false,
+        autoRecall: false,
+        embedding: {
+          provider: "openai-compatible",
+          apiKey: "dummy",
+          model: "text-embedding-3-small",
+          baseURL: "http://127.0.0.1:9/v1",
+          dimensions: 1536,
+        },
+      },
+      { services: secondSharedServices },
+    );
+    resetRegistration();
+    plugin.register(firstSharedApi);
+    plugin.register(secondSharedApi);
+    assert.equal(firstSharedServices.length, 1, "first registration should add a service");
+    assert.equal(secondSharedServices.length, 1, "second registration should add a service");
+    await firstSharedServices[0].stop();
+    assert.equal(
+      destroyCalls,
+      0,
+      "stopping one of multiple registrations should keep the shared store alive",
+    );
+    assert.deepEqual(destroyedDbPaths, []);
+    await secondSharedServices[0].stop();
+    assert.equal(
+      destroyCalls,
+      1,
+      "shared store should be destroyed only after the final registration stops",
+    );
+    assert.deepEqual(destroyedDbPaths, [sharedDbPath]);
   } finally {
     MemoryStore.prototype.destroy = originalDestroy;
   }

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -351,14 +351,17 @@ try {
 
   const originalDestroy = MemoryStore.prototype.destroy;
   let destroyCalls = 0;
+  const destroyedDbPaths = [];
   try {
     MemoryStore.prototype.destroy = async function () {
       destroyCalls += 1;
+      destroyedDbPaths.push(this.config.dbPath);
     };
     const stopCleanupServices = [];
+    const stopCleanupDbPath = path.join(workDir, "db-stop-cleanup");
     const stopCleanupApi = createMockApi(
       {
-        dbPath: path.join(workDir, "db-stop-cleanup"),
+        dbPath: stopCleanupDbPath,
         autoCapture: false,
         autoRecall: false,
         embedding: {
@@ -376,6 +379,34 @@ try {
     assert.equal(stopCleanupServices.length, 1, "plugin should register a service for cleanup coverage");
     await stopCleanupServices[0].stop();
     assert.equal(destroyCalls, 1, "service stop should destroy the store and close lock resources");
+    assert.deepEqual(destroyedDbPaths, [stopCleanupDbPath]);
+
+    const reRegisterServices = [];
+    const reRegisterDbPath = path.join(workDir, "db-stop-cleanup-reregistered");
+    const reRegisterApi = createMockApi(
+      {
+        dbPath: reRegisterDbPath,
+        autoCapture: false,
+        autoRecall: false,
+        embedding: {
+          provider: "openai-compatible",
+          apiKey: "dummy",
+          model: "text-embedding-3-small",
+          baseURL: "http://127.0.0.1:9/v1",
+          dimensions: 1536,
+        },
+      },
+      { services: reRegisterServices },
+    );
+    plugin.register(reRegisterApi);
+    assert.equal(reRegisterServices.length, 1, "plugin should register after service stop");
+    await reRegisterServices[0].stop();
+    assert.equal(destroyCalls, 2, "re-registered service should destroy its own store");
+    assert.deepEqual(
+      destroyedDbPaths,
+      [stopCleanupDbPath, reRegisterDbPath],
+      "service stop should clear the cached singleton before re-registration",
+    );
   } finally {
     MemoryStore.prototype.destroy = originalDestroy;
   }

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -17,6 +17,7 @@ Module._initPaths();
 
 const jiti = jitiFactory(import.meta.url, { interopDefault: true });
 const plugin = jiti("../index.ts");
+const { MemoryStore } = jiti("../src/store.ts");
 const resetRegistration = plugin.resetRegistration ?? (() => {});
 
 const manifest = JSON.parse(
@@ -347,6 +348,37 @@ try {
     services[0].stop(),
     "service stop should not throw when no access tracker is configured",
   );
+
+  const originalDestroy = MemoryStore.prototype.destroy;
+  let destroyCalls = 0;
+  try {
+    MemoryStore.prototype.destroy = async function () {
+      destroyCalls += 1;
+    };
+    const stopCleanupServices = [];
+    const stopCleanupApi = createMockApi(
+      {
+        dbPath: path.join(workDir, "db-stop-cleanup"),
+        autoCapture: false,
+        autoRecall: false,
+        embedding: {
+          provider: "openai-compatible",
+          apiKey: "dummy",
+          model: "text-embedding-3-small",
+          baseURL: "http://127.0.0.1:9/v1",
+          dimensions: 1536,
+        },
+      },
+      { services: stopCleanupServices },
+    );
+    resetRegistration();
+    plugin.register(stopCleanupApi);
+    assert.equal(stopCleanupServices.length, 1, "plugin should register a service for cleanup coverage");
+    await stopCleanupServices[0].stop();
+    assert.equal(destroyCalls, 1, "service stop should destroy the store and close lock resources");
+  } finally {
+    MemoryStore.prototype.destroy = originalDestroy;
+  }
 
   const sessionDefaultApi = createMockApi({
     dbPath: path.join(workDir, "db-session-default"),

--- a/test/redis-lock.test.mjs
+++ b/test/redis-lock.test.mjs
@@ -139,6 +139,50 @@ describe("RedisLockManager", () => {
     assert.equal(setCalls, 0);
   });
 
+  it("waits for active Redis-locked writes before closing the client", async () => {
+    const events = [];
+    let releaseWrite;
+    const writeMayFinish = new Promise((resolve) => {
+      releaseWrite = resolve;
+    });
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      ttlMs: 5_000,
+      acquireTimeoutMs: 20,
+      retryDelayMs: 1,
+    }, {
+      async set() {
+        events.push("acquired");
+        return "OK";
+      },
+      async eval() {
+        events.push("released");
+        return 1;
+      },
+      async quit() {
+        events.push("quit");
+      },
+    });
+
+    const write = manager.withLock("/tmp/db", async () => {
+      events.push("write-started");
+      await writeMayFinish;
+      events.push("write-finished");
+    });
+
+    while (!events.includes("write-started")) {
+      await sleep(1);
+    }
+    const close = manager.close();
+    await sleep(10);
+    assert.deepEqual(events, ["acquired", "write-started"]);
+
+    releaseWrite();
+    await Promise.all([write, close]);
+
+    assert.deepEqual(events, ["acquired", "write-started", "write-finished", "released", "quit"]);
+  });
+
   it("rejects empty Redis lock resources without acquiring a client", async () => {
     let setCalls = 0;
     const manager = new RedisLockManager({
@@ -536,6 +580,33 @@ describe("Redis lock configuration", () => {
     assert.equal(parsed.redisUrl, "redis://localhost:6379/2");
     assert.equal(parsed.locking.redis.enabled, true);
     assert.equal(parsed.locking.redis.url, "redis://localhost:6379/2");
+  });
+
+  it("does not resolve Redis URL placeholders when Redis locking is disabled", () => {
+    delete process.env.REDIS_URL;
+    delete process.env.MEMORY_LANCEDB_REDIS_URL;
+
+    const parsed = parsePluginConfig({
+      embedding: { apiKey: "test-key" },
+      redisUrl: "${REDIS_URL}",
+      locking: {
+        redis: {
+          enabled: false,
+          url: "${REDIS_URL}",
+        },
+      },
+    });
+
+    assert.equal(parsed.redisUrl, undefined);
+    assert.deepEqual(parsed.locking.redis, {
+      enabled: false,
+      url: undefined,
+      keyPrefix: undefined,
+      ttlMs: 60000,
+      acquireTimeoutMs: 5000,
+      retryDelayMs: 50,
+      connectTimeoutMs: 1000,
+    });
   });
 
   it("declares Redis lock schema, ui hints, and dependency", () => {

--- a/test/redis-lock.test.mjs
+++ b/test/redis-lock.test.mjs
@@ -19,7 +19,7 @@ const jiti = jitiFactory(import.meta.url, {
 const {
   RedisLockManager,
   RedisLockAcquisitionError,
-  RedisLockLeaseLostError,
+  RedisLockLeaseIntegrityError,
   RedisLockUnavailableError,
 } = jiti("../src/redis-lock.ts");
 const {
@@ -231,7 +231,8 @@ describe("RedisLockManager", () => {
     assert.ok(overlaps >= 1);
   });
 
-  it("fails the write if Redis lease renewal loses ownership", async () => {
+  it("waits for the active write before reporting Redis lease integrity loss", async () => {
+    const events = [];
     const manager = new RedisLockManager({
       url: "redis://localhost:6379",
       ttlMs: 5,
@@ -242,17 +243,62 @@ describe("RedisLockManager", () => {
         return "OK";
       },
       async eval(script) {
-        if (script.includes("pexpire")) return 0;
+        if (script.includes("pexpire")) {
+          events.push("lease-lost");
+          return 0;
+        }
         return 0;
       },
     });
 
     await assert.rejects(
       () => manager.withLock("/tmp/db", async () => {
+        events.push("write-started");
         await sleep(20);
+        events.push("write-settled");
       }),
-      RedisLockLeaseLostError,
+      RedisLockLeaseIntegrityError,
     );
+    assert.deepEqual(events.at(-1), "write-settled");
+    assert.ok(events.includes("lease-lost"));
+  });
+
+  it("does not lose the lease after a single transient renewal failure", async () => {
+    const warnings = [];
+    let renewAttempts = 0;
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      ttlMs: 100,
+      acquireTimeoutMs: 20,
+      retryDelayMs: 1,
+      onWarning: (message) => warnings.push(message),
+    }, {
+      async set() {
+        return "OK";
+      },
+      async eval(script) {
+        if (script.includes("pexpire")) {
+          renewAttempts += 1;
+          if (renewAttempts === 1) {
+            throw new Error("temporary Redis timeout");
+          }
+          return 1;
+        }
+        return 1;
+      },
+    });
+
+    const result = await manager.withLock("/tmp/db", async () => {
+      const deadline = Date.now() + 90;
+      while (renewAttempts < 2 && Date.now() < deadline) {
+        await sleep(5);
+      }
+      return "committed";
+    });
+
+    assert.equal(result, "committed");
+    assert.ok(renewAttempts >= 2);
+    assert.match(warnings.join("\n"), /transient Redis lock renewal failure/);
   });
 
   it("does not mask a successful write when Redis release fails", async () => {

--- a/test/redis-lock.test.mjs
+++ b/test/redis-lock.test.mjs
@@ -443,19 +443,15 @@ describe("RedisLockManager", () => {
   });
 });
 
-describe("MemoryStore Redis fallback", () => {
-  it("falls back to the file lock when Redis is unavailable before the write runs", async () => {
+describe("MemoryStore Redis fail-closed locking", () => {
+  it("fails closed instead of falling back to file locking when Redis is unavailable", async () => {
     const dbPath = tempDbPath();
-    const warnings = [];
     let fileLocks = 0;
-    let fileReleases = 0;
     const added = [];
     __setLockfileModuleForTests({
       lock: async () => {
         fileLocks += 1;
-        return async () => {
-          fileReleases += 1;
-        };
+        return async () => {};
       },
     });
 
@@ -463,7 +459,6 @@ describe("MemoryStore Redis fallback", () => {
       dbPath,
       vectorDim: 3,
       redisLock: { enabled: true, url: "redis://localhost:6379" },
-      onLockWarning: (message) => warnings.push(message),
     });
     store.table = {
       add: async (entries) => {
@@ -477,21 +472,22 @@ describe("MemoryStore Redis fallback", () => {
       close: async () => {},
     };
 
-    await store.importEntry({
-      id: "memory-1",
-      text: "stored through fallback",
-      vector: [0.1, 0.2, 0.3],
-      category: "fact",
-      scope: "global",
-      importance: 0.7,
-      timestamp: Date.now(),
-      metadata: "{}",
-    });
+    await assert.rejects(
+      () => store.importEntry({
+        id: "memory-1",
+        text: "must not write through local fallback",
+        vector: [0.1, 0.2, 0.3],
+        category: "fact",
+        scope: "global",
+        importance: 0.7,
+        timestamp: Date.now(),
+        metadata: "{}",
+      }),
+      RedisLockUnavailableError,
+    );
 
-    assert.equal(added.length, 1);
-    assert.equal(fileLocks, 1);
-    assert.equal(fileReleases, 1);
-    assert.match(warnings.join("\n"), /falling back to file lock/i);
+    assert.equal(added.length, 0);
+    assert.equal(fileLocks, 0);
   });
 
   it("does not fall back to file locking when Redis lock acquisition times out", async () => {
@@ -539,6 +535,92 @@ describe("MemoryStore Redis fallback", () => {
     assert.equal(added.length, 0);
     assert.equal(fileLocks, 0);
   });
+
+  it("fails closed when Redis locking is explicitly enabled without a URL", async () => {
+    const dbPath = tempDbPath();
+    let fileLocks = 0;
+    const added = [];
+    __setLockfileModuleForTests({
+      lock: async () => {
+        fileLocks += 1;
+        return async () => {};
+      },
+    });
+
+    const store = new MemoryStore({
+      dbPath,
+      vectorDim: 3,
+      redisLock: { enabled: true },
+    });
+    store.table = {
+      add: async (entries) => {
+        added.push(...entries);
+      },
+    };
+
+    await assert.rejects(
+      () => store.importEntry({
+        id: "memory-1",
+        text: "must not write without redis url",
+        vector: [0.1, 0.2, 0.3],
+        category: "fact",
+        scope: "global",
+        importance: 0.7,
+        timestamp: Date.now(),
+        metadata: "{}",
+      }),
+      RedisLockUnavailableError,
+    );
+
+    assert.equal(added.length, 0);
+    assert.equal(fileLocks, 0);
+  });
+
+  it("runs automatic index folding inside the Redis write-lock domain", async () => {
+    const dbPath = tempDbPath();
+    let fileLocks = 0;
+    const redisEvents = [];
+    __setLockfileModuleForTests({
+      lock: async () => {
+        fileLocks += 1;
+        return async () => {};
+      },
+    });
+
+    let optimizeCalls = 0;
+    const store = new MemoryStore({
+      dbPath,
+      vectorDim: 3,
+      redisLock: { enabled: true, url: "redis://localhost:6379" },
+    });
+    store.table = {
+      optimize: async (options) => {
+        optimizeCalls += 1;
+        redisEvents.push(options.cleanupOlderThan?.getTime?.());
+        return {};
+      },
+    };
+    store.redisLock = {
+      withLock: async (_resource, fn) => {
+        redisEvents.push("redis-lock");
+        return fn();
+      },
+      close: async () => {},
+    };
+
+    for (let i = 0; i < 20; i++) {
+      store.noteDataModification();
+    }
+
+    const deadline = Date.now() + 250;
+    while (optimizeCalls === 0 && Date.now() < deadline) {
+      await sleep(5);
+    }
+
+    assert.equal(optimizeCalls, 1);
+    assert.deepEqual(redisEvents, ["redis-lock", 0]);
+    assert.equal(fileLocks, 0);
+  });
 });
 
 describe("Redis lock configuration", () => {
@@ -580,6 +662,26 @@ describe("Redis lock configuration", () => {
     assert.equal(parsed.redisUrl, "redis://localhost:6379/2");
     assert.equal(parsed.locking.redis.enabled, true);
     assert.equal(parsed.locking.redis.url, "redis://localhost:6379/2");
+  });
+
+  it("prefers nested Redis URL before resolving legacy redisUrl", () => {
+    delete process.env.REDIS_URL;
+    delete process.env.MEMORY_LANCEDB_REDIS_URL;
+
+    const parsed = parsePluginConfig({
+      embedding: { apiKey: "test-key" },
+      redisUrl: "${REDIS_URL}",
+      locking: {
+        redis: {
+          enabled: true,
+          url: "redis://localhost:6379/3",
+        },
+      },
+    });
+
+    assert.equal(parsed.redisUrl, undefined);
+    assert.equal(parsed.locking.redis.enabled, true);
+    assert.equal(parsed.locking.redis.url, "redis://localhost:6379/3");
   });
 
   it("does not resolve Redis URL placeholders when Redis locking is disabled", () => {

--- a/test/redis-lock.test.mjs
+++ b/test/redis-lock.test.mjs
@@ -443,19 +443,16 @@ describe("RedisLockManager", () => {
   });
 });
 
-describe("MemoryStore Redis fallback", () => {
-  it("falls back to the file lock when Redis is unavailable before the write runs", async () => {
+describe("MemoryStore Redis lock domain", () => {
+  it("fails closed without taking a file lock when Redis is unavailable", async () => {
     const dbPath = tempDbPath();
     const warnings = [];
     let fileLocks = 0;
-    let fileReleases = 0;
     const added = [];
     __setLockfileModuleForTests({
       lock: async () => {
         fileLocks += 1;
-        return async () => {
-          fileReleases += 1;
-        };
+        return async () => {};
       },
     });
 
@@ -477,21 +474,23 @@ describe("MemoryStore Redis fallback", () => {
       close: async () => {},
     };
 
-    await store.importEntry({
-      id: "memory-1",
-      text: "stored through fallback",
-      vector: [0.1, 0.2, 0.3],
-      category: "fact",
-      scope: "global",
-      importance: 0.7,
-      timestamp: Date.now(),
-      metadata: "{}",
-    });
+    await assert.rejects(
+      () => store.importEntry({
+        id: "memory-1",
+        text: "must not write through fallback",
+        vector: [0.1, 0.2, 0.3],
+        category: "fact",
+        scope: "global",
+        importance: 0.7,
+        timestamp: Date.now(),
+        metadata: "{}",
+      }),
+      RedisLockUnavailableError,
+    );
 
-    assert.equal(added.length, 1);
-    assert.equal(fileLocks, 1);
-    assert.equal(fileReleases, 1);
-    assert.match(warnings.join("\n"), /falling back to file lock/i);
+    assert.equal(added.length, 0);
+    assert.equal(fileLocks, 0);
+    assert.match(warnings.join("\n"), /failed closed/i);
   });
 
   it("does not fall back to file locking when Redis lock acquisition times out", async () => {
@@ -537,6 +536,44 @@ describe("MemoryStore Redis fallback", () => {
     );
 
     assert.equal(added.length, 0);
+    assert.equal(fileLocks, 0);
+  });
+
+  it("routes automatic index folding through the Redis write lock domain", async () => {
+    const dbPath = tempDbPath();
+    let fileLocks = 0;
+    let redisLocks = 0;
+    let optimized = 0;
+    __setLockfileModuleForTests({
+      lock: async () => {
+        fileLocks += 1;
+        return async () => {};
+      },
+    });
+
+    const store = new MemoryStore({
+      dbPath,
+      vectorDim: 3,
+      redisLock: { enabled: true, url: "redis://localhost:6379" },
+    });
+    store.table = {
+      optimize: async () => {
+        optimized += 1;
+        return {};
+      },
+    };
+    store.redisLock = {
+      withLock: async (_resource, fn) => {
+        redisLocks += 1;
+        return fn();
+      },
+      close: async () => {},
+    };
+
+    await Reflect.get(store, "foldIndices").call(store, "test");
+
+    assert.equal(optimized, 1);
+    assert.equal(redisLocks, 1);
     assert.equal(fileLocks, 0);
   });
 });

--- a/test/redis-lock.test.mjs
+++ b/test/redis-lock.test.mjs
@@ -114,6 +114,54 @@ describe("RedisLockManager", () => {
     assert.equal(attempts, 3);
   });
 
+  it("rejects new writes after the lock manager is closed", async () => {
+    let setCalls = 0;
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      acquireTimeoutMs: 20,
+      retryDelayMs: 1,
+    }, {
+      async set() {
+        setCalls += 1;
+        return "OK";
+      },
+      async eval() {
+        return 1;
+      },
+    });
+
+    await manager.close();
+
+    await assert.rejects(
+      () => manager.withLock("/tmp/db", async () => "should not run"),
+      RedisLockUnavailableError,
+    );
+    assert.equal(setCalls, 0);
+  });
+
+  it("rejects empty Redis lock resources without acquiring a client", async () => {
+    let setCalls = 0;
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      acquireTimeoutMs: 20,
+      retryDelayMs: 1,
+    }, {
+      async set() {
+        setCalls += 1;
+        return "OK";
+      },
+      async eval() {
+        return 1;
+      },
+    });
+
+    await assert.rejects(
+      () => manager.withLock("", async () => "should not run"),
+      RedisLockAcquisitionError,
+    );
+    assert.equal(setCalls, 0);
+  });
+
   it("throws RedisLockAcquisitionError when Redis SET keeps failing after protocol starts", async () => {
     const manager = new RedisLockManager({
       url: "redis://localhost:6379",
@@ -205,19 +253,19 @@ describe("RedisLockManager", () => {
     };
     const first = new RedisLockManager({
       url: "redis://localhost:6379",
-      ttlMs: 20,
+      ttlMs: 200,
       acquireTimeoutMs: 20,
       retryDelayMs: 1,
     }, client);
     const second = new RedisLockManager({
       url: "redis://localhost:6379",
-      ttlMs: 20,
+      ttlMs: 200,
       acquireTimeoutMs: 5,
       retryDelayMs: 1,
     }, client);
 
     await first.withLock("/tmp/db", async () => {
-      await sleep(45);
+      await sleep(130);
       await assert.rejects(
         () => second.withLock("/tmp/db", async () => {
           throw new Error("second writer should not enter");
@@ -235,7 +283,7 @@ describe("RedisLockManager", () => {
     const events = [];
     const manager = new RedisLockManager({
       url: "redis://localhost:6379",
-      ttlMs: 5,
+      ttlMs: 120,
       acquireTimeoutMs: 20,
       retryDelayMs: 1,
     }, {
@@ -254,7 +302,7 @@ describe("RedisLockManager", () => {
     await assert.rejects(
       () => manager.withLock("/tmp/db", async () => {
         events.push("write-started");
-        await sleep(20);
+        await sleep(150);
         events.push("write-settled");
       }),
       RedisLockLeaseIntegrityError,
@@ -268,7 +316,7 @@ describe("RedisLockManager", () => {
     let renewAttempts = 0;
     const manager = new RedisLockManager({
       url: "redis://localhost:6379",
-      ttlMs: 100,
+      ttlMs: 700,
       acquireTimeoutMs: 20,
       retryDelayMs: 1,
       onWarning: (message) => warnings.push(message),
@@ -289,7 +337,7 @@ describe("RedisLockManager", () => {
     });
 
     const result = await manager.withLock("/tmp/db", async () => {
-      const deadline = Date.now() + 90;
+      const deadline = Date.now() + 350;
       while (renewAttempts < 2 && Date.now() < deadline) {
         await sleep(5);
       }
@@ -299,6 +347,35 @@ describe("RedisLockManager", () => {
     assert.equal(result, "committed");
     assert.ok(renewAttempts >= 2);
     assert.match(warnings.join("\n"), /transient Redis lock renewal failure/);
+  });
+
+  it("does not renew sub-second leases more aggressively than every 100ms", async () => {
+    let renewAttempts = 0;
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      ttlMs: 1_000,
+      acquireTimeoutMs: 20,
+      retryDelayMs: 1,
+    }, {
+      async set() {
+        return "OK";
+      },
+      async eval(script) {
+        if (script.includes("pexpire")) {
+          renewAttempts += 1;
+          return 1;
+        }
+        return 1;
+      },
+    });
+
+    const result = await manager.withLock("/tmp/db", async () => {
+      await sleep(90);
+      return "committed";
+    });
+
+    assert.equal(result, "committed");
+    assert.equal(renewAttempts, 0);
   });
 
   it("does not mask a successful write when Redis release fails", async () => {

--- a/test/redis-lock.test.mjs
+++ b/test/redis-lock.test.mjs
@@ -1,0 +1,432 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginSdkStubPath = path.resolve(testDir, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+
+const {
+  RedisLockManager,
+  RedisLockAcquisitionError,
+  RedisLockLeaseLostError,
+  RedisLockUnavailableError,
+} = jiti("../src/redis-lock.ts");
+const {
+  MemoryStore,
+  __setLockfileModuleForTests,
+} = jiti("../src/store.ts");
+const { parsePluginConfig } = jiti("../index.ts");
+
+const tempDirs = [];
+const originalRedisUrl = process.env.MEMORY_LANCEDB_REDIS_URL;
+
+afterEach(() => {
+  if (originalRedisUrl === undefined) {
+    delete process.env.MEMORY_LANCEDB_REDIS_URL;
+  } else {
+    process.env.MEMORY_LANCEDB_REDIS_URL = originalRedisUrl;
+  }
+  __setLockfileModuleForTests({
+    lock: async () => async () => {},
+  });
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDbPath() {
+  const dir = mkdtempSync(join(tmpdir(), "memory-lancedb-pro-redis-lock-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("RedisLockManager", () => {
+  it("acquires Redis locks with token ownership and releases with Lua", async () => {
+    const setCalls = [];
+    const evalCalls = [];
+    const client = {
+      async set(...args) {
+        setCalls.push(args);
+        return "OK";
+      },
+      async eval(...args) {
+        evalCalls.push(args);
+        return 1;
+      },
+    };
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      keyPrefix: "test-lock",
+      ttlMs: 1234,
+      acquireTimeoutMs: 50,
+      retryDelayMs: 1,
+    }, client);
+
+    const result = await manager.withLock("/tmp/db", async () => "written");
+
+    assert.equal(result, "written");
+    assert.equal(setCalls.length, 1);
+    assert.match(setCalls[0][0], /^test-lock:[a-f0-9]{64}$/);
+    assert.equal(typeof setCalls[0][1], "string");
+    assert.deepEqual(setCalls[0].slice(2), ["PX", 1234, "NX"]);
+    assert.equal(evalCalls.length, 1);
+    assert.match(String(evalCalls[0][0]), /redis\.call\("get", KEYS\[1\]\)/);
+    assert.equal(evalCalls[0][1], 1);
+    assert.equal(evalCalls[0][2], setCalls[0][0]);
+    assert.equal(evalCalls[0][3], setCalls[0][1]);
+  });
+
+  it("retries transient Redis command errors until acquisition succeeds", async () => {
+    let attempts = 0;
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      acquireTimeoutMs: 50,
+      retryDelayMs: 1,
+    }, {
+      async set() {
+        attempts += 1;
+        if (attempts < 3) throw new Error("temporary network blip");
+        return "OK";
+      },
+      async eval() {
+        return 1;
+      },
+    });
+
+    const result = await manager.withLock("/tmp/db", async () => "ok");
+
+    assert.equal(result, "ok");
+    assert.equal(attempts, 3);
+  });
+
+  it("throws RedisLockAcquisitionError when Redis SET keeps failing after protocol starts", async () => {
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      acquireTimeoutMs: 20,
+      retryDelayMs: 1,
+    }, {
+      async set() {
+        throw new Error("connection refused");
+      },
+      async eval() {
+        return 0;
+      },
+    });
+
+    await assert.rejects(
+      () => manager.withLock("/tmp/db", async () => undefined),
+      RedisLockAcquisitionError,
+    );
+  });
+
+  it("throws RedisLockUnavailableError when Redis commands are unavailable", async () => {
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      acquireTimeoutMs: 20,
+      retryDelayMs: 1,
+    }, {});
+
+    await assert.rejects(
+      () => manager.withLock("/tmp/db", async () => undefined),
+      RedisLockUnavailableError,
+    );
+  });
+
+  it("times out when another Redis owner keeps the lock", async () => {
+    let attempts = 0;
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      acquireTimeoutMs: 5,
+      retryDelayMs: 1,
+    }, {
+      async set() {
+        attempts += 1;
+        return null;
+      },
+      async eval() {
+        return 0;
+      },
+    });
+
+    await assert.rejects(
+      () => manager.withLock("/tmp/db", async () => undefined),
+      RedisLockAcquisitionError,
+    );
+    assert.ok(attempts >= 1);
+  });
+
+  it("renews the Redis lease so another writer cannot acquire during a long write", async () => {
+    let token = null;
+    let expiresAt = 0;
+    let renewals = 0;
+    let overlaps = 0;
+    const client = {
+      async set(_key, nextToken, _px, ttlMs, _nx) {
+        const now = Date.now();
+        if (!token || expiresAt <= now) {
+          token = nextToken;
+          expiresAt = now + Number(ttlMs);
+          return "OK";
+        }
+        overlaps += 1;
+        return null;
+      },
+      async eval(script, _keyCount, _key, nextToken, ttlArg) {
+        if (script.includes("pexpire")) {
+          if (token === nextToken) {
+            renewals += 1;
+            expiresAt = Date.now() + Number(ttlArg);
+            return 1;
+          }
+          return 0;
+        }
+        if (token === nextToken) {
+          token = null;
+          expiresAt = 0;
+          return 1;
+        }
+        return 0;
+      },
+    };
+    const first = new RedisLockManager({
+      url: "redis://localhost:6379",
+      ttlMs: 20,
+      acquireTimeoutMs: 20,
+      retryDelayMs: 1,
+    }, client);
+    const second = new RedisLockManager({
+      url: "redis://localhost:6379",
+      ttlMs: 20,
+      acquireTimeoutMs: 5,
+      retryDelayMs: 1,
+    }, client);
+
+    await first.withLock("/tmp/db", async () => {
+      await sleep(45);
+      await assert.rejects(
+        () => second.withLock("/tmp/db", async () => {
+          throw new Error("second writer should not enter");
+        }),
+        RedisLockAcquisitionError,
+      );
+      return "done";
+    });
+
+    assert.ok(renewals >= 1);
+    assert.ok(overlaps >= 1);
+  });
+
+  it("fails the write if Redis lease renewal loses ownership", async () => {
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      ttlMs: 5,
+      acquireTimeoutMs: 20,
+      retryDelayMs: 1,
+    }, {
+      async set() {
+        return "OK";
+      },
+      async eval(script) {
+        if (script.includes("pexpire")) return 0;
+        return 0;
+      },
+    });
+
+    await assert.rejects(
+      () => manager.withLock("/tmp/db", async () => {
+        await sleep(20);
+      }),
+      RedisLockLeaseLostError,
+    );
+  });
+
+  it("does not mask a successful write when Redis release fails", async () => {
+    const warnings = [];
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      onWarning: (message) => warnings.push(message),
+    }, {
+      async set() {
+        return "OK";
+      },
+      async eval() {
+        throw new Error("release failed");
+      },
+    });
+
+    const result = await manager.withLock("/tmp/db", async () => 42);
+
+    assert.equal(result, 42);
+    assert.match(warnings.join("\n"), /Redis lock release failed/);
+  });
+});
+
+describe("MemoryStore Redis fallback", () => {
+  it("falls back to the file lock when Redis is unavailable before the write runs", async () => {
+    const dbPath = tempDbPath();
+    const warnings = [];
+    let fileLocks = 0;
+    let fileReleases = 0;
+    const added = [];
+    __setLockfileModuleForTests({
+      lock: async () => {
+        fileLocks += 1;
+        return async () => {
+          fileReleases += 1;
+        };
+      },
+    });
+
+    const store = new MemoryStore({
+      dbPath,
+      vectorDim: 3,
+      redisLock: { enabled: true, url: "redis://localhost:6379" },
+      onLockWarning: (message) => warnings.push(message),
+    });
+    store.table = {
+      add: async (entries) => {
+        added.push(...entries);
+      },
+    };
+    store.redisLock = {
+      withLock: async () => {
+        throw new RedisLockUnavailableError("redis down");
+      },
+      close: async () => {},
+    };
+
+    await store.importEntry({
+      id: "memory-1",
+      text: "stored through fallback",
+      vector: [0.1, 0.2, 0.3],
+      category: "fact",
+      scope: "global",
+      importance: 0.7,
+      timestamp: Date.now(),
+      metadata: "{}",
+    });
+
+    assert.equal(added.length, 1);
+    assert.equal(fileLocks, 1);
+    assert.equal(fileReleases, 1);
+    assert.match(warnings.join("\n"), /falling back to file lock/i);
+  });
+
+  it("does not fall back to file locking when Redis lock acquisition times out", async () => {
+    const dbPath = tempDbPath();
+    let fileLocks = 0;
+    const added = [];
+    __setLockfileModuleForTests({
+      lock: async () => {
+        fileLocks += 1;
+        return async () => {};
+      },
+    });
+
+    const store = new MemoryStore({
+      dbPath,
+      vectorDim: 3,
+      redisLock: { enabled: true, url: "redis://localhost:6379" },
+    });
+    store.table = {
+      add: async (entries) => {
+        added.push(...entries);
+      },
+    };
+    store.redisLock = {
+      withLock: async () => {
+        throw new RedisLockAcquisitionError("lock held by another writer");
+      },
+      close: async () => {},
+    };
+
+    await assert.rejects(
+      () => store.importEntry({
+        id: "memory-1",
+        text: "must not write through fallback",
+        vector: [0.1, 0.2, 0.3],
+        category: "fact",
+        scope: "global",
+        importance: 0.7,
+        timestamp: Date.now(),
+        metadata: "{}",
+      }),
+      RedisLockAcquisitionError,
+    );
+
+    assert.equal(added.length, 0);
+    assert.equal(fileLocks, 0);
+  });
+});
+
+describe("Redis lock configuration", () => {
+  it("parses nested Redis lock config", () => {
+    delete process.env.MEMORY_LANCEDB_REDIS_URL;
+    const parsed = parsePluginConfig({
+      embedding: { apiKey: "test-key" },
+      locking: {
+        redis: {
+          enabled: true,
+          url: "redis://localhost:6379/1",
+          keyPrefix: "custom-prefix",
+          ttlMs: "45000",
+          acquireTimeoutMs: 2500,
+          retryDelayMs: 25,
+          connectTimeoutMs: 750,
+        },
+      },
+    });
+
+    assert.deepEqual(parsed.locking.redis, {
+      enabled: true,
+      url: "redis://localhost:6379/1",
+      keyPrefix: "custom-prefix",
+      ttlMs: 45000,
+      acquireTimeoutMs: 2500,
+      retryDelayMs: 25,
+      connectTimeoutMs: 750,
+    });
+  });
+
+  it("enables Redis locking from redisUrl shortcut", () => {
+    delete process.env.MEMORY_LANCEDB_REDIS_URL;
+    const parsed = parsePluginConfig({
+      embedding: { apiKey: "test-key" },
+      redisUrl: "redis://localhost:6379/2",
+    });
+
+    assert.equal(parsed.redisUrl, "redis://localhost:6379/2");
+    assert.equal(parsed.locking.redis.enabled, true);
+    assert.equal(parsed.locking.redis.url, "redis://localhost:6379/2");
+  });
+
+  it("declares Redis lock schema, ui hints, and dependency", () => {
+    const manifest = JSON.parse(
+      readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+    );
+    const pkg = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    );
+
+    assert.equal(manifest.configSchema.properties.locking.properties.redis.properties.enabled.default, false);
+    assert.equal(manifest.configSchema.properties.locking.properties.redis.properties.ttlMs.default, 60000);
+    assert.ok(Object.prototype.hasOwnProperty.call(manifest.uiHints, "locking.redis.enabled"));
+    assert.equal(manifest.uiHints["locking.redis.url"].sensitive, true);
+    assert.ok(pkg.dependencies.ioredis, "package.json should declare ioredis");
+  });
+});

--- a/test/redis-lock.test.mjs
+++ b/test/redis-lock.test.mjs
@@ -523,6 +523,27 @@ describe("RedisLockManager", () => {
     assert.equal(result, 42);
     assert.match(warnings.join("\n"), /Redis lock release failed/);
   });
+
+  it("reports lease integrity loss when final release no longer owns the token", async () => {
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      ttlMs: 5_000,
+      acquireTimeoutMs: 20,
+      retryDelayMs: 1,
+    }, {
+      async set() {
+        return "OK";
+      },
+      async eval() {
+        return 0;
+      },
+    });
+
+    await assert.rejects(
+      () => manager.withLock("/tmp/db", async () => 42),
+      RedisLockLeaseIntegrityError,
+    );
+  });
 });
 
 describe("MemoryStore Redis fail-closed locking", () => {
@@ -703,6 +724,61 @@ describe("MemoryStore Redis fail-closed locking", () => {
     assert.deepEqual(redisEvents, ["redis-lock", 0]);
     assert.equal(fileLocks, 0);
   });
+
+  it("rebuilds the FTS index inside the Redis write-lock domain", async () => {
+    const dbPath = tempDbPath();
+    let fileLocks = 0;
+    const events = [];
+    __setLockfileModuleForTests({
+      lock: async () => {
+        fileLocks += 1;
+        return async () => {};
+      },
+    });
+
+    let indices = [{ indexType: "FTS", columns: ["text"], name: "text_idx" }];
+    const store = new MemoryStore({
+      dbPath,
+      vectorDim: 3,
+      redisLock: { enabled: true, url: "redis://localhost:6379" },
+    });
+    store.table = {
+      listIndices: async () => {
+        events.push("list");
+        return indices;
+      },
+      dropIndex: async (name) => {
+        events.push(`drop:${name}`);
+        indices = [];
+      },
+      createIndex: async (column) => {
+        events.push(`create:${column}`);
+        indices = [{ indexType: "FTS", columns: ["text"], name: "text_idx" }];
+      },
+    };
+    store.redisLock = {
+      withLock: async (_resource, fn) => {
+        events.push("redis-lock:start");
+        const result = await fn();
+        events.push("redis-lock:end");
+        return result;
+      },
+      close: async () => {},
+    };
+
+    const result = await store.rebuildFtsIndex();
+
+    assert.deepEqual(result, { success: true });
+    assert.deepEqual(events, [
+      "redis-lock:start",
+      "list",
+      "drop:text_idx",
+      "list",
+      "create:text",
+      "redis-lock:end",
+    ]);
+    assert.equal(fileLocks, 0);
+  });
 });
 
 describe("Redis lock configuration", () => {
@@ -744,6 +820,18 @@ describe("Redis lock configuration", () => {
     assert.equal(parsed.redisUrl, "redis://localhost:6379/2");
     assert.equal(parsed.locking.redis.enabled, true);
     assert.equal(parsed.locking.redis.url, "redis://localhost:6379/2");
+  });
+
+  it("enables Redis locking from MEMORY_LANCEDB_REDIS_URL", () => {
+    process.env.MEMORY_LANCEDB_REDIS_URL = "redis://localhost:6379/9";
+
+    const parsed = parsePluginConfig({
+      embedding: { apiKey: "test-key" },
+    });
+
+    assert.equal(parsed.redisUrl, undefined);
+    assert.equal(parsed.locking.redis.enabled, true);
+    assert.equal(parsed.locking.redis.url, "redis://localhost:6379/9");
   });
 
   it("prefers nested Redis URL before resolving legacy redisUrl", () => {
@@ -805,6 +893,7 @@ describe("Redis lock configuration", () => {
     assert.equal(manifest.configSchema.properties.locking.properties.redis.properties.ttlMs.default, 60000);
     assert.ok(Object.prototype.hasOwnProperty.call(manifest.uiHints, "locking.redis.enabled"));
     assert.equal(manifest.uiHints["locking.redis.url"].sensitive, true);
-    assert.ok(pkg.dependencies.ioredis, "package.json should declare ioredis");
+    assert.equal(pkg.dependencies.ioredis, undefined, "ioredis should not be a hard dependency");
+    assert.ok(pkg.optionalDependencies.ioredis, "package.json should declare ioredis as optional");
   });
 });

--- a/test/redis-lock.test.mjs
+++ b/test/redis-lock.test.mjs
@@ -183,6 +183,50 @@ describe("RedisLockManager", () => {
     assert.deepEqual(events, ["acquired", "write-started", "write-finished", "released", "quit"]);
   });
 
+  it("waits for in-flight Redis lock acquisition before closing the client", async () => {
+    const events = [];
+    let finishAcquire;
+    const acquireMayFinish = new Promise((resolve) => {
+      finishAcquire = resolve;
+    });
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      ttlMs: 5_000,
+      acquireTimeoutMs: 200,
+      retryDelayMs: 1,
+    }, {
+      async set() {
+        events.push("acquire-started");
+        await acquireMayFinish;
+        events.push("acquired");
+        return "OK";
+      },
+      async eval() {
+        events.push("released");
+        return 1;
+      },
+      async quit() {
+        events.push("quit");
+      },
+    });
+
+    const write = manager.withLock("/tmp/db", async () => {
+      events.push("write-started");
+    });
+
+    while (!events.includes("acquire-started")) {
+      await sleep(1);
+    }
+    const close = manager.close();
+    await sleep(10);
+    assert.deepEqual(events, ["acquire-started"]);
+
+    finishAcquire();
+    await Promise.all([write, close]);
+
+    assert.deepEqual(events, ["acquire-started", "acquired", "write-started", "released", "quit"]);
+  });
+
   it("rejects empty Redis lock resources without acquiring a client", async () => {
     let setCalls = 0;
     const manager = new RedisLockManager({
@@ -352,6 +396,44 @@ describe("RedisLockManager", () => {
       RedisLockLeaseIntegrityError,
     );
     assert.deepEqual(events.at(-1), "write-settled");
+    assert.ok(events.includes("lease-lost"));
+  });
+
+  it("reports Redis lease integrity loss even when the locked callback throws", async () => {
+    const events = [];
+    const manager = new RedisLockManager({
+      url: "redis://localhost:6379",
+      ttlMs: 120,
+      acquireTimeoutMs: 20,
+      retryDelayMs: 1,
+    }, {
+      async set() {
+        return "OK";
+      },
+      async eval(script) {
+        if (script.includes("pexpire")) {
+          events.push("lease-lost");
+          return 0;
+        }
+        return 0;
+      },
+    });
+
+    await assert.rejects(
+      () => manager.withLock("/tmp/db", async () => {
+        events.push("write-started");
+        await sleep(150);
+        events.push("write-throwing");
+        throw new Error("callback failed");
+      }),
+      (err) => {
+        assert.ok(err instanceof RedisLockLeaseIntegrityError);
+        assert.match(err.message, /callback also failed: callback failed/);
+        assert.equal(err.cause?.name, "RedisLockLeaseLostError");
+        return true;
+      },
+    );
+    assert.deepEqual(events.at(-1), "write-throwing");
     assert.ok(events.includes("lease-lost"));
   });
 

--- a/test/storage-maintenance.test.mjs
+++ b/test/storage-maintenance.test.mjs
@@ -73,6 +73,34 @@ describe("LanceDB storage maintenance", () => {
     assert.equal(result.cleanupOlderThan, optimizeOptions.cleanupOlderThan.toISOString());
   });
 
+  it("uses the Redis write lock domain when Redis locking is enabled", async () => {
+    let fileLocks = 0;
+    let redisLocks = 0;
+    __setLockfileModuleForTests({
+      lock: async () => {
+        fileLocks += 1;
+        return async () => {};
+      },
+    });
+
+    const store = makeStoreWithMockTable({
+      optimize: async () => ({ removedFiles: 1 }),
+    });
+    store.redisLock = {
+      withLock: async (_resource, fn) => {
+        redisLocks += 1;
+        return fn();
+      },
+      close: async () => {},
+    };
+
+    const result = await store.runStorageMaintenance(7);
+
+    assert.equal(result.retentionDays, 7);
+    assert.equal(redisLocks, 1);
+    assert.equal(fileLocks, 0);
+  });
+
   it("clamps unsafe retention values before cleanup", async () => {
     __setLockfileModuleForTests({
       lock: async () => async () => {},


### PR DESCRIPTION
## Summary
- add an optional Redis write lock manager using token ownership and Lua safe release
- route LanceDB write paths through Redis when enabled, with file-lock fallback when Redis is unavailable
- expose Redis lock config and ioredis dependency with unit and storage CI coverage

Fixes #659

## Verification
- node --test test/redis-lock.test.mjs
- npm run build
- npm run test:storage-and-schema
- npm run test:packaging-and-workflow