### PR TITLE
fix: route dual-memory hint and rerank cost advisory through the CLI-aware logging convention

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15,6 +15,10 @@ import { spawn } from "node:child_process";
 // lifecycle logs are noisy in CLI context (printed to stderr before command output),
 // so we downgrade them to debug level when running in CLI mode.
 const isCliMode = () => process.env.OPENCLAW_CLI === "1";
+// register() can run several times per gateway boot (one per registration
+// context) and once per CLI command; the dual-memory hint only needs to be
+// taught once per process.
+let dualMemoryHintLogged = false;
 // Import core components
 import { MemoryStore, normalizeStoragePath } from "./src/store.js";
 import { createEmbedder, getEffectiveVectorDimensions, } from "./src/embedder.js";
@@ -1695,7 +1699,9 @@ function _initPluginState(api) {
     const retriever = createRetriever(store, embedder, resolvedRetrievalConfig, { decayEngine });
     const rerankCostWarning = buildAutoRecallRerankCostWarning(config, resolvedRetrievalConfig);
     if (rerankCostWarning) {
-        api.logger.warn(rerankCostWarning);
+        // Gateway-boot cost advisory (#843); debug in CLI mode so every
+        // memory-pro command does not repeat it before its output (#888).
+        (isCliMode() ? api.logger.debug : api.logger.warn)(rerankCostWarning);
     }
     const scopeManager = createScopeManager(config.scopes);
     const canonicalCorpusIndexer = new CanonicalCorpusIndexer({
@@ -2116,10 +2122,15 @@ const memoryLanceDBProPlugin = {
         logReg(`memory-lancedb-pro: diagnostic build tag loaded (${DIAG_BUILD_TAG})`);
         // Dual-memory model warning: help users understand the two-layer architecture
         // Runs synchronously and logs warnings; does NOT block gateway startup.
-        api.logger.info(`[memory-lancedb-pro] memory_recall queries the plugin store (LanceDB), not MEMORY.md.\n` +
-            `  - Plugin memory (LanceDB) = primary recall source for semantic search\n` +
-            `  - MEMORY.md / memory/YYYY-MM-DD.md = startup context / journal only\n` +
-            `  - Use memory_store or auto-capture for recallable memories.\n`);
+        // Once per process via the CLI-aware logReg (#888): repeated per-registration
+        // info copies drowned operational logs and CLI command output.
+        if (!dualMemoryHintLogged) {
+            dualMemoryHintLogged = true;
+            logReg(`[memory-lancedb-pro] memory_recall queries the plugin store (LanceDB), not MEMORY.md.\n` +
+                `  - Plugin memory (LanceDB) = primary recall source for semantic search\n` +
+                `  - MEMORY.md / memory/YYYY-MM-DD.md = startup context / journal only\n` +
+                `  - Use memory_store or auto-capture for recallable memories.\n`);
+        }
         // Health status for OpenClaw memory runtime (reflects actual plugin health)
         // Updated by runStartupChecks after testing embedder and retriever
         let embedHealth = {

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,11 @@ import { spawn } from "node:child_process";
 // so we downgrade them to debug level when running in CLI mode.
 const isCliMode = () => process.env.OPENCLAW_CLI === "1";
 
+// register() can run several times per gateway boot (one per registration
+// context) and once per CLI command; the dual-memory hint only needs to be
+// taught once per process.
+let dualMemoryHintLogged = false;
+
 // Import core components
 import { MemoryStore, normalizeStoragePath, type MemoryEntry } from "./src/store.js";
 import {
@@ -2276,7 +2281,9 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
   );
   const rerankCostWarning = buildAutoRecallRerankCostWarning(config, resolvedRetrievalConfig);
   if (rerankCostWarning) {
-    api.logger.warn(rerankCostWarning);
+    // Gateway-boot cost advisory (#843); debug in CLI mode so every
+    // memory-pro command does not repeat it before its output (#888).
+    (isCliMode() ? api.logger.debug : api.logger.warn)(rerankCostWarning);
   }
   const scopeManager = createScopeManager(config.scopes);
   const canonicalCorpusIndexer = new CanonicalCorpusIndexer({
@@ -2815,12 +2822,17 @@ const memoryLanceDBProPlugin = {
 
     // Dual-memory model warning: help users understand the two-layer architecture
     // Runs synchronously and logs warnings; does NOT block gateway startup.
-    api.logger.info(
-      `[memory-lancedb-pro] memory_recall queries the plugin store (LanceDB), not MEMORY.md.\n` +
-      `  - Plugin memory (LanceDB) = primary recall source for semantic search\n` +
-      `  - MEMORY.md / memory/YYYY-MM-DD.md = startup context / journal only\n` +
-      `  - Use memory_store or auto-capture for recallable memories.\n`
-    );
+    // Once per process via the CLI-aware logReg (#888): repeated per-registration
+    // info copies drowned operational logs and CLI command output.
+    if (!dualMemoryHintLogged) {
+      dualMemoryHintLogged = true;
+      logReg(
+        `[memory-lancedb-pro] memory_recall queries the plugin store (LanceDB), not MEMORY.md.\n` +
+        `  - Plugin memory (LanceDB) = primary recall source for semantic search\n` +
+        `  - MEMORY.md / memory/YYYY-MM-DD.md = startup context / journal only\n` +
+        `  - Use memory_store or auto-capture for recallable memories.\n`
+      );
+    }
 
     // Health status for OpenClaw memory runtime (reflects actual plugin health)
     // Updated by runStartupChecks after testing embedder and retriever


### PR DESCRIPTION
Fixes [#888](https://github.com/CortexReach/memory-lancedb-pro/issues/888)

### What

- The dual-memory model hint (from [#344](https://github.com/CortexReach/memory-lancedb-pro/issues/344)) now logs once per process and goes through the existing CLI-aware `logReg` convention: a gateway boot prints it once at info instead of once per registration context, and CLI commands see it only at debug.
- The auto-recall rerank cost advisory from [#843](https://github.com/CortexReach/memory-lancedb-pro/issues/843) remains a gateway-boot warning, but routes to debug when `isCliMode()`, so `memory-pro` subcommand output is no longer prefixed with the multi-line advisory on every invocation.

Both banners keep their educational and cost-awareness intent; only the repetition and the CLI placement change.

### Tests

- `test/startup-health-diagnostics.test.mjs` 2/2 (the `buildAutoRecallRerankCostWarning` builder is untouched; only the log call changes)
- `test/plugin-manifest-regression.mjs` passes

### Note

A clean `tsc -p tsconfig.json` build also wants to modify `dist/src/store.js` and `dist/src/retriever.js`, because `src/` contains fixes the committed dist predates (a `process.report.excludeNetwork` guard against a long first-load hang, and a rerank `top_n` cap). Those files are intentionally left untouched here to keep this PR scoped; filing the dist drift separately.
