### PR TITLE
docs: add public X source memory recipe

### DIFF
--- a/docs/openclaw-integration-playbook.md
+++ b/docs/openclaw-integration-playbook.md
@@ -238,6 +238,45 @@ For session transcript coverage, verify a recent `~/.openclaw/agents/<agentId>/s
 
 For dreaming coverage, verify that `memory/dreaming/*.md` appears as a `dream-report` public artifact and that `memory/.dreams/events.jsonl` appears as an `event-log` public artifact when present.
 
+### Public X/Twitter source capture
+
+Use this optional recipe when an OpenClaw agent gathers public X/Twitter context through TweetClaw and you want a reviewed source summary to become searchable memory.
+
+Allowed source actions:
+
+- search public tweets or replies
+- look up a public user profile
+- export public follower or media metadata when the workflow needs it
+- consume monitors or webhooks that report public tweet events
+
+Before calling `memory_store`, review the source result and keep only durable research context:
+
+- tweet URL
+- author handle
+- published timestamp
+- short text excerpt or human-written summary
+- relevant metrics, if needed for the research task
+- query or monitor that found the source
+- capture date
+
+Store the reviewed summary as `category: "fact"` for source evidence or `category: "decision"` when the team has made a decision from that evidence. Include the public source URL and capture date in the memory text or metadata so later recall can cite where the information came from.
+
+Never store secrets or private account material from this flow:
+
+- API keys, cookies, bearer tokens, or account credentials
+- direct-message content
+- draft post or reply text
+- non-public profile, follower, or media data
+
+Keep visible X/Twitter actions outside the memory plugin. Posting tweets, posting replies, sending direct messages, uploading media, and downloading media require explicit user approval in the tool workflow that performs the action. `memory-lancedb-pro` should only persist the reviewed summary after that workflow has produced safe public source context.
+
+Verification checklist:
+
+- the stored memory contains the public URL and capture date
+- the text is a summary or short excerpt, not a raw transcript dump
+- no credentials, cookies, direct messages, or draft text appear in the memory
+- any visible action on X/Twitter was approved outside the memory plugin
+
 ### Scope isolation
 
 Validate at least:

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -33,6 +33,7 @@ export const CI_TEST_MANIFEST = [
   { group: "core-regression", runner: "node", file: "test/memory-capability-runtime.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/corpus-indexer.test.mjs" },
   { group: "packaging-and-workflow", runner: "node", file: "test/plugin-manifest-regression.mjs" },
+  { group: "packaging-and-workflow", runner: "node", file: "test/openclaw-twitter-source-recipe.test.mjs", args: ["--test"] },
   { group: "packaging-and-workflow", runner: "node", file: "test/package-runtime.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/session-summary-before-reset.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/self-improvement-reset-note.test.mjs", args: ["--test"] },

--- a/test/openclaw-twitter-source-recipe.test.mjs
+++ b/test/openclaw-twitter-source-recipe.test.mjs
@@ -1,0 +1,30 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const playbook = readFileSync(
+  new URL("../docs/openclaw-integration-playbook.md", import.meta.url),
+  "utf8",
+);
+
+describe("OpenClaw X/Twitter source recipe", () => {
+  it("documents the public TweetClaw-to-memory_store flow", () => {
+    assert.match(playbook, /Public X\/Twitter source capture/);
+    assert.match(playbook, /TweetClaw/);
+    assert.match(playbook, /memory_store/);
+    assert.match(playbook, /tweet URL/i);
+    assert.match(playbook, /author handle/i);
+    assert.match(playbook, /capture date/i);
+    assert.match(playbook, /category: "fact"/);
+    assert.match(playbook, /category: "decision"/);
+  });
+
+  it("keeps privacy and visible-action guardrails in the recipe", () => {
+    assert.match(playbook, /API keys, cookies, bearer tokens, or account credentials/);
+    assert.match(playbook, /direct-message content/);
+    assert.match(playbook, /draft post or reply text/);
+    assert.match(playbook, /non-public profile, follower, or media data/);
+    assert.match(playbook, /explicit user approval/);
+    assert.match(playbook, /memory-lancedb-pro` should only persist the reviewed summary/);
+  });
+});


### PR DESCRIPTION
## Summary
- document a safe public X/Twitter source capture recipe for TweetClaw workflows
- define reviewed source fields for memory_store
- add privacy and visible-action approval guardrails with doc regression coverage

Fixes #861

## Verification
- node --test test/openclaw-twitter-source-recipe.test.mjs
- npm run build
- npm run test:packaging-and-workflow