### PR TITLE
feat: support SecretRef API key config

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,21 @@ Query → BM25 FTS ─────┘
 
 ## Configuration
 
+API-key fields (`embedding.apiKey`, `retrieval.rerankApiKey`, and `llm.apiKey`) accept plain strings, `${ENV_VAR}` placeholders, or SecretRef objects. This plugin supports the `env` and `file` SecretRef sources:
+
+```json
+{
+  "embedding": {
+    "apiKey": { "source": "env", "id": "JINA_API_KEY" }
+  },
+  "retrieval": {
+    "rerankApiKey": { "source": "file", "id": "~/.openclaw/secrets/jina-rerank" }
+  }
+}
+```
+
+For `source: "file"`, `id` is resolved through OpenClaw's `api.resolvePath()` and then read as a UTF-8 file. The optional `provider` field is accepted for SecretRef object-shape compatibility but is not used for provider dispatch. `exec` and other SecretRef sources are rejected by runtime config validation.
+
 <details>
 <summary><strong>Full Configuration Example</strong></summary>
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -51,6 +51,7 @@ import { normalizeAdmissionControlConfig, resolveRejectedAuditFilePath, } from "
 import { analyzeIntent, applyCategoryBoost } from "./src/intent-analyzer.js";
 import { createOpenClawMemoryCapability } from "./src/openclaw-memory-capability.js";
 import { CanonicalCorpusIndexer, parseCanonicalCorpusConfig, } from "./src/corpus-indexer.js";
+const SUPPORTED_SECRET_REF_SOURCES = ["env", "file"];
 // ============================================================================
 // Default Configuration
 // ============================================================================
@@ -83,8 +84,15 @@ function isSecretRefConfig(value) {
     if (!value || typeof value !== "object" || Array.isArray(value))
         return false;
     const raw = value;
-    return typeof raw.source === "string" && raw.source.trim().length > 0 &&
+    return isSupportedSecretRefSource(raw.source) &&
         typeof raw.id === "string" && raw.id.trim().length > 0;
+}
+function isSupportedSecretRefSource(value) {
+    return typeof value === "string" &&
+        SUPPORTED_SECRET_REF_SOURCES.includes(value.trim());
+}
+function isSecretCredential(value) {
+    return (typeof value === "string" && value.trim().length > 0) || isSecretRefConfig(value);
 }
 function describeSecretRef(ref) {
     return `source=${ref.source}, id=${ref.id}`;
@@ -106,7 +114,8 @@ function resolveSecretRef(api, ref, label) {
                 throw new Error(`file ${filePath} is empty`);
             return value;
         }
-        throw new Error(`unsupported SecretRef source "${source}"`);
+        const exhaustive = source;
+        throw new Error(`unsupported SecretRef source "${exhaustive}"`);
     }
     catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -1665,7 +1674,7 @@ function _initPluginState(api) {
         ...(config.tier || {}),
     });
     const retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...config.retrieval };
-    if (retrievalConfig.rerankApiKey) {
+    if (retrievalConfig.rerank === "cross-encoder" && retrievalConfig.rerankApiKey) {
         retrievalConfig.rerankApiKey = resolveSecretCredential(api, retrievalConfig.rerankApiKey, "retrieval.rerankApiKey");
     }
     const resolvedRetrievalConfig = retrievalConfig;
@@ -4183,6 +4192,9 @@ export function parsePluginConfig(value) {
     const storageMaintenanceRaw = typeof cfg.storageMaintenance === "object" && cfg.storageMaintenance !== null
         ? cfg.storageMaintenance
         : null;
+    const llmRaw = typeof cfg.llm === "object" && cfg.llm !== null
+        ? cfg.llm
+        : null;
     const storageAutoCleanupRaw = typeof storageMaintenanceRaw?.autoCleanup === "object" && storageMaintenanceRaw.autoCleanup !== null
         ? storageMaintenanceRaw.autoCleanup
         : null;
@@ -4304,6 +4316,9 @@ export function parsePluginConfig(value) {
                 // This prevents startup failures when reranking is disabled and rerankApiKey
                 // is left as an unresolved placeholder.
                 const rerankEnabled = retrieval.rerank !== "none";
+                if (retrieval.rerankApiKey !== undefined && !isSecretCredential(retrieval.rerankApiKey)) {
+                    throw new Error("retrieval.rerankApiKey must be a non-empty string or SecretRef with source env/file");
+                }
                 if (rerankEnabled && typeof retrieval.rerankApiKey === "string" && retrieval.rerankApiKey.includes("${")) {
                     retrieval.rerankApiKey = resolveEnvVars(retrieval.rerankApiKey);
                 }
@@ -4323,7 +4338,15 @@ export function parsePluginConfig(value) {
         tier: typeof cfg.tier === "object" && cfg.tier !== null ? cfg.tier : undefined,
         // Smart extraction config (Phase 1)
         smartExtraction: cfg.smartExtraction !== false, // Default ON
-        llm: typeof cfg.llm === "object" && cfg.llm !== null ? cfg.llm : undefined,
+        llm: llmRaw
+            ? (() => {
+                const llm = { ...llmRaw };
+                if (llm.apiKey !== undefined && !isSecretCredential(llm.apiKey)) {
+                    throw new Error("llm.apiKey must be a non-empty string or SecretRef with source env/file");
+                }
+                return llm;
+            })()
+            : undefined,
         extractMinMessages: parsePositiveInt(cfg.extractMinMessages) ?? 4,
         extractMaxChars: parsePositiveInt(cfg.extractMaxChars) ?? 8000,
         scopes: typeof cfg.scopes === "object" && cfg.scopes !== null ? cfg.scopes : undefined,

--- a/dist/index.js
+++ b/dist/index.js
@@ -79,12 +79,56 @@ function resolveEnvVars(value) {
         return envValue;
     });
 }
-function resolveFirstApiKey(apiKey) {
+function isSecretRefConfig(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value))
+        return false;
+    const raw = value;
+    return typeof raw.source === "string" && raw.source.trim().length > 0 &&
+        typeof raw.id === "string" && raw.id.trim().length > 0;
+}
+function describeSecretRef(ref) {
+    return `source=${ref.source}, id=${ref.id}`;
+}
+function resolveSecretRef(api, ref, label) {
+    const source = ref.source.trim();
+    const id = ref.id.trim();
+    try {
+        if (source === "env") {
+            const value = process.env[id];
+            if (!value)
+                throw new Error(`environment variable ${id} is not set`);
+            return value;
+        }
+        if (source === "file") {
+            const filePath = api.resolvePath(id);
+            const value = readFileSync(filePath, "utf8").trimEnd();
+            if (!value)
+                throw new Error(`file ${filePath} is empty`);
+            return value;
+        }
+        throw new Error(`unsupported SecretRef source "${source}"`);
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to resolve SecretRef for ${label} (${describeSecretRef(ref)}): ${message}`);
+    }
+}
+function resolveSecretCredential(api, value, label) {
+    return typeof value === "string"
+        ? resolveEnvVars(value)
+        : resolveSecretRef(api, value, label);
+}
+function resolveSecretCredentialArray(api, value, label) {
+    if (!Array.isArray(value))
+        return resolveSecretCredential(api, value, label);
+    return value.map((entry, index) => resolveSecretCredential(api, entry, `${label}[${index}]`));
+}
+function resolveFirstApiKey(api, apiKey) {
     const key = Array.isArray(apiKey) ? apiKey[0] : apiKey;
     if (!key) {
         throw new Error("embedding.apiKey is empty");
     }
-    return resolveEnvVars(key);
+    return resolveSecretCredential(api, key, "embedding.apiKey");
 }
 function resolveOptionalPathWithEnv(api, value, fallback) {
     const raw = typeof value === "string" && value.trim().length > 0 ? value.trim() : fallback;
@@ -1590,6 +1634,7 @@ function _initPluginState(api) {
     const config = parsePluginConfig(api.pluginConfig);
     let resolvedDbPath = normalizeStoragePath(api.resolvePath(config.dbPath || getDefaultDbPath()));
     const vectorDim = getEffectiveVectorDimensions(config.embedding.model || "text-embedding-3-small", config.embedding.dimensions, config.embedding.requestDimensions);
+    const embeddingApiKey = resolveSecretCredentialArray(api, config.embedding.apiKey, "embedding.apiKey");
     const store = new MemoryStore({
         dbPath: resolvedDbPath,
         vectorDim,
@@ -1598,7 +1643,7 @@ function _initPluginState(api) {
     });
     const embedder = createEmbedder({
         provider: "openai-compatible",
-        apiKey: config.embedding.apiKey,
+        apiKey: embeddingApiKey,
         model: config.embedding.model || "text-embedding-3-small",
         baseURL: config.embedding.baseURL,
         dimensions: config.embedding.dimensions,
@@ -1620,8 +1665,12 @@ function _initPluginState(api) {
         ...(config.tier || {}),
     });
     const retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...config.retrieval };
-    const retriever = createRetriever(store, embedder, retrievalConfig, { decayEngine });
-    const rerankCostWarning = buildAutoRecallRerankCostWarning(config, retrievalConfig);
+    if (retrievalConfig.rerankApiKey) {
+        retrievalConfig.rerankApiKey = resolveSecretCredential(api, retrievalConfig.rerankApiKey, "retrieval.rerankApiKey");
+    }
+    const resolvedRetrievalConfig = retrievalConfig;
+    const retriever = createRetriever(store, embedder, resolvedRetrievalConfig, { decayEngine });
+    const rerankCostWarning = buildAutoRecallRerankCostWarning(config, resolvedRetrievalConfig);
     if (rerankCostWarning) {
         api.logger.warn(rerankCostWarning);
     }
@@ -1647,8 +1696,8 @@ function _initPluginState(api) {
             const llmApiKey = llmAuth === "oauth"
                 ? undefined
                 : config.llm?.apiKey
-                    ? resolveEnvVars(config.llm.apiKey)
-                    : resolveFirstApiKey(config.embedding.apiKey);
+                    ? resolveSecretCredential(api, config.llm.apiKey, "llm.apiKey")
+                    : resolveFirstApiKey(api, config.embedding.apiKey);
             const llmBaseURL = llmAuth === "oauth"
                 ? (config.llm?.baseURL ? resolveEnvVars(config.llm.baseURL) : undefined)
                 : config.llm?.baseURL
@@ -2183,8 +2232,8 @@ const memoryLanceDBProPlugin = {
                     const llmApiKey = llmAuth === "oauth"
                         ? undefined
                         : config.llm?.apiKey
-                            ? resolveEnvVars(config.llm.apiKey)
-                            : resolveFirstApiKey(config.embedding.apiKey);
+                            ? resolveSecretCredential(api, config.llm.apiKey, "llm.apiKey")
+                            : resolveFirstApiKey(api, config.embedding.apiKey);
                     const llmBaseURL = llmAuth === "oauth"
                         ? (config.llm?.baseURL ? resolveEnvVars(config.llm.baseURL) : undefined)
                         : config.llm?.baseURL
@@ -4095,22 +4144,26 @@ export function parsePluginConfig(value) {
         throw new Error("memory-lancedb-pro: missing top-level config.embedding block. " +
             "Set plugins.entries.memory-lancedb-pro.config.embedding; do not nest it as config.embedding.embedding.");
     }
-    // Accept single key (string) or array of keys for round-robin rotation
+    // Accept single key (string or SecretRef) or array of keys for round-robin rotation
     let apiKey;
     if (typeof embedding.apiKey === "string") {
         apiKey = embedding.apiKey;
     }
+    else if (isSecretRefConfig(embedding.apiKey)) {
+        apiKey = embedding.apiKey;
+    }
     else if (Array.isArray(embedding.apiKey) && embedding.apiKey.length > 0) {
-        // Validate every element is a non-empty string
-        const invalid = embedding.apiKey.findIndex((k) => typeof k !== "string" || k.trim().length === 0);
+        // Validate every element is a non-empty string or SecretRef
+        const invalid = embedding.apiKey.findIndex((k) => !((typeof k === "string" && k.trim().length > 0) ||
+            isSecretRefConfig(k)));
         if (invalid !== -1) {
-            throw new Error(`embedding.apiKey[${invalid}] is invalid: expected non-empty string`);
+            throw new Error(`embedding.apiKey[${invalid}] is invalid: expected non-empty string or SecretRef`);
         }
         apiKey = embedding.apiKey;
     }
     else if (embedding.apiKey !== undefined) {
         // apiKey is present but wrong type — throw, don't silently fall back
-        throw new Error("embedding.apiKey must be a string or non-empty array of strings");
+        throw new Error("embedding.apiKey must be a string, SecretRef, or non-empty array of strings/SecretRefs");
     }
     else {
         apiKey = process.env.OPENAI_API_KEY || "";

--- a/index.ts
+++ b/index.ts
@@ -295,8 +295,11 @@ interface PluginConfig {
   declaredAgents?: Set<string>;
 }
 
+const SUPPORTED_SECRET_REF_SOURCES = ["env", "file"] as const;
+type SecretRefSource = (typeof SUPPORTED_SECRET_REF_SOURCES)[number];
+
 type SecretRefConfig = {
-  source: string;
+  source: SecretRefSource;
   provider?: string;
   id: string;
 };
@@ -344,8 +347,17 @@ function resolveEnvVars(value: string): string {
 function isSecretRefConfig(value: unknown): value is SecretRefConfig {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const raw = value as Record<string, unknown>;
-  return typeof raw.source === "string" && raw.source.trim().length > 0 &&
+  return isSupportedSecretRefSource(raw.source) &&
     typeof raw.id === "string" && raw.id.trim().length > 0;
+}
+
+function isSupportedSecretRefSource(value: unknown): value is SecretRefSource {
+  return typeof value === "string" &&
+    (SUPPORTED_SECRET_REF_SOURCES as readonly string[]).includes(value.trim());
+}
+
+function isSecretCredential(value: unknown): value is SecretCredential {
+  return (typeof value === "string" && value.trim().length > 0) || isSecretRefConfig(value);
 }
 
 function describeSecretRef(ref: SecretRefConfig): string {
@@ -357,7 +369,7 @@ function resolveSecretRef(
   ref: SecretRefConfig,
   label: string,
 ): string {
-  const source = ref.source.trim();
+  const source = ref.source.trim() as SecretRefSource;
   const id = ref.id.trim();
   try {
     if (source === "env") {
@@ -371,7 +383,8 @@ function resolveSecretRef(
       if (!value) throw new Error(`file ${filePath} is empty`);
       return value;
     }
-    throw new Error(`unsupported SecretRef source "${source}"`);
+    const exhaustive: never = source;
+    throw new Error(`unsupported SecretRef source "${exhaustive}"`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to resolve SecretRef for ${label} (${describeSecretRef(ref)}): ${message}`);
@@ -2232,7 +2245,7 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
   const retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...config.retrieval } as RetrievalConfig & {
     rerankApiKey?: SecretCredential;
   };
-  if (retrievalConfig.rerankApiKey) {
+  if (retrievalConfig.rerank === "cross-encoder" && retrievalConfig.rerankApiKey) {
     retrievalConfig.rerankApiKey = resolveSecretCredential(
       api,
       retrievalConfig.rerankApiKey,
@@ -5296,6 +5309,9 @@ export function parsePluginConfig(value: unknown): PluginConfig {
   const storageMaintenanceRaw = typeof cfg.storageMaintenance === "object" && cfg.storageMaintenance !== null
     ? cfg.storageMaintenance as Record<string, unknown>
     : null;
+  const llmRaw = typeof cfg.llm === "object" && cfg.llm !== null
+    ? cfg.llm as Record<string, unknown>
+    : null;
   const storageAutoCleanupRaw = typeof storageMaintenanceRaw?.autoCleanup === "object" && storageMaintenanceRaw.autoCleanup !== null
     ? storageMaintenanceRaw.autoCleanup as Record<string, unknown>
     : null;
@@ -5428,6 +5444,9 @@ export function parsePluginConfig(value: unknown): PluginConfig {
           // This prevents startup failures when reranking is disabled and rerankApiKey
           // is left as an unresolved placeholder.
           const rerankEnabled = retrieval.rerank !== "none";
+          if (retrieval.rerankApiKey !== undefined && !isSecretCredential(retrieval.rerankApiKey)) {
+            throw new Error("retrieval.rerankApiKey must be a non-empty string or SecretRef with source env/file");
+          }
           if (rerankEnabled && typeof retrieval.rerankApiKey === "string" && retrieval.rerankApiKey.includes("${")) {
             retrieval.rerankApiKey = resolveEnvVars(retrieval.rerankApiKey);
           }
@@ -5447,7 +5466,15 @@ export function parsePluginConfig(value: unknown): PluginConfig {
     tier: typeof cfg.tier === "object" && cfg.tier !== null ? cfg.tier as any : undefined,
     // Smart extraction config (Phase 1)
     smartExtraction: cfg.smartExtraction !== false, // Default ON
-    llm: typeof cfg.llm === "object" && cfg.llm !== null ? cfg.llm as any : undefined,
+    llm: llmRaw
+      ? (() => {
+        const llm = { ...llmRaw };
+        if (llm.apiKey !== undefined && !isSecretCredential(llm.apiKey)) {
+          throw new Error("llm.apiKey must be a non-empty string or SecretRef with source env/file");
+        }
+        return llm as any;
+      })()
+      : undefined,
     extractMinMessages: parsePositiveInt(cfg.extractMinMessages) ?? 4,
     extractMaxChars: parsePositiveInt(cfg.extractMaxChars) ?? 8000,
     scopes: typeof cfg.scopes === "object" && cfg.scopes !== null ? cfg.scopes as any : undefined,

--- a/index.ts
+++ b/index.ts
@@ -107,7 +107,7 @@ import {
 interface PluginConfig {
   embedding: {
     provider: "openai-compatible";
-    apiKey: string | string[];
+    apiKey: SecretCredential | SecretCredential[];
     model?: string;
     baseURL?: string;
     dimensions?: number;
@@ -160,7 +160,7 @@ interface PluginConfig {
     minScore?: number;
     rerank?: "cross-encoder" | "lightweight" | "none";
     candidatePoolSize?: number;
-    rerankApiKey?: string;
+    rerankApiKey?: SecretCredential;
     rerankModel?: string;
     rerankEndpoint?: string;
     /** Rerank API timeout in milliseconds (default: 5000). Increase for local/CPU-based rerank servers. */
@@ -211,7 +211,7 @@ interface PluginConfig {
   smartExtraction?: boolean;
   llm?: {
     auth?: "api-key" | "oauth";
-    apiKey?: string;
+    apiKey?: SecretCredential;
     model?: string;
     baseURL?: string;
     oauthProvider?: string;
@@ -295,6 +295,14 @@ interface PluginConfig {
   declaredAgents?: Set<string>;
 }
 
+type SecretRefConfig = {
+  source: string;
+  provider?: string;
+  id: string;
+};
+
+type SecretCredential = string | SecretRefConfig;
+
 type ReflectionThinkLevel = "off" | "minimal" | "low" | "medium" | "high";
 type SessionStrategy = "memoryReflection" | "systemSessionMemory" | "none";
 type ReflectionInjectMode = "inheritance-only" | "inheritance+derived";
@@ -333,12 +341,68 @@ function resolveEnvVars(value: string): string {
   });
 }
 
-function resolveFirstApiKey(apiKey: string | string[]): string {
+function isSecretRefConfig(value: unknown): value is SecretRefConfig {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const raw = value as Record<string, unknown>;
+  return typeof raw.source === "string" && raw.source.trim().length > 0 &&
+    typeof raw.id === "string" && raw.id.trim().length > 0;
+}
+
+function describeSecretRef(ref: SecretRefConfig): string {
+  return `source=${ref.source}, id=${ref.id}`;
+}
+
+function resolveSecretRef(
+  api: Pick<OpenClawPluginApi, "resolvePath">,
+  ref: SecretRefConfig,
+  label: string,
+): string {
+  const source = ref.source.trim();
+  const id = ref.id.trim();
+  try {
+    if (source === "env") {
+      const value = process.env[id];
+      if (!value) throw new Error(`environment variable ${id} is not set`);
+      return value;
+    }
+    if (source === "file") {
+      const filePath = api.resolvePath(id);
+      const value = readFileSync(filePath, "utf8").trimEnd();
+      if (!value) throw new Error(`file ${filePath} is empty`);
+      return value;
+    }
+    throw new Error(`unsupported SecretRef source "${source}"`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to resolve SecretRef for ${label} (${describeSecretRef(ref)}): ${message}`);
+  }
+}
+
+function resolveSecretCredential(
+  api: Pick<OpenClawPluginApi, "resolvePath">,
+  value: SecretCredential,
+  label: string,
+): string {
+  return typeof value === "string"
+    ? resolveEnvVars(value)
+    : resolveSecretRef(api, value, label);
+}
+
+function resolveSecretCredentialArray(
+  api: Pick<OpenClawPluginApi, "resolvePath">,
+  value: SecretCredential | SecretCredential[],
+  label: string,
+): string | string[] {
+  if (!Array.isArray(value)) return resolveSecretCredential(api, value, label);
+  return value.map((entry, index) => resolveSecretCredential(api, entry, `${label}[${index}]`));
+}
+
+function resolveFirstApiKey(api: Pick<OpenClawPluginApi, "resolvePath">, apiKey: SecretCredential | SecretCredential[]): string {
   const key = Array.isArray(apiKey) ? apiKey[0] : apiKey;
   if (!key) {
     throw new Error("embedding.apiKey is empty");
   }
-  return resolveEnvVars(key);
+  return resolveSecretCredential(api, key, "embedding.apiKey");
 }
 
 function resolveOptionalPathWithEnv(
@@ -425,7 +489,7 @@ function getAutoRecallRerankInputLimit(retrieveLimit: number): number {
 
 export function buildAutoRecallRerankCostWarning(
   config: PluginConfig,
-  retrievalConfig: RetrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...(config.retrieval || {}) },
+  retrievalConfig: RetrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...(config.retrieval || {}) } as RetrievalConfig,
 ): string | null {
   if (config.autoRecall !== true || config.recallMode === "off") return null;
   if (retrievalConfig.mode === "vector") return null;
@@ -2135,6 +2199,7 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
     config.embedding.dimensions,
     config.embedding.requestDimensions,
   );
+  const embeddingApiKey = resolveSecretCredentialArray(api, config.embedding.apiKey, "embedding.apiKey");
   const store = new MemoryStore({
     dbPath: resolvedDbPath,
     vectorDim,
@@ -2143,7 +2208,7 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
   });
   const embedder = createEmbedder({
     provider: "openai-compatible",
-    apiKey: config.embedding.apiKey,
+    apiKey: embeddingApiKey,
     model: config.embedding.model || "text-embedding-3-small",
     baseURL: config.embedding.baseURL,
     dimensions: config.embedding.dimensions,
@@ -2164,14 +2229,24 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
     ...DEFAULT_TIER_CONFIG,
     ...(config.tier || {}),
   });
-  const retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...config.retrieval };
+  const retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...config.retrieval } as RetrievalConfig & {
+    rerankApiKey?: SecretCredential;
+  };
+  if (retrievalConfig.rerankApiKey) {
+    retrievalConfig.rerankApiKey = resolveSecretCredential(
+      api,
+      retrievalConfig.rerankApiKey,
+      "retrieval.rerankApiKey",
+    );
+  }
+  const resolvedRetrievalConfig = retrievalConfig as RetrievalConfig;
   const retriever = createRetriever(
     store,
     embedder,
-    retrievalConfig,
+    resolvedRetrievalConfig,
     { decayEngine },
   );
-  const rerankCostWarning = buildAutoRecallRerankCostWarning(config, retrievalConfig);
+  const rerankCostWarning = buildAutoRecallRerankCostWarning(config, resolvedRetrievalConfig);
   if (rerankCostWarning) {
     api.logger.warn(rerankCostWarning);
   }
@@ -2200,8 +2275,8 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
       const llmApiKey = llmAuth === "oauth"
         ? undefined
         : config.llm?.apiKey
-          ? resolveEnvVars(config.llm.apiKey)
-          : resolveFirstApiKey(config.embedding.apiKey);
+          ? resolveSecretCredential(api, config.llm.apiKey, "llm.apiKey")
+          : resolveFirstApiKey(api, config.embedding.apiKey);
       const llmBaseURL = llmAuth === "oauth"
         ? (config.llm?.baseURL ? resolveEnvVars(config.llm.baseURL) : undefined)
         : config.llm?.baseURL
@@ -2886,8 +2961,8 @@ const memoryLanceDBProPlugin = {
             const llmApiKey = llmAuth === "oauth"
               ? undefined
               : config.llm?.apiKey
-                ? resolveEnvVars(config.llm.apiKey)
-                : resolveFirstApiKey(config.embedding.apiKey);
+                ? resolveSecretCredential(api, config.llm.apiKey, "llm.apiKey")
+                : resolveFirstApiKey(api, config.embedding.apiKey);
             const llmBaseURL = llmAuth === "oauth"
               ? (config.llm?.baseURL ? resolveEnvVars(config.llm.baseURL) : undefined)
               : config.llm?.baseURL
@@ -5178,24 +5253,29 @@ export function parsePluginConfig(value: unknown): PluginConfig {
     );
   }
 
-  // Accept single key (string) or array of keys for round-robin rotation
-  let apiKey: string | string[];
+  // Accept single key (string or SecretRef) or array of keys for round-robin rotation
+  let apiKey: SecretCredential | SecretCredential[];
   if (typeof embedding.apiKey === "string") {
     apiKey = embedding.apiKey;
+  } else if (isSecretRefConfig(embedding.apiKey)) {
+    apiKey = embedding.apiKey;
   } else if (Array.isArray(embedding.apiKey) && embedding.apiKey.length > 0) {
-    // Validate every element is a non-empty string
+    // Validate every element is a non-empty string or SecretRef
     const invalid = embedding.apiKey.findIndex(
-      (k: unknown) => typeof k !== "string" || (k as string).trim().length === 0,
+      (k: unknown) => !(
+        (typeof k === "string" && k.trim().length > 0) ||
+        isSecretRefConfig(k)
+      ),
     );
     if (invalid !== -1) {
       throw new Error(
-        `embedding.apiKey[${invalid}] is invalid: expected non-empty string`,
+        `embedding.apiKey[${invalid}] is invalid: expected non-empty string or SecretRef`,
       );
     }
-    apiKey = embedding.apiKey as string[];
+    apiKey = embedding.apiKey as SecretCredential[];
   } else if (embedding.apiKey !== undefined) {
     // apiKey is present but wrong type — throw, don't silently fall back
-    throw new Error("embedding.apiKey must be a string or non-empty array of strings");
+    throw new Error("embedding.apiKey must be a string, SecretRef, or non-empty array of strings/SecretRefs");
   } else {
     apiKey = process.env.OPENAI_API_KEY || "";
   }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -39,15 +39,67 @@
                 "minLength": 1
               },
               {
+                "type": "object",
+                "additionalProperties": true,
+                "required": [
+                  "source",
+                  "id"
+                ],
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "enum": [
+                      "env",
+                      "file"
+                    ]
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              {
                 "type": "array",
                 "items": {
-                  "type": "string",
-                  "minLength": 1
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "required": [
+                        "source",
+                        "id"
+                      ],
+                      "properties": {
+                        "source": {
+                          "type": "string",
+                          "enum": [
+                            "env",
+                            "file"
+                          ]
+                        },
+                        "provider": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    }
+                  ]
                 },
                 "minItems": 1
               }
             ],
-            "description": "Single API key or array of keys for round-robin rotation"
+            "description": "Single API key, SecretRef, or array of keys/SecretRefs for round-robin rotation"
           },
           "model": {
             "type": "string"
@@ -499,7 +551,36 @@
             "default": "cross-encoder"
           },
           "rerankApiKey": {
-            "type": "string",
+            "oneOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "object",
+                "additionalProperties": true,
+                "required": [
+                  "source",
+                  "id"
+                ],
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "enum": [
+                      "env",
+                      "file"
+                    ]
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            ],
             "description": "API key for reranker service (enables cross-encoder reranking)"
           },
           "rerankModel": {
@@ -1326,7 +1407,36 @@
             "description": "LLM authentication mode. oauth uses the local Codex/ChatGPT login cache instead of llm.apiKey."
           },
           "apiKey": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "object",
+                "additionalProperties": true,
+                "required": [
+                  "source",
+                  "id"
+                ],
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "enum": [
+                      "env",
+                      "file"
+                    ]
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            ]
           },
           "model": {
             "type": "string",

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -137,6 +137,18 @@ assert.ok(
   manifest.configSchema.properties.embedding.required.includes("apiKey"),
   "embedding.apiKey should remain schema-required when an embedding block is supplied",
 );
+assert.ok(
+  manifest.configSchema.properties.embedding.properties.apiKey.oneOf.some((entry) =>
+    entry.type === "object" && entry.required?.includes("source") && entry.required?.includes("id")
+  ),
+  "embedding.apiKey should accept OpenClaw SecretRef objects",
+);
+assert.ok(
+  manifest.configSchema.properties.embedding.properties.apiKey.oneOf
+    .find((entry) => entry.type === "array")
+    ?.items?.oneOf?.some((entry) => entry.type === "object" && entry.required?.includes("source")),
+  "embedding.apiKey arrays should accept SecretRef objects",
+);
 assert.equal(
   manifest.configSchema.properties.embedding.properties.omitDimensions?.type,
   "boolean",
@@ -159,6 +171,18 @@ assert.equal(
 assert.ok(
   manifest.configSchema.properties.retrieval.properties.rerankProvider.enum.includes("tei"),
   "rerankProvider schema should include tei",
+);
+assert.ok(
+  manifest.configSchema.properties.retrieval.properties.rerankApiKey.oneOf.some((entry) =>
+    entry.type === "object" && entry.required?.includes("source") && entry.required?.includes("id")
+  ),
+  "retrieval.rerankApiKey should accept OpenClaw SecretRef objects",
+);
+assert.ok(
+  manifest.configSchema.properties.llm.properties.apiKey.oneOf.some((entry) =>
+    entry.type === "object" && entry.required?.includes("source") && entry.required?.includes("id")
+  ),
+  "llm.apiKey should accept OpenClaw SecretRef objects",
 );
 assert.ok(
   Object.prototype.hasOwnProperty.call(manifest.configSchema.properties, "dreaming"),

--- a/test/resolve-env-vars-array.test.mjs
+++ b/test/resolve-env-vars-array.test.mjs
@@ -146,6 +146,24 @@ test("smart extraction initializes with env var in array apiKey", async () => {
   }
 });
 
+test("smart extraction initializes with env SecretRef apiKey", async () => {
+  process.env.__TEST_MEMORY_SECRET_REF_KEY = "resolved-secret-ref";
+  try {
+    await withTestEnv(
+      { source: "env", provider: "default", id: "__TEST_MEMORY_SECRET_REF_KEY" },
+      (logs) => {
+        const warnLogs = logs.filter(([level]) => level === "warn").map(([, msg]) => msg);
+        assert.ok(
+          !warnLogs.some((msg) => msg.includes("smart extraction init failed")),
+          `env SecretRef should resolve, got: ${JSON.stringify(warnLogs)}`,
+        );
+      },
+    );
+  } finally {
+    delete process.env.__TEST_MEMORY_SECRET_REF_KEY;
+  }
+});
+
 test("parsePluginConfig preserves string[] apiKey", () => {
   const config = parsePluginConfig({
     embedding: {
@@ -158,6 +176,17 @@ test("parsePluginConfig preserves string[] apiKey", () => {
   assert.equal(config.embedding.apiKey.length, 2);
 });
 
+test("parsePluginConfig preserves SecretRef apiKey", () => {
+  const secretRef = { source: "file", provider: "filemain", id: "/tmp/memory-secret" };
+  const config = parsePluginConfig({
+    embedding: {
+      apiKey: secretRef,
+      model: "text-embedding-3-small",
+    },
+  });
+  assert.deepEqual(config.embedding.apiKey, secretRef);
+});
+
 test("parsePluginConfig preserves single string apiKey", () => {
   const config = parsePluginConfig({
     embedding: {
@@ -166,6 +195,27 @@ test("parsePluginConfig preserves single string apiKey", () => {
     },
   });
   assert.equal(config.embedding.apiKey, "single-key");
+});
+
+test("parsePluginConfig preserves SecretRef rerank and llm api keys", () => {
+  const rerankRef = { source: "env", provider: "default", id: "RERANK_SECRET" };
+  const llmRef = { source: "file", provider: "filemain", id: "/tmp/llm-secret" };
+  const config = parsePluginConfig({
+    embedding: {
+      apiKey: "embed-key",
+      model: "text-embedding-3-small",
+    },
+    retrieval: {
+      rerank: "cross-encoder",
+      rerankApiKey: rerankRef,
+    },
+    llm: {
+      apiKey: llmRef,
+      model: "mock-llm",
+    },
+  });
+  assert.deepEqual(config.retrieval.rerankApiKey, rerankRef);
+  assert.deepEqual(config.llm.apiKey, llmRef);
 });
 
 test("parsePluginConfig rejects empty array apiKey", () => {

--- a/test/resolve-env-vars-array.test.mjs
+++ b/test/resolve-env-vars-array.test.mjs
@@ -45,7 +45,7 @@ function createLlmServer() {
   });
 }
 
-async function withTestEnv(apiKeyConfig, fn) {
+async function withTestEnv(apiKeyConfig, fn, configOverrides = {}) {
   const workDir = mkdtempSync(path.join(tmpdir(), "env-vars-array-test-"));
   const dbPath = path.join(workDir, "test.db");
   const embeddingServer = createEmbeddingServer();
@@ -78,6 +78,7 @@ async function withTestEnv(apiKeyConfig, fn) {
           default: "global",
           definitions: { global: { description: "shared" } },
         },
+        ...configOverrides,
       },
       hooks: {},
       toolFactories: {},
@@ -228,6 +229,61 @@ test("parsePluginConfig rejects empty array apiKey", () => {
     }),
     /apiKey/,
   );
+});
+
+test("parsePluginConfig rejects unsupported SecretRef sources", () => {
+  assert.throws(
+    () => parsePluginConfig({
+      embedding: {
+        apiKey: { source: "exec", id: "print-secret" },
+        model: "text-embedding-3-small",
+      },
+    }),
+    /embedding\.apiKey/,
+  );
+
+  assert.throws(
+    () => parsePluginConfig({
+      embedding: {
+        apiKey: "embed-key",
+        model: "text-embedding-3-small",
+      },
+      retrieval: {
+        rerank: "cross-encoder",
+        rerankApiKey: { source: "vault", id: "rerank-secret" },
+      },
+    }),
+    /retrieval\.rerankApiKey.*source env\/file/,
+  );
+
+  assert.throws(
+    () => parsePluginConfig({
+      embedding: {
+        apiKey: "embed-key",
+        model: "text-embedding-3-small",
+      },
+      llm: {
+        apiKey: { source: "provider", id: "llm-secret" },
+      },
+    }),
+    /llm\.apiKey.*source env\/file/,
+  );
+});
+
+test("plugin startup does not resolve rerank SecretRef when rerank is none", async () => {
+  await withTestEnv("embed-key", (logs) => {
+    const warnLogs = logs.filter(([level]) => level === "warn").map(([, msg]) => msg);
+    assert.ok(
+      !warnLogs.some((msg) => msg.includes("smart extraction init failed")),
+      `disabled rerank SecretRef should not fail startup, got: ${JSON.stringify(warnLogs)}`,
+    );
+  }, {
+    retrieval: {
+      mode: "hybrid",
+      rerank: "none",
+      rerankApiKey: { source: "env", id: "__MISSING_DISABLED_RERANK_SECRET" },
+    },
+  });
 });
 
 test("parsePluginConfig resolves env vars in retrieval rerank config", () => {


### PR DESCRIPTION
## Summary
- accept OpenClaw SecretRef objects for embedding, rerank, and LLM API keys
- resolve env/file SecretRefs during plugin initialization before constructing clients
- update the plugin manifest schema and regression coverage

Fixes #891

## Verification
- node --test test/resolve-env-vars-array.test.mjs
- node test/plugin-manifest-regression.mjs
- npm run build