### PR TITLE
feat: add LanceDB storage maintenance

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3869,6 +3869,10 @@ const memoryLanceDBProPlugin = {
         // ========================================================================
         let backupTimer = null;
         const BACKUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+        let storageMaintenanceInitialTimer = null;
+        let storageMaintenanceTimer = null;
+        let storageMaintenanceRunning = false;
+        const storageAutoCleanup = config.storageMaintenance?.autoCleanup;
         async function runBackup() {
             try {
                 // resolvedDbPath is already absolute (produced by api.resolvePath at
@@ -3917,6 +3921,29 @@ const memoryLanceDBProPlugin = {
             }
             catch (err) {
                 api.logger.warn(`memory-lancedb-pro: backup failed: ${String(err)}`);
+            }
+        }
+        async function runStorageMaintenance() {
+            if (storageAutoCleanup?.enabled !== true)
+                return;
+            if (storageMaintenanceRunning) {
+                api.logger.debug("memory-lancedb-pro: storage maintenance skipped because a prior run is still active");
+                return;
+            }
+            storageMaintenanceRunning = true;
+            const startedAt = Date.now();
+            const retentionDays = storageAutoCleanup.retentionDays ?? 7;
+            try {
+                const result = await store.runStorageMaintenance(retentionDays);
+                api.logger.info(`memory-lancedb-pro: storage maintenance completed ` +
+                    `(retentionDays=${result.retentionDays}, cleanupOlderThan=${result.cleanupOlderThan}, elapsedMs=${Date.now() - startedAt})`);
+            }
+            catch (err) {
+                api.logger.warn(`memory-lancedb-pro: storage maintenance failed ` +
+                    `(retentionDays=${retentionDays}, elapsedMs=${Date.now() - startedAt}): ${String(err)}`);
+            }
+            finally {
+                storageMaintenanceRunning = false;
             }
         }
         // ========================================================================
@@ -4020,11 +4047,27 @@ const memoryLanceDBProPlugin = {
                 // Run initial backup after a short delay, then schedule daily
                 setTimeout(() => void runBackup(), 60_000); // 1 min after start
                 backupTimer = setInterval(() => void runBackup(), BACKUP_INTERVAL_MS);
+                if (storageAutoCleanup?.enabled === true) {
+                    const intervalMs = (storageAutoCleanup.intervalHours ?? 24) * 60 * 60 * 1000;
+                    const initialDelayMs = storageAutoCleanup.initialDelayMs ?? 300_000;
+                    api.logger.info(`memory-lancedb-pro: storage maintenance scheduled ` +
+                        `(intervalHours=${storageAutoCleanup.intervalHours ?? 24}, retentionDays=${storageAutoCleanup.retentionDays ?? 7})`);
+                    storageMaintenanceInitialTimer = setTimeout(() => void runStorageMaintenance(), initialDelayMs);
+                    storageMaintenanceTimer = setInterval(() => void runStorageMaintenance(), intervalMs);
+                }
             },
             stop: async () => {
                 if (backupTimer) {
                     clearInterval(backupTimer);
                     backupTimer = null;
+                }
+                if (storageMaintenanceInitialTimer) {
+                    clearTimeout(storageMaintenanceInitialTimer);
+                    storageMaintenanceInitialTimer = null;
+                }
+                if (storageMaintenanceTimer) {
+                    clearInterval(storageMaintenanceTimer);
+                    storageMaintenanceTimer = null;
                 }
                 api.logger.info("memory-lancedb-pro: stopped");
             },
@@ -4084,6 +4127,12 @@ export function parsePluginConfig(value) {
     const workspaceBoundaryRaw = typeof cfg.workspaceBoundary === "object" && cfg.workspaceBoundary !== null
         ? cfg.workspaceBoundary
         : null;
+    const storageMaintenanceRaw = typeof cfg.storageMaintenance === "object" && cfg.storageMaintenance !== null
+        ? cfg.storageMaintenance
+        : null;
+    const storageAutoCleanupRaw = typeof storageMaintenanceRaw?.autoCleanup === "object" && storageMaintenanceRaw.autoCleanup !== null
+        ? storageMaintenanceRaw.autoCleanup
+        : null;
     const userMdExclusiveRaw = typeof workspaceBoundaryRaw?.userMdExclusive === "object" && workspaceBoundaryRaw.userMdExclusive !== null
         ? workspaceBoundaryRaw.userMdExclusive
         : null;
@@ -4137,6 +4186,16 @@ export function parsePluginConfig(value) {
             clientTimeoutMs: parsePositiveInt(embedding.clientTimeoutMs),
         },
         dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : undefined,
+        storageMaintenance: storageAutoCleanupRaw
+            ? {
+                autoCleanup: {
+                    enabled: storageAutoCleanupRaw.enabled === true,
+                    intervalHours: parsePositiveInt(storageAutoCleanupRaw.intervalHours) ?? 24,
+                    retentionDays: parsePositiveInt(storageAutoCleanupRaw.retentionDays) ?? 7,
+                    initialDelayMs: parseNonNegativeInt(storageAutoCleanupRaw.initialDelayMs) ?? 300_000,
+                },
+            }
+            : undefined,
         autoCapture: cfg.autoCapture !== false,
         // Default OFF: only enable when explicitly set to true.
         autoRecall: cfg.autoRecall === true,

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -514,6 +514,25 @@ export class MemoryStore {
     get dbPath() {
         return this.config.dbPath;
     }
+    async runStorageMaintenance(retentionDays = 7) {
+        if (this.destroyed) {
+            throw new Error("MemoryStore instance has been destroyed");
+        }
+        await this.ensureInitialized();
+        const safeRetentionDays = clampInt(retentionDays, 1, 3650);
+        const cleanupOlderThan = new Date(Date.now() - safeRetentionDays * 24 * 60 * 60 * 1000);
+        return this.runWithFileLock(async () => {
+            if (!this.table || typeof this.table.optimize !== "function") {
+                throw new Error("LanceDB table.optimize() is not available in this runtime");
+            }
+            const stats = await this.table.optimize({ cleanupOlderThan });
+            return {
+                retentionDays: safeRetentionDays,
+                cleanupOlderThan: cleanupOlderThan.toISOString(),
+                stats,
+            };
+        });
+    }
     async ensureInitialized() {
         if (this.table) {
             return;

--- a/index.ts
+++ b/index.ts
@@ -121,6 +121,14 @@ interface PluginConfig {
     clientTimeoutMs?: number;
   };
   dbPath?: string;
+  storageMaintenance?: {
+    autoCleanup?: {
+      enabled?: boolean;
+      intervalHours?: number;
+      retentionDays?: number;
+      initialDelayMs?: number;
+    };
+  };
   autoCapture?: boolean;
   autoRecall?: boolean;
   autoRecallMinLength?: number;
@@ -4870,6 +4878,10 @@ const memoryLanceDBProPlugin = {
 
     let backupTimer: ReturnType<typeof setInterval> | null = null;
     const BACKUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+    let storageMaintenanceInitialTimer: ReturnType<typeof setTimeout> | null = null;
+    let storageMaintenanceTimer: ReturnType<typeof setInterval> | null = null;
+    let storageMaintenanceRunning = false;
+    const storageAutoCleanup = config.storageMaintenance?.autoCleanup;
 
     async function runBackup() {
       try {
@@ -4931,6 +4943,32 @@ const memoryLanceDBProPlugin = {
         );
       } catch (err) {
         api.logger.warn(`memory-lancedb-pro: backup failed: ${String(err)}`);
+      }
+    }
+
+    async function runStorageMaintenance() {
+      if (storageAutoCleanup?.enabled !== true) return;
+      if (storageMaintenanceRunning) {
+        api.logger.debug("memory-lancedb-pro: storage maintenance skipped because a prior run is still active");
+        return;
+      }
+
+      storageMaintenanceRunning = true;
+      const startedAt = Date.now();
+      const retentionDays = storageAutoCleanup.retentionDays ?? 7;
+      try {
+        const result = await store.runStorageMaintenance(retentionDays);
+        api.logger.info(
+          `memory-lancedb-pro: storage maintenance completed ` +
+          `(retentionDays=${result.retentionDays}, cleanupOlderThan=${result.cleanupOlderThan}, elapsedMs=${Date.now() - startedAt})`,
+        );
+      } catch (err) {
+        api.logger.warn(
+          `memory-lancedb-pro: storage maintenance failed ` +
+          `(retentionDays=${retentionDays}, elapsedMs=${Date.now() - startedAt}): ${String(err)}`,
+        );
+      } finally {
+        storageMaintenanceRunning = false;
       }
     }
 
@@ -5074,11 +5112,36 @@ const memoryLanceDBProPlugin = {
         // Run initial backup after a short delay, then schedule daily
         setTimeout(() => void runBackup(), 60_000); // 1 min after start
         backupTimer = setInterval(() => void runBackup(), BACKUP_INTERVAL_MS);
+
+        if (storageAutoCleanup?.enabled === true) {
+          const intervalMs = (storageAutoCleanup.intervalHours ?? 24) * 60 * 60 * 1000;
+          const initialDelayMs = storageAutoCleanup.initialDelayMs ?? 300_000;
+          api.logger.info(
+            `memory-lancedb-pro: storage maintenance scheduled ` +
+            `(intervalHours=${storageAutoCleanup.intervalHours ?? 24}, retentionDays=${storageAutoCleanup.retentionDays ?? 7})`,
+          );
+          storageMaintenanceInitialTimer = setTimeout(
+            () => void runStorageMaintenance(),
+            initialDelayMs,
+          );
+          storageMaintenanceTimer = setInterval(
+            () => void runStorageMaintenance(),
+            intervalMs,
+          );
+        }
       },
       stop: async () => {
         if (backupTimer) {
           clearInterval(backupTimer);
           backupTimer = null;
+        }
+        if (storageMaintenanceInitialTimer) {
+          clearTimeout(storageMaintenanceInitialTimer);
+          storageMaintenanceInitialTimer = null;
+        }
+        if (storageMaintenanceTimer) {
+          clearInterval(storageMaintenanceTimer);
+          storageMaintenanceTimer = null;
         }
         api.logger.info("memory-lancedb-pro: stopped");
       },
@@ -5150,6 +5213,12 @@ export function parsePluginConfig(value: unknown): PluginConfig {
   const workspaceBoundaryRaw = typeof cfg.workspaceBoundary === "object" && cfg.workspaceBoundary !== null
     ? cfg.workspaceBoundary as Record<string, unknown>
     : null;
+  const storageMaintenanceRaw = typeof cfg.storageMaintenance === "object" && cfg.storageMaintenance !== null
+    ? cfg.storageMaintenance as Record<string, unknown>
+    : null;
+  const storageAutoCleanupRaw = typeof storageMaintenanceRaw?.autoCleanup === "object" && storageMaintenanceRaw.autoCleanup !== null
+    ? storageMaintenanceRaw.autoCleanup as Record<string, unknown>
+    : null;
   const userMdExclusiveRaw = typeof workspaceBoundaryRaw?.userMdExclusive === "object" && workspaceBoundaryRaw.userMdExclusive !== null
     ? workspaceBoundaryRaw.userMdExclusive as Record<string, unknown>
     : null;
@@ -5214,6 +5283,16 @@ export function parsePluginConfig(value: unknown): PluginConfig {
       clientTimeoutMs: parsePositiveInt(embedding.clientTimeoutMs),
     },
     dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : undefined,
+    storageMaintenance: storageAutoCleanupRaw
+      ? {
+        autoCleanup: {
+          enabled: storageAutoCleanupRaw.enabled === true,
+          intervalHours: parsePositiveInt(storageAutoCleanupRaw.intervalHours) ?? 24,
+          retentionDays: parsePositiveInt(storageAutoCleanupRaw.retentionDays) ?? 7,
+          initialDelayMs: parseNonNegativeInt(storageAutoCleanupRaw.initialDelayMs) ?? 300_000,
+        },
+      }
+      : undefined,
     autoCapture: cfg.autoCapture !== false,
     // Default OFF: only enable when explicitly set to true.
     autoRecall: cfg.autoRecall === true,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -133,6 +133,42 @@
       "dbPath": {
         "type": "string"
       },
+      "storageMaintenance": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Optional LanceDB table maintenance for pruning old version snapshots with table.optimize(). Disabled by default.",
+        "properties": {
+          "autoCleanup": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Enable scheduled LanceDB table.optimize() cleanup."
+              },
+              "intervalHours": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 24,
+                "description": "Hours between scheduled storage maintenance runs."
+              },
+              "retentionDays": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 7,
+                "description": "Keep LanceDB table versions newer than this many days."
+              },
+              "initialDelayMs": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 300000,
+                "description": "Delay before the first storage maintenance run after service start."
+              }
+            }
+          }
+        }
+      },
       "enableManagementTools": {
         "type": "boolean",
         "default": false,
@@ -1521,6 +1557,29 @@
       "label": "Database Path",
       "placeholder": "~/.openclaw/memory/lancedb-pro",
       "help": "Directory path for the LanceDB database files",
+      "advanced": true
+    },
+    "storageMaintenance.autoCleanup.enabled": {
+      "label": "Storage Auto-Cleanup",
+      "help": "Run scheduled LanceDB table maintenance to remove old version snapshots. Disabled by default.",
+      "advanced": true
+    },
+    "storageMaintenance.autoCleanup.intervalHours": {
+      "label": "Storage Cleanup Interval",
+      "placeholder": "24",
+      "help": "Hours between scheduled LanceDB table.optimize() cleanup runs.",
+      "advanced": true
+    },
+    "storageMaintenance.autoCleanup.retentionDays": {
+      "label": "Storage Retention Days",
+      "placeholder": "7",
+      "help": "Keep LanceDB table versions newer than this many days.",
+      "advanced": true
+    },
+    "storageMaintenance.autoCleanup.initialDelayMs": {
+      "label": "Storage Cleanup Initial Delay",
+      "placeholder": "300000",
+      "help": "Milliseconds to wait after startup before the first storage cleanup run.",
       "advanced": true
     },
     "smartExtraction": {

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -17,6 +17,7 @@ export const CI_TEST_MANIFEST = [
   { group: "storage-and-schema", runner: "node", file: "test/store-empty-scope-filter.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/store-timestamp-normalization.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/storage-path-normalization.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/storage-maintenance.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/store-list-stats-projection-fallback.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/recall-text-cleanup.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/update-consistency-lancedb.test.mjs" },

--- a/src/store.ts
+++ b/src/store.ts
@@ -57,6 +57,12 @@ export interface StoreConfig {
   onStoragePathWarning?: (message: string) => void;
 }
 
+export interface StorageMaintenanceResult {
+  retentionDays: number;
+  cleanupOlderThan: string;
+  stats: unknown;
+}
+
 export interface MetadataPatch {
   [key: string]: unknown;
 }
@@ -646,6 +652,30 @@ export class MemoryStore {
 
   get dbPath(): string {
     return this.config.dbPath;
+  }
+
+  async runStorageMaintenance(retentionDays = 7): Promise<StorageMaintenanceResult> {
+    if (this.destroyed) {
+      throw new Error("MemoryStore instance has been destroyed");
+    }
+
+    await this.ensureInitialized();
+
+    const safeRetentionDays = clampInt(retentionDays, 1, 3650);
+    const cleanupOlderThan = new Date(Date.now() - safeRetentionDays * 24 * 60 * 60 * 1000);
+
+    return this.runWithFileLock(async () => {
+      if (!this.table || typeof this.table.optimize !== "function") {
+        throw new Error("LanceDB table.optimize() is not available in this runtime");
+      }
+
+      const stats = await this.table.optimize({ cleanupOlderThan });
+      return {
+        retentionDays: safeRetentionDays,
+        cleanupOlderThan: cleanupOlderThan.toISOString(),
+        stats,
+      };
+    });
   }
 
   private async ensureInitialized(): Promise<void> {

--- a/test/storage-maintenance.test.mjs
+++ b/test/storage-maintenance.test.mjs
@@ -1,0 +1,156 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginSdkStubPath = path.resolve(testDir, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+const { MemoryStore, __setLockfileModuleForTests } = jiti("../src/store.ts");
+const { parsePluginConfig } = jiti("../index.ts");
+
+const tempDirs = [];
+
+afterEach(() => {
+  __setLockfileModuleForTests({
+    lock: async () => async () => {},
+  });
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeStoreWithMockTable(table) {
+  const dir = mkdtempSync(join(tmpdir(), "memory-lancedb-pro-maintenance-"));
+  tempDirs.push(dir);
+  const store = new MemoryStore({ dbPath: dir, vectorDim: 3 });
+  store.table = table;
+  return store;
+}
+
+describe("LanceDB storage maintenance", () => {
+  it("runs table.optimize under the store write lock", async () => {
+    const calls = [];
+    let releases = 0;
+    __setLockfileModuleForTests({
+      lock: async () => {
+        calls.push("lock");
+        return async () => {
+          releases += 1;
+        };
+      },
+    });
+
+    let optimizeOptions;
+    const store = makeStoreWithMockTable({
+      optimize: async (options) => {
+        optimizeOptions = options;
+        return { removedFiles: 2 };
+      },
+    });
+
+    const startedAt = Date.now();
+    const result = await store.runStorageMaintenance(3);
+
+    assert.deepEqual(calls, ["lock"]);
+    assert.equal(releases, 1);
+    assert.equal(result.retentionDays, 3);
+    assert.deepEqual(result.stats, { removedFiles: 2 });
+    assert.ok(optimizeOptions.cleanupOlderThan instanceof Date);
+    assert.ok(
+      Math.abs(optimizeOptions.cleanupOlderThan.getTime() - (startedAt - 3 * 24 * 60 * 60 * 1000)) < 5000,
+      "cleanup cutoff should be based on the requested retention days",
+    );
+    assert.equal(result.cleanupOlderThan, optimizeOptions.cleanupOlderThan.toISOString());
+  });
+
+  it("clamps unsafe retention values before cleanup", async () => {
+    __setLockfileModuleForTests({
+      lock: async () => async () => {},
+    });
+    const store = makeStoreWithMockTable({
+      optimize: async () => ({ ok: true }),
+    });
+
+    const result = await store.runStorageMaintenance(0);
+
+    assert.equal(result.retentionDays, 1);
+  });
+
+  it("keeps optimize failures observable", async () => {
+    let releases = 0;
+    __setLockfileModuleForTests({
+      lock: async () => async () => {
+        releases += 1;
+      },
+    });
+    const store = makeStoreWithMockTable({
+      optimize: async () => {
+        throw new Error("optimize failed");
+      },
+    });
+
+    await assert.rejects(
+      () => store.runStorageMaintenance(7),
+      /optimize failed/,
+    );
+    assert.equal(releases, 1, "lock should still be released after optimize failure");
+  });
+});
+
+describe("storage maintenance config", () => {
+  it("parses auto-cleanup defaults and explicit values", () => {
+    const parsed = parsePluginConfig({
+      embedding: { apiKey: "test-key" },
+      storageMaintenance: {
+        autoCleanup: {
+          enabled: true,
+          intervalHours: "12",
+          retentionDays: 5,
+          initialDelayMs: 0,
+        },
+      },
+    });
+
+    assert.deepEqual(parsed.storageMaintenance, {
+      autoCleanup: {
+        enabled: true,
+        intervalHours: 12,
+        retentionDays: 5,
+        initialDelayMs: 0,
+      },
+    });
+  });
+
+  it("declares schema and ui hints for auto-cleanup", () => {
+    const manifest = JSON.parse(
+      readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+    );
+
+    assert.equal(
+      manifest.configSchema.properties.storageMaintenance.properties.autoCleanup.properties.enabled.default,
+      false,
+    );
+    assert.equal(
+      manifest.configSchema.properties.storageMaintenance.properties.autoCleanup.properties.intervalHours.default,
+      24,
+    );
+    assert.equal(
+      manifest.configSchema.properties.storageMaintenance.properties.autoCleanup.properties.retentionDays.default,
+      7,
+    );
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(manifest.uiHints, "storageMaintenance.autoCleanup.enabled"),
+      "storage maintenance should be discoverable in ui hints",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add opt-in scheduled LanceDB table maintenance for old version snapshots
- serialize cleanup with existing store write locking and log success/failure details
- expose storage maintenance config in the plugin manifest with regression coverage

Fixes #792

## Verification
- node --test test/storage-maintenance.test.mjs
- npm run build
- npm run test:storage-and-schema
- npm run test:packaging-and-workflow