### PR TITLE
docs: clarify read-only scope fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Query → BM25 FTS ─────┘
 - Built-in scopes: `global`, `agent:<id>`, `custom:<name>`, `project:<id>`, `user:<id>`
 - Agent-level access control via `scopes.agentAccess`
 - Default: each agent accesses `global` + its own `agent:<id>` scope
+- Read-only tools such as `memory_recall`, `memory_search`, `memory_list`, and `memory_debug` fail soft when a requested scope is inaccessible: they search the caller's accessible scopes instead and return `ignoredScope` plus `accessibleScopes` in details. Write and mutation tools still return `scope_access_denied` for inaccessible scopes.
 
 ### Auto-Capture & Auto-Recall
 

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -1368,7 +1368,7 @@ export function registerMemoryStatsTool(api, context) {
 }
 export function registerMemoryDebugTool(api, context) {
     api.registerTool((toolCtx) => {
-        const agentId = resolveAgentId(toolCtx?.agentId, context.agentId) ?? "main";
+        const staticAgentId = resolveAgentId(toolCtx?.agentId, context.agentId);
         return {
             name: "memory_debug",
             label: "Memory Debug",
@@ -1378,10 +1378,11 @@ export function registerMemoryDebugTool(api, context) {
                 limit: Type.Optional(Type.Number({ description: "Max results to return (default: 5, max: 20)" })),
                 scope: Type.Optional(Type.String({ description: "Specific memory scope to search in (optional)" })),
             }),
-            async execute(_toolCallId, params) {
+            async execute(_toolCallId, params, _signal, _onUpdate, runtimeCtx) {
                 const { query, limit = 5, scope } = params;
                 try {
                     const safeLimit = clampInt(limit, 1, 20);
+                    const agentId = resolveRuntimeAgentId(staticAgentId, runtimeCtx);
                     const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
                     const { scopeFilter } = resolvedScopes;
                     const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1754,7 +1754,7 @@ export function registerMemoryDebugTool(
 ) {
   api.registerTool(
     (toolCtx) => {
-      const agentId = resolveAgentId((toolCtx as any)?.agentId, context.agentId) ?? "main";
+      const staticAgentId = resolveAgentId((toolCtx as any)?.agentId, context.agentId);
       return {
         name: "memory_debug",
         label: "Memory Debug",
@@ -1769,12 +1769,13 @@ export function registerMemoryDebugTool(
             Type.String({ description: "Specific memory scope to search in (optional)" }),
           ),
         }),
-        async execute(_toolCallId, params) {
+        async execute(_toolCallId, params, _signal, _onUpdate, runtimeCtx) {
           const { query, limit = 5, scope } = params as {
             query: string; limit?: number; scope?: string;
           };
           try {
             const safeLimit = clampInt(limit, 1, 20);
+            const agentId = resolveRuntimeAgentId(staticAgentId, runtimeCtx);
             const resolvedScopes = resolveReadableToolScopeFilter(context.scopeManager, agentId, scope);
             const { scopeFilter } = resolvedScopes;
             const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);

--- a/test/memory-governance-tools.test.mjs
+++ b/test/memory-governance-tools.test.mjs
@@ -119,6 +119,55 @@ describe("memory governance tools", () => {
     assert.equal(res.details.requestedScope, "current_conversation");
   });
 
+  it("resolves memory_debug scopes from execute-time runtime context", async () => {
+    const debugScopeFilters = [];
+    const context = {
+      workspaceDir: "/tmp",
+      mdMirror: null,
+      scopeManager: {
+        getAccessibleScopes: (agentId) => ["global", `agent:${agentId}`, `reflection:agent:${agentId}`],
+        getScopeFilter: (agentId) => ["global", `agent:${agentId}`, `reflection:agent:${agentId}`],
+        isAccessible: (scope, agentId) => ["global", `agent:${agentId}`, `reflection:agent:${agentId}`].includes(scope),
+        getDefaultScope: (agentId) => `agent:${agentId}`,
+      },
+      retriever: {
+        async retrieveWithTrace({ scopeFilter }) {
+          debugScopeFilters.push(scopeFilter);
+          return {
+            results: [],
+            trace: {
+              mode: "hybrid",
+              totalMs: 1,
+              stages: [],
+            },
+          };
+        },
+        getConfig() {
+          return { mode: "hybrid" };
+        },
+      },
+      store: {},
+      embedder: { async embedPassage() { return [0.1, 0.2, 0.3]; } },
+    };
+
+    const tools = createToolSet(context);
+    const debug = tools.get("memory_debug");
+
+    const res = await debug.execute(
+      null,
+      { query: "coffee", scope: "current_conversation" },
+      undefined,
+      undefined,
+      { agentId: "debugger" },
+    );
+
+    const expectedScopes = ["global", "agent:debugger", "reflection:agent:debugger"];
+    assert.deepEqual(debugScopeFilters[0], expectedScopes);
+    assert.match(res.content[0].text, /Ignored inaccessible scope "current_conversation"/);
+    assert.equal(res.details.ignoredScope, "current_conversation");
+    assert.deepEqual(res.details.accessibleScopes, expectedScopes);
+  });
+
   it("defaults stats and list to the caller's accessible scopes", async () => {
     const statsScopeFilters = [];
     const listScopeFilters = [];


### PR DESCRIPTION
Follow-up from PR #878 review after the original PR was merged and its branch deleted.

Changes:
- Align `memory_debug` with other read-only tools by resolving agent identity from execute-time runtime context.
- Document that read-only tools return `ignoredScope` / `accessibleScopes` when a requested scope is inaccessible, while mutation tools still hard-deny with `scope_access_denied`.
- Add focused regression coverage for `memory_debug` runtime scope resolution.

Validation:
- `node --test test/memory-governance-tools.test.mjs`
- `npx tsc -p tsconfig.json --noEmit`