### PR TITLE
fix: await store init before retrieval routing reads hasFtsSupport

### DIFF
--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -340,6 +340,8 @@ export class MemoryRetriever {
         const { query, limit, scopeFilter, category, source, signal } = context;
         const safeLimit = clampInt(limit, 1, 20);
         this.lastDiagnostics = null;
+        // FLEET-PATCH(#884): resolve lazy store init BEFORE routing reads hasFtsSupport.
+        await this.store.ensureInitialized?.();
         const diagnostics = {
             source,
             mode: this.config.mode,

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -588,6 +588,10 @@ export class MemoryRetriever {
     const { query, limit, scopeFilter, category, source, signal } = context;
     const safeLimit = clampInt(limit, 1, 20);
     this.lastDiagnostics = null;
+
+    // FLEET-PATCH(#884): resolve lazy store init BEFORE routing reads hasFtsSupport,
+    // otherwise the first retrieve() in a fresh process silently routes vector-only.
+    await (this.store as { ensureInitialized?: () => Promise<void> }).ensureInitialized?.();
     const diagnostics: RetrievalDiagnostics = {
       source,
       mode: this.config.mode,

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -591,7 +591,7 @@ export class MemoryRetriever {
 
     // FLEET-PATCH(#884): resolve lazy store init BEFORE routing reads hasFtsSupport,
     // otherwise the first retrieve() in a fresh process silently routes vector-only.
-    await (this.store as { ensureInitialized?: () => Promise<void> }).ensureInitialized?.();
+    await (this.store as unknown as { ensureInitialized?: () => Promise<void> }).ensureInitialized?.();
     const diagnostics: RetrievalDiagnostics = {
       source,
       mode: this.config.mode,


### PR DESCRIPTION
Fixes [#884](https://github.com/CortexReach/memory-lancedb-pro/issues/884).

## Problem

`MemoryRetriever.retrieve()` decides between hybrid and vector-only retrieval by reading `this.store.hasFtsSupport` before any store operation has triggered the store's lazy `ensureInitialized()`. On the first `retrieve()` of a fresh process the getter still returns the constructor default `false`, so the search silently routes vector-only. Every `openclaw memory-pro search` invocation is a fresh process, which means the CLI never exercised BM25 or the cross-encoder rerank at all (both live behind the hybrid route).

## Fix

One awaited call at the top of `retrieve()` so initialization resolves before the routing check. Optional chaining keeps it safe for store implementations without the method.

The same change is mirrored into `dist/src/retriever.js` to match this repo's convention of committing compiled output. Happy to drop that hunk if you prefer to regenerate dist through your own build.

## Verification

A/B on an identical store and query (a rare keyword that appears verbatim in exactly one stored memory; scoped search; fresh process for each run):

| | bm25ResultCount | result tags |
| --- | --- | --- |
| before | 0 | `vector` only |
| after | 1 | `vector+BM25+reranked` |

Also verified in a live OpenClaw deployment: first-call CLI searches now report non-zero BM25 counts and reranked tags, with no behavior change for already-initialized stores (the await is a no-op once init has completed).