### PR TITLE
fix: fold FTS index after write threshold and on startup backlog

### DIFF
--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -30,6 +30,21 @@ export function __setLockfileModuleForTests(module) {
 }
 export const loadLanceDB = async () => {
     if (!lancedbImportPromise) {
+        // @lancedb/lancedb's napi-rs loader (dist/native.js) detects musl via
+        // process.report.getReport(). The report's network section performs
+        // reverse-DNS lookups for every network interface, synchronously on the
+        // calling thread; on hosts with several interfaces and a slow or flaky
+        // DNS path (measured on WSL2 + Tailscale) this blocks the event loop for
+        // 110-250s on the FIRST LanceDB load — the host app's HTTP server and
+        // pollers freeze with CPU at 0% (main thread stuck in poll()). Excluding
+        // the network section turns the measured 235s hang into ~3ms and loses
+        // nothing: isMusl() only reads report.header.glibcVersionRuntime.
+        try {
+            process.report.excludeNetwork = true;
+        }
+        catch {
+            /* Node < 22 without the flag — keep the previous behavior */
+        }
         // Use a createRequire-built require() so LanceDB's CommonJS native bindings
         // keep Windows-safe CJS semantics while still working in pure ESM runtimes.
         // Do not name this binding "require": bundlers may rewrite bare require()
@@ -361,6 +376,8 @@ export class MemoryStore {
     _lastFtsError = null;
     updateQueue = Promise.resolve();
     nativeCosineFallbackLogged = false;
+    dataModsSinceIndexFold = 0;
+    indexFoldInFlight = false;
     // Cross-call batch accumulator（Issue #690）
     // 多個 concurrent bulkStore() 會先累積在這裡，每 100ms flush 一次，
     // 合併成一個 lock acquisition，大幅降低 lock contention。
@@ -381,6 +398,10 @@ export class MemoryStore {
     // 【MR2 fix】pendingBatch 上限，防止高生產率時無限增長。
     // 當 pending callers 超過此值時，block 並同步 flush，確保 pendingBatch 不會無限膨胀。
     static MAX_PENDING_BATCH_SIZE = 1000;
+    // LanceDB indices are point-in-time snapshots; the SDK recommends running
+    // optimize() after ~20 data modification operations so indices fold in
+    // newly written rows instead of leaving them in the brute-force-scanned tail.
+    static INDEX_FOLD_OP_THRESHOLD = 20;
     config;
     disableNativeCosine;
     constructor(config) {
@@ -538,6 +559,63 @@ export class MemoryStore {
             };
         });
     }
+    /**
+     * Fold newly written rows into existing indices without touching version
+     * history. LanceDB indices are point-in-time snapshots: rows added after
+     * index creation sit in an unindexed tail that searches must brute-force
+     * scan, so without periodic optimize() the FTS index never covers rows
+     * written after first init. The epoch cleanupOlderThan cutoff makes the
+     * prune step a no-op; version retention stays under the opt-in
+     * storageMaintenance.autoCleanup path (see runStorageMaintenance).
+     */
+    async foldIndices(reason) {
+        if (this.indexFoldInFlight || !this.table || typeof this.table.optimize !== "function") {
+            return;
+        }
+        this.indexFoldInFlight = true;
+        const mods = this.dataModsSinceIndexFold;
+        this.dataModsSinceIndexFold = 0;
+        try {
+            await this.runWithFileLock(async () => {
+                await this.table.optimize({ cleanupOlderThan: new Date(0) });
+            });
+            console.log(`[memory-lancedb-pro] index fold completed (reason=${reason}, modsSinceLast=${mods})`);
+        }
+        catch (err) {
+            // Re-arm the counter so a transient failure retries on later writes.
+            this.dataModsSinceIndexFold += mods;
+            console.warn(`[memory-lancedb-pro] index fold failed (reason=${reason}): ${err instanceof Error ? err.message : String(err)}`);
+        }
+        finally {
+            this.indexFoldInFlight = false;
+        }
+    }
+    noteDataModification() {
+        this.dataModsSinceIndexFold += 1;
+        if (this.dataModsSinceIndexFold >= MemoryStore.INDEX_FOLD_OP_THRESHOLD) {
+            void this.foldIndices("write-threshold");
+        }
+    }
+    async scheduleStartupIndexCatchUp() {
+        try {
+            const table = this.table;
+            if (!table || typeof table.indexStats !== "function")
+                return;
+            const indices = await table.listIndices();
+            const fts = indices.find((idx) => idx.indexType === "FTS" || idx.columns?.includes("text"));
+            if (!fts)
+                return;
+            const stats = await table.indexStats(fts.name ?? "text_idx");
+            const backlog = stats?.numUnindexedRows ?? 0;
+            if (backlog >= MemoryStore.INDEX_FOLD_OP_THRESHOLD) {
+                console.log(`[memory-lancedb-pro] FTS index has ${backlog} unindexed rows; scheduling catch-up fold`);
+                void this.foldIndices("startup-backlog");
+            }
+        }
+        catch {
+            // Index stats are best-effort; failures must never affect initialization.
+        }
+    }
     async ensureInitialized() {
         if (this.table) {
             return;
@@ -658,6 +736,9 @@ export class MemoryStore {
         }
         this.db = db;
         this.table = table;
+        // Fold any unindexed backlog accumulated while no maintenance ran
+        // (best-effort, runs in the background, never blocks initialization).
+        void this.scheduleStartupIndexCatchUp();
     }
     async backfillLegacySecondTimestamps(table) {
         try {
@@ -774,7 +855,7 @@ export class MemoryStore {
     }
     async upsert(entry) {
         await this.ensureInitialized();
-        return this.runWithFileLock(() => this.runSerializedUpdate(async () => {
+        const result = await this.runWithFileLock(() => this.runSerializedUpdate(async () => {
             const safeId = escapeSqlLiteral(entry.id);
             await this.table.delete(`id = '${safeId}'`).catch(() => undefined);
             const normalizedEntry = {
@@ -784,6 +865,8 @@ export class MemoryStore {
             await this.table.add([normalizedEntry]);
             return normalizedEntry;
         }));
+        this.noteDataModification();
+        return result;
     }
     /**
      * Store multiple memory entries in a single batch operation.
@@ -928,6 +1011,7 @@ export class MemoryStore {
                     await this.runWithFileLock(async () => {
                         await this.table.add(chunk);
                     });
+                    this.noteDataModification();
                 }
                 catch (err) {
                     lastError = err;
@@ -1645,6 +1729,7 @@ export class MemoryStore {
                     await this.table.delete(`(${deleteWhereClause})`);
                     deleted = true;
                     await this.table.add(updatedEntries);
+                    this.noteDataModification();
                     for (let index = 0; index < updatedEntries.length; index++) {
                         results.set(updatedInputIndices[index], {
                             id: updatedEntries[index].id,
@@ -1812,6 +1897,7 @@ export class MemoryStore {
                 throw new Error(`Failed to update memory ${id}: write failed after delete, latest available record restored. ` +
                     `Write error: ${addError instanceof Error ? addError.message : String(addError)}`);
             }
+            this.noteDataModification();
             return updated;
         }));
     }

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -18,6 +18,7 @@ export const CI_TEST_MANIFEST = [
   { group: "storage-and-schema", runner: "node", file: "test/store-timestamp-normalization.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/storage-path-normalization.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/storage-maintenance.test.mjs", args: ["--test"] },
+  { group: "storage-and-schema", runner: "node", file: "test/fts-index-fold.test.mjs", args: ["--test"] },
   { group: "storage-and-schema", runner: "node", file: "test/store-list-stats-projection-fallback.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/recall-text-cleanup.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/category-filter-normalization.test.mjs", args: ["--test"] },

--- a/src/store.ts
+++ b/src/store.ts
@@ -508,6 +508,8 @@ export class MemoryStore {
   private _lastFtsError: string | null = null;
   private updateQueue: Promise<void> = Promise.resolve();
   private nativeCosineFallbackLogged = false;
+  private dataModsSinceIndexFold = 0;
+  private indexFoldInFlight = false;
 
   // Cross-call batch accumulator（Issue #690）
   // 多個 concurrent bulkStore() 會先累積在這裡，每 100ms flush 一次，
@@ -535,6 +537,10 @@ export class MemoryStore {
   // 【MR2 fix】pendingBatch 上限，防止高生產率時無限增長。
   // 當 pending callers 超過此值時，block 並同步 flush，確保 pendingBatch 不會無限膨胀。
   private static readonly MAX_PENDING_BATCH_SIZE = 1000;
+  // LanceDB indices are point-in-time snapshots; the SDK recommends running
+  // optimize() after ~20 data modification operations so indices fold in
+  // newly written rows instead of leaving them in the brute-force-scanned tail.
+  private static readonly INDEX_FOLD_OP_THRESHOLD = 20;
 
   private readonly config: StoreConfig;
   private readonly disableNativeCosine: boolean;
@@ -693,6 +699,69 @@ export class MemoryStore {
     });
   }
 
+  /**
+   * Fold newly written rows into existing indices without touching version
+   * history. LanceDB indices are point-in-time snapshots: rows added after
+   * index creation sit in an unindexed tail that searches must brute-force
+   * scan, so without periodic optimize() the FTS index never covers rows
+   * written after first init. The epoch cleanupOlderThan cutoff makes the
+   * prune step a no-op; version retention stays under the opt-in
+   * storageMaintenance.autoCleanup path (see runStorageMaintenance).
+   */
+  private async foldIndices(reason: string): Promise<void> {
+    if (this.indexFoldInFlight || !this.table || typeof this.table.optimize !== "function") {
+      return;
+    }
+    this.indexFoldInFlight = true;
+    const mods = this.dataModsSinceIndexFold;
+    this.dataModsSinceIndexFold = 0;
+    try {
+      await this.runWithFileLock(async () => {
+        await this.table!.optimize({ cleanupOlderThan: new Date(0) });
+      });
+      console.log(
+        `[memory-lancedb-pro] index fold completed (reason=${reason}, modsSinceLast=${mods})`,
+      );
+    } catch (err) {
+      // Re-arm the counter so a transient failure retries on later writes.
+      this.dataModsSinceIndexFold += mods;
+      console.warn(
+        `[memory-lancedb-pro] index fold failed (reason=${reason}): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      this.indexFoldInFlight = false;
+    }
+  }
+
+  private noteDataModification(): void {
+    this.dataModsSinceIndexFold += 1;
+    if (this.dataModsSinceIndexFold >= MemoryStore.INDEX_FOLD_OP_THRESHOLD) {
+      void this.foldIndices("write-threshold");
+    }
+  }
+
+  private async scheduleStartupIndexCatchUp(): Promise<void> {
+    try {
+      const table = this.table;
+      if (!table || typeof table.indexStats !== "function") return;
+      const indices = await table.listIndices();
+      const fts = indices.find(
+        (idx) => idx.indexType === "FTS" || idx.columns?.includes("text"),
+      );
+      if (!fts) return;
+      const stats = await table.indexStats((fts as any).name ?? "text_idx");
+      const backlog = stats?.numUnindexedRows ?? 0;
+      if (backlog >= MemoryStore.INDEX_FOLD_OP_THRESHOLD) {
+        console.log(
+          `[memory-lancedb-pro] FTS index has ${backlog} unindexed rows; scheduling catch-up fold`,
+        );
+        void this.foldIndices("startup-backlog");
+      }
+    } catch {
+      // Index stats are best-effort; failures must never affect initialization.
+    }
+  }
+
   private async ensureInitialized(): Promise<void> {
     if (this.table) {
       return;
@@ -834,6 +903,10 @@ export class MemoryStore {
 
     this.db = db;
     this.table = table;
+
+    // Fold any unindexed backlog accumulated while no maintenance ran
+    // (best-effort, runs in the background, never blocks initialization).
+    void this.scheduleStartupIndexCatchUp();
   }
 
   private async backfillLegacySecondTimestamps(table: LanceDB.Table): Promise<void> {
@@ -979,7 +1052,7 @@ export class MemoryStore {
   async upsert(entry: MemoryEntry): Promise<MemoryEntry> {
     await this.ensureInitialized();
 
-    return this.runWithFileLock(() => this.runSerializedUpdate(async () => {
+    const result = await this.runWithFileLock(() => this.runSerializedUpdate(async () => {
       const safeId = escapeSqlLiteral(entry.id);
       await this.table!.delete(`id = '${safeId}'`).catch(() => undefined);
       const normalizedEntry: MemoryEntry = {
@@ -989,6 +1062,8 @@ export class MemoryStore {
       await this.table!.add([normalizedEntry]);
       return normalizedEntry;
     }));
+    this.noteDataModification();
+    return result;
   }
 
   /**
@@ -1149,6 +1224,7 @@ export class MemoryStore {
           await this.runWithFileLock(async () => {
             await this.table!.add(chunk);
           });
+          this.noteDataModification();
         } catch (err) {
           lastError = err as Error;
           // 標記此 chunk 區間內的所有 caller 為失敗
@@ -2018,6 +2094,7 @@ export class MemoryStore {
           await this.table!.delete(`(${deleteWhereClause})`);
           deleted = true;
           await this.table!.add(updatedEntries);
+          this.noteDataModification();
           for (let index = 0; index < updatedEntries.length; index++) {
             results.set(updatedInputIndices[index], {
               id: updatedEntries[index].id,
@@ -2220,6 +2297,7 @@ export class MemoryStore {
         );
       }
 
+      this.noteDataModification();
       return updated;
     }));
   }

--- a/test/fts-index-fold.test.mjs
+++ b/test/fts-index-fold.test.mjs
@@ -1,0 +1,121 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import jitiFactory from "jiti";
+import * as lancedb from "@lancedb/lancedb";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const { MemoryStore } = jiti("../src/store.ts");
+
+// Mirrors MemoryStore.INDEX_FOLD_OP_THRESHOLD (private).
+const FOLD_THRESHOLD = 20;
+
+function makeEntry(i) {
+  return {
+    text: `fold probe row ${i} zephyr`,
+    vector: [0.1, 0.2, 0.3],
+    category: "fact",
+    scope: "global",
+    importance: 0.5,
+    metadata: "{}",
+  };
+}
+
+async function ftsIndexStats(dir) {
+  const db = await lancedb.connect(dir);
+  const table = await db.openTable("memories");
+  const indices = await table.listIndices();
+  const fts = indices.find(
+    (idx) => idx.indexType === "FTS" || (idx.columns ?? []).includes("text"),
+  );
+  if (!fts) return null;
+  return await table.indexStats(fts.name ?? "text_idx");
+}
+
+async function waitFor(probe, timeoutMs = 30_000, stepMs = 250) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await probe();
+    if (last) return last;
+    await new Promise((resolve) => setTimeout(resolve, stepMs));
+  }
+  return last;
+}
+
+describe("FTS index fold maintenance", () => {
+  it("folds the unindexed tail after the data-modification threshold", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "memory-lancedb-pro-fold-"));
+    const store = new MemoryStore({ dbPath: dir, vectorDim: 3 });
+    try {
+      for (let i = 0; i < FOLD_THRESHOLD; i++) {
+        await store.store(makeEntry(i));
+      }
+      const folded = await waitFor(async () => {
+        const stats = await ftsIndexStats(dir);
+        return stats &&
+          stats.numUnindexedRows === 0 &&
+          stats.numIndexedRows >= FOLD_THRESHOLD
+          ? stats
+          : null;
+      });
+      assert.ok(
+        folded,
+        "expected a write-threshold index fold to clear the unindexed tail",
+      );
+      assert.equal(folded.numUnindexedRows, 0);
+      assert.ok(folded.numIndexedRows >= FOLD_THRESHOLD);
+    } finally {
+      await store.destroy();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("schedules a catch-up fold at init when a backlog already exists", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "memory-lancedb-pro-catchup-"));
+    // Seed one row through the store so the table and FTS index exist.
+    const seed = new MemoryStore({ dbPath: dir, vectorDim: 3 });
+    await seed.store(makeEntry(0));
+    await seed.destroy();
+
+    // Grow a backlog behind the store's back (no modification counters fire).
+    const db = await lancedb.connect(dir);
+    const table = await db.openTable("memories");
+    const rows = [];
+    for (let i = 1; i <= FOLD_THRESHOLD + 5; i++) {
+      rows.push({
+        id: `raw-backlog-${i}`,
+        text: `backlog row ${i} quartz`,
+        vector: [0.1, 0.2, 0.3],
+        category: "fact",
+        scope: "global",
+        importance: 0.5,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+    }
+    await table.add(rows);
+    const before = await ftsIndexStats(dir);
+    assert.ok(
+      before && before.numUnindexedRows >= FOLD_THRESHOLD,
+      "precondition: an unindexed backlog above the threshold exists",
+    );
+
+    // A fresh store instance should detect the backlog during init and fold it.
+    const store = new MemoryStore({ dbPath: dir, vectorDim: 3 });
+    try {
+      await store.list(undefined, undefined, 1, 0); // trigger lazy init
+      const folded = await waitFor(async () => {
+        const stats = await ftsIndexStats(dir);
+        return stats && stats.numUnindexedRows === 0 ? stats : null;
+      });
+      assert.ok(folded, "expected the startup catch-up fold to clear the backlog");
+      assert.equal(folded.numUnindexedRows, 0);
+    } finally {
+      await store.destroy();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes [#886](https://github.com/CortexReach/memory-lancedb-pro/issues/886)

### What

- `MemoryStore` now counts data modification operations (the batched `table.add` in `doFlush`, plus the delete-and-re-add paths in `upsert`, `update`, and bulk update) and runs `table.optimize({ cleanupOlderThan: new Date(0) })` after 20 ops, following the LanceDB SDK guidance, so indices fold in newly written rows instead of leaving them in the brute-force-scanned unindexed tail. The epoch cutoff makes the prune step a no-op, so version retention remains exclusively under the existing opt-in `storageMaintenance.autoCleanup` path, which is unchanged.
- On initialization, if the FTS index reports an unindexed backlog of 20 or more rows, a one-time background catch-up fold is scheduled. This repairs long-lived stores on the first boot after upgrade (the store in the issue reported `numIndexedRows: 0, numUnindexedRows: 205`).
- Folds are guarded by an in-flight flag, run under the existing cross-process file lock, never block writes or initialization, and re-arm the op counter on failure so a transient error retries on later writes.

### Tests

- New `test/fts-index-fold.test.mjs` (registered in the CI manifest under storage-and-schema): asserts the write-threshold fold and the startup catch-up fold via `indexStats` on a live store. 2/2 pass.
- Neighboring suites pass: storage-maintenance 5/5, update-consistency-lancedb 6/6, cross-process-lock 7/7, store-empty-scope-filter 1/1.

### Notes

`dist/src/store.js` was rebuilt with the repo's `tsc` build. A fresh build also wants to modify `dist/src/retriever.js`, because `src/retriever.ts` already contains a rerank `top_n` cap that the committed dist predates; that file is intentionally left untouched here to keep this PR scoped to the issue. You may want to refresh that file separately.
