### PR TITLE
feat: add temporal fact query tool

### DIFF
--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import { isNoise } from "./noise-filter.js";
 import { stripEnvelopeMetadata } from "./smart-extractor.js";
 import { isSystemBypassId, resolveScopeFilter, parseAgentIdFromSessionKey } from "./scopes.js";
-import { appendRelation, buildSmartMetadata, deriveFactKey, parseSmartMetadata, stringifySmartMetadata, } from "./smart-metadata.js";
+import { appendRelation, buildSmartMetadata, deriveFactKey, isMemoryActiveAt, isMemoryExpired, parseSmartMetadata, stringifySmartMetadata, } from "./smart-metadata.js";
 import { classifyTemporal, inferExpiry } from "./temporal-classifier.js";
 import { TEMPORAL_VERSIONED_CATEGORIES } from "./memory-categories.js";
 import { appendSelfImprovementEntry, countSelfImprovementEntries, DEFAULT_SELF_IMPROVEMENT_MAX_ENTRIES, ensureSelfImprovementLearningFiles, } from "./self-improvement-files.js";
@@ -104,6 +104,62 @@ function formatReflectionResolvePreview(candidates) {
         `Reflection resolve preview: ${candidates.length} candidate(s). No changes made.`,
         ...lines,
     ].join("\n");
+}
+function parseFactQueryTimestamp(value) {
+    if (typeof value !== "string" || value.trim().length === 0)
+        return Date.now();
+    const parsed = Date.parse(value);
+    if (!Number.isFinite(parsed)) {
+        throw new Error(`Invalid at timestamp: ${value}`);
+    }
+    return parsed;
+}
+function formatFactTimestamp(value) {
+    return typeof value === "number" && Number.isFinite(value)
+        ? new Date(value).toISOString()
+        : undefined;
+}
+function factQueryMatches(entry, query, factKey) {
+    const meta = parseSmartMetadata(entry.metadata, entry);
+    const normalizedFactKey = factKey?.trim().toLowerCase();
+    if (normalizedFactKey && meta.fact_key?.toLowerCase() !== normalizedFactKey)
+        return false;
+    const normalizedQuery = query?.trim().toLowerCase();
+    if (!normalizedQuery)
+        return true;
+    return [
+        meta.fact_key,
+        meta.memory_category,
+        meta.l0_abstract,
+        meta.l1_overview,
+        entry.text,
+    ].some((value) => typeof value === "string" && value.toLowerCase().includes(normalizedQuery));
+}
+function isTemporalFactEntry(entry) {
+    const meta = parseSmartMetadata(entry.metadata, entry);
+    return Boolean(meta.fact_key ||
+        meta.supersedes ||
+        meta.superseded_by ||
+        meta.invalidated_at ||
+        meta.valid_until);
+}
+function serializeFactEntry(entry, atMs) {
+    const meta = parseSmartMetadata(entry.metadata, entry);
+    const activeAt = isMemoryActiveAt(meta, atMs) && !isMemoryExpired(meta, atMs);
+    return {
+        id: entry.id,
+        text: entry.text,
+        scope: entry.scope,
+        category: entry.category,
+        memoryCategory: meta.memory_category,
+        factKey: meta.fact_key,
+        activeAt,
+        validFrom: formatFactTimestamp(meta.valid_from),
+        validUntil: formatFactTimestamp(meta.valid_until),
+        invalidatedAt: formatFactTimestamp(meta.invalidated_at),
+        supersedes: meta.supersedes,
+        supersededBy: meta.superseded_by,
+    };
 }
 const _warnedMissingAgentId = new Set();
 /** @internal Exported for testing only — resets the missing-agent warning throttle. */
@@ -619,6 +675,85 @@ export function registerMemoryRecallAliasTool(api, context, alias) {
             description,
         });
     }, { name: alias });
+}
+export function registerMemoryFactQueryTool(api, context) {
+    api.registerTool((toolCtx) => {
+        const runtimeContext = resolveToolContext(context, toolCtx);
+        return {
+            name: "memory_fact_query",
+            label: "Memory Fact Query",
+            description: "Deterministically query current or historical temporal facts by fact key or text without semantic reranking.",
+            parameters: Type.Object({
+                query: Type.Optional(Type.String({ description: "Text to match against fact keys and fact summaries." })),
+                factKey: Type.Optional(Type.String({ description: "Exact temporal fact key, such as preferences:drink." })),
+                at: Type.Optional(Type.String({ description: "ISO timestamp/date for as-of lookup. Defaults to now." })),
+                scope: Type.Optional(Type.String({ description: "Optional scope filter." })),
+                includeHistory: Type.Optional(Type.Boolean({ description: "Include inactive superseded/expired facts (default false)." })),
+                limit: Type.Optional(Type.Number({ description: "Maximum facts to return (default 10, max 100)." })),
+            }),
+            async execute(_toolCallId, params, _signal, _onUpdate, runtimeCtx) {
+                const { query, factKey, at, scope, includeHistory = false, limit = 10, } = params;
+                try {
+                    const safeLimit = clampInt(limit, 1, 100);
+                    const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
+                    const resolvedScopes = resolveReadableToolScopeFilter(runtimeContext.scopeManager, agentId, scope);
+                    const atMs = parseFactQueryTimestamp(at);
+                    const entries = await runtimeContext.store.list(resolvedScopes.scopeFilter, undefined, Math.max(safeLimit * 10, 100), 0);
+                    const facts = entries
+                        .filter(isTemporalFactEntry)
+                        .filter((entry) => factQueryMatches(entry, query, factKey))
+                        .map((entry) => ({ entry, fact: serializeFactEntry(entry, atMs) }))
+                        .filter(({ fact }) => includeHistory || fact.activeAt)
+                        .sort((a, b) => {
+                        if (a.fact.activeAt !== b.fact.activeAt)
+                            return a.fact.activeAt ? -1 : 1;
+                        return (b.entry.timestamp || 0) - (a.entry.timestamp || 0);
+                    })
+                        .slice(0, safeLimit)
+                        .map(({ fact }) => fact);
+                    const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
+                    const lines = facts.map((fact, index) => {
+                        const status = fact.activeAt ? "active" : "historical";
+                        const datePart = [fact.validFrom ? `from=${fact.validFrom}` : undefined, fact.validUntil ? `until=${fact.validUntil}` : undefined]
+                            .filter(Boolean)
+                            .join(" ");
+                        return `${index + 1}. [${status}] ${fact.factKey ?? fact.memoryCategory ?? fact.category} ${datePart} ${truncateText(normalizeInlineText(fact.text), 180)}`.trim();
+                    });
+                    return {
+                        content: [{
+                                type: "text",
+                                text: [
+                                    ignoredScopeNotice,
+                                    lines.length > 0
+                                        ? `Fact query returned ${facts.length} result(s) as of ${new Date(atMs).toISOString()}:\n${lines.join("\n")}`
+                                        : `Fact query returned 0 result(s) as of ${new Date(atMs).toISOString()}.`,
+                                ].filter(Boolean).join("\n"),
+                            }],
+                        details: {
+                            action: "fact_query",
+                            query,
+                            factKey,
+                            asOf: new Date(atMs).toISOString(),
+                            includeHistory,
+                            count: facts.length,
+                            ignoredScope: resolvedScopes.ignoredScope,
+                            accessibleScopes: resolvedScopes.accessibleScopes,
+                            facts,
+                        },
+                    };
+                }
+                catch (error) {
+                    return {
+                        content: [{
+                                type: "text",
+                                text: `Fact query failed: ${error instanceof Error ? error.message : String(error)}`,
+                            }],
+                        details: { error: "fact_query_failed", message: String(error) },
+                    };
+                }
+            },
+        };
+    }, { name: "memory_fact_query" });
 }
 export function registerMemoryStoreTool(api, context) {
     api.registerTool((toolCtx) => {
@@ -2037,6 +2172,7 @@ export function registerAllMemoryTools(api, context, options = {}) {
     registerMemoryRecallTool(api, context);
     registerMemoryRecallAliasTool(api, context, "memory_search");
     registerMemoryRecallAliasTool(api, context, "memory_get");
+    registerMemoryFactQueryTool(api, context);
     registerMemoryStoreTool(api, context);
     registerMemoryForgetTool(api, context);
     registerMemoryUpdateTool(api, context);

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -119,6 +119,22 @@ function formatFactTimestamp(value) {
         ? new Date(value).toISOString()
         : undefined;
 }
+function parseMetadataObject(rawMetadata) {
+    if (!rawMetadata)
+        return {};
+    try {
+        const parsed = JSON.parse(rawMetadata);
+        return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+            ? parsed
+            : {};
+    }
+    catch {
+        return {};
+    }
+}
+function hasExplicitMetadataField(entry, field) {
+    return Object.prototype.hasOwnProperty.call(parseMetadataObject(entry.metadata), field);
+}
 function factQueryMatches(entry, query, factKey) {
     const meta = parseSmartMetadata(entry.metadata, entry);
     const normalizedFactKey = factKey?.trim().toLowerCase();
@@ -138,6 +154,7 @@ function factQueryMatches(entry, query, factKey) {
 function isTemporalFactEntry(entry) {
     const meta = parseSmartMetadata(entry.metadata, entry);
     return Boolean(meta.fact_key ||
+        hasExplicitMetadataField(entry, "valid_from") ||
         meta.supersedes ||
         meta.superseded_by ||
         meta.invalidated_at ||
@@ -160,6 +177,29 @@ function serializeFactEntry(entry, atMs) {
         supersedes: meta.supersedes,
         supersededBy: meta.superseded_by,
     };
+}
+const FACT_QUERY_PAGE_SIZE = 500;
+async function collectFactQueryMatches(store, scopeFilter, query, factKey) {
+    const matches = [];
+    const seenIds = new Set();
+    for (let offset = 0;; offset += FACT_QUERY_PAGE_SIZE) {
+        const page = await store.list(scopeFilter, undefined, FACT_QUERY_PAGE_SIZE, offset);
+        if (page.length === 0)
+            break;
+        let newRows = 0;
+        for (const entry of page) {
+            if (seenIds.has(entry.id))
+                continue;
+            seenIds.add(entry.id);
+            newRows += 1;
+            if (isTemporalFactEntry(entry) && factQueryMatches(entry, query, factKey)) {
+                matches.push(entry);
+            }
+        }
+        if (page.length < FACT_QUERY_PAGE_SIZE || newRows === 0)
+            break;
+    }
+    return matches;
 }
 const _warnedMissingAgentId = new Set();
 /** @internal Exported for testing only — resets the missing-agent warning throttle. */
@@ -698,16 +738,18 @@ export function registerMemoryFactQueryTool(api, context) {
                     const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
                     const resolvedScopes = resolveReadableToolScopeFilter(runtimeContext.scopeManager, agentId, scope);
                     const atMs = parseFactQueryTimestamp(at);
-                    const entries = await runtimeContext.store.list(resolvedScopes.scopeFilter, undefined, Math.max(safeLimit * 10, 100), 0);
+                    const entries = await collectFactQueryMatches(runtimeContext.store, resolvedScopes.scopeFilter, query, factKey);
                     const facts = entries
-                        .filter(isTemporalFactEntry)
-                        .filter((entry) => factQueryMatches(entry, query, factKey))
-                        .map((entry) => ({ entry, fact: serializeFactEntry(entry, atMs) }))
-                        .filter(({ fact }) => includeHistory || fact.activeAt)
+                        .map((entry) => {
+                        const meta = parseSmartMetadata(entry.metadata, entry);
+                        return { entry, meta, fact: serializeFactEntry(entry, atMs) };
+                    })
+                        .filter(({ meta, fact }) => meta.valid_from <= atMs && (includeHistory || fact.activeAt))
                         .sort((a, b) => {
                         if (a.fact.activeAt !== b.fact.activeAt)
                             return a.fact.activeAt ? -1 : 1;
-                        return (b.entry.timestamp || 0) - (a.entry.timestamp || 0);
+                        return (b.meta.valid_from || 0) - (a.meta.valid_from || 0)
+                            || (b.entry.timestamp || 0) - (a.entry.timestamp || 0);
                     })
                         .slice(0, safeLimit)
                         .map(({ fact }) => fact);

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -151,14 +151,15 @@ function factQueryMatches(entry, query, factKey) {
         entry.text,
     ].some((value) => typeof value === "string" && value.toLowerCase().includes(normalizedQuery));
 }
-function isTemporalFactEntry(entry) {
-    const meta = parseSmartMetadata(entry.metadata, entry);
-    return Boolean(meta.fact_key ||
-        hasExplicitMetadataField(entry, "valid_from") ||
-        meta.supersedes ||
-        meta.superseded_by ||
-        meta.invalidated_at ||
-        meta.valid_until);
+function isTemporalFactEntry(entry, hasFactKeySelector) {
+    const rawMetadata = parseMetadataObject(entry.metadata);
+    if (hasFactKeySelector)
+        return true;
+    return Boolean(hasExplicitMetadataField(entry, "supersedes") ||
+        hasExplicitMetadataField(entry, "superseded_by") ||
+        hasExplicitMetadataField(entry, "invalidated_at") ||
+        hasExplicitMetadataField(entry, "valid_until") ||
+        rawMetadata.memory_temporal_type === "dynamic");
 }
 function serializeFactEntry(entry, atMs) {
     const meta = parseSmartMetadata(entry.metadata, entry);
@@ -188,6 +189,7 @@ function compareFactQueryCandidates(a, b) {
 async function collectFactQueryMatches(store, scopeFilter, query, factKey, atMs, includeHistory, limit, workspaceBoundary) {
     const matches = [];
     const seenIds = new Set();
+    const hasFactKeySelector = Boolean(factKey?.trim());
     for (let offset = 0;; offset += FACT_QUERY_PAGE_SIZE) {
         const page = await store.list(scopeFilter, undefined, FACT_QUERY_PAGE_SIZE, offset);
         if (page.length === 0)
@@ -199,7 +201,7 @@ async function collectFactQueryMatches(store, scopeFilter, query, factKey, atMs,
                 continue;
             seenIds.add(entry.id);
             newRows += 1;
-            if (isTemporalFactEntry(entry) && factQueryMatches(entry, query, factKey)) {
+            if (isTemporalFactEntry(entry, hasFactKeySelector) && factQueryMatches(entry, query, factKey)) {
                 const meta = parseSmartMetadata(entry.metadata, entry);
                 const fact = serializeFactEntry(entry, atMs);
                 if (meta.valid_from <= atMs && (includeHistory || fact.activeAt)) {
@@ -751,10 +753,24 @@ export function registerMemoryFactQueryTool(api, context) {
                 const { query, factKey, at, scope, includeHistory = false, limit = 10, } = params;
                 try {
                     const safeLimit = clampInt(limit, 1, 100);
+                    const trimmedQuery = query?.trim();
+                    const trimmedFactKey = factKey?.trim();
+                    if (!trimmedQuery && !trimmedFactKey) {
+                        return {
+                            content: [{
+                                    type: "text",
+                                    text: "Fact query requires a query or exact factKey selector.",
+                                }],
+                            details: {
+                                action: "fact_query",
+                                error: "missing_selector",
+                            },
+                        };
+                    }
                     const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
                     const resolvedScopes = resolveReadableToolScopeFilter(runtimeContext.scopeManager, agentId, scope);
                     const atMs = parseFactQueryTimestamp(at);
-                    const entries = await collectFactQueryMatches(runtimeContext.store, resolvedScopes.scopeFilter, query, factKey, atMs, includeHistory, safeLimit, runtimeContext.workspaceBoundary);
+                    const entries = await collectFactQueryMatches(runtimeContext.store, resolvedScopes.scopeFilter, trimmedQuery, trimmedFactKey, atMs, includeHistory, safeLimit, runtimeContext.workspaceBoundary);
                     const facts = entries
                         .map(({ fact }) => fact);
                     const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
@@ -777,8 +793,8 @@ export function registerMemoryFactQueryTool(api, context) {
                             }],
                         details: {
                             action: "fact_query",
-                            query,
-                            factKey,
+                            query: trimmedQuery,
+                            factKey: trimmedFactKey,
                             asOf: new Date(atMs).toISOString(),
                             includeHistory,
                             count: facts.length,

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -179,7 +179,13 @@ function serializeFactEntry(entry, atMs) {
     };
 }
 const FACT_QUERY_PAGE_SIZE = 500;
-async function collectFactQueryMatches(store, scopeFilter, query, factKey) {
+function compareFactQueryCandidates(a, b) {
+    if (a.fact.activeAt !== b.fact.activeAt)
+        return a.fact.activeAt ? -1 : 1;
+    return (b.meta.valid_from || 0) - (a.meta.valid_from || 0)
+        || (b.entry.timestamp || 0) - (a.entry.timestamp || 0);
+}
+async function collectFactQueryMatches(store, scopeFilter, query, factKey, atMs, includeHistory, limit, workspaceBoundary) {
     const matches = [];
     const seenIds = new Set();
     for (let offset = 0;; offset += FACT_QUERY_PAGE_SIZE) {
@@ -187,14 +193,24 @@ async function collectFactQueryMatches(store, scopeFilter, query, factKey) {
         if (page.length === 0)
             break;
         let newRows = 0;
+        const pageMatches = [];
         for (const entry of page) {
             if (seenIds.has(entry.id))
                 continue;
             seenIds.add(entry.id);
             newRows += 1;
             if (isTemporalFactEntry(entry) && factQueryMatches(entry, query, factKey)) {
-                matches.push(entry);
+                const meta = parseSmartMetadata(entry.metadata, entry);
+                const fact = serializeFactEntry(entry, atMs);
+                if (meta.valid_from <= atMs && (includeHistory || fact.activeAt)) {
+                    pageMatches.push({ entry, meta, fact });
+                }
             }
+        }
+        matches.push(...filterUserMdExclusiveRecallResults(pageMatches, workspaceBoundary));
+        matches.sort(compareFactQueryCandidates);
+        if (matches.length > limit) {
+            matches.length = limit;
         }
         if (page.length < FACT_QUERY_PAGE_SIZE || newRows === 0)
             break;
@@ -738,20 +754,8 @@ export function registerMemoryFactQueryTool(api, context) {
                     const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
                     const resolvedScopes = resolveReadableToolScopeFilter(runtimeContext.scopeManager, agentId, scope);
                     const atMs = parseFactQueryTimestamp(at);
-                    const entries = await collectFactQueryMatches(runtimeContext.store, resolvedScopes.scopeFilter, query, factKey);
+                    const entries = await collectFactQueryMatches(runtimeContext.store, resolvedScopes.scopeFilter, query, factKey, atMs, includeHistory, safeLimit, runtimeContext.workspaceBoundary);
                     const facts = entries
-                        .map((entry) => {
-                        const meta = parseSmartMetadata(entry.metadata, entry);
-                        return { entry, meta, fact: serializeFactEntry(entry, atMs) };
-                    })
-                        .filter(({ meta, fact }) => meta.valid_from <= atMs && (includeHistory || fact.activeAt))
-                        .sort((a, b) => {
-                        if (a.fact.activeAt !== b.fact.activeAt)
-                            return a.fact.activeAt ? -1 : 1;
-                        return (b.meta.valid_from || 0) - (a.meta.valid_from || 0)
-                            || (b.entry.timestamp || 0) - (a.entry.timestamp || 0);
-                    })
-                        .slice(0, safeLimit)
                         .map(({ fact }) => fact);
                     const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
                     const lines = facts.map((fact, index) => {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2102,6 +2102,7 @@
       "memory_recall",
       "memory_search",
       "memory_get",
+      "memory_fact_query",
       "memory_store",
       "memory_update",
       "memory_forget",

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -46,6 +46,7 @@ export const CI_TEST_MANIFEST = [
   { group: "storage-and-schema", runner: "node", file: "test/vector-search-cosine.test.mjs" },
   { group: "core-regression", runner: "node", file: "test/context-support-e2e.mjs" },
   { group: "core-regression", runner: "node", file: "test/temporal-facts.test.mjs" },
+  { group: "core-regression", runner: "node", file: "test/memory-fact-query.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/memory-update-supersede.test.mjs" },
   { group: "llm-clients-and-auth", runner: "node", file: "test/memory-upgrader-diagnostics.test.mjs" },
   { group: "llm-clients-and-auth", runner: "node", file: "test/llm-api-key-client.test.mjs", args: ["--test"] },

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -238,13 +238,29 @@ function serializeFactEntry(entry: MemoryEntry, atMs: number) {
 
 const FACT_QUERY_PAGE_SIZE = 500;
 
+type FactQueryCandidate = {
+  entry: MemoryEntry;
+  meta: ReturnType<typeof parseSmartMetadata>;
+  fact: ReturnType<typeof serializeFactEntry>;
+};
+
+function compareFactQueryCandidates(a: FactQueryCandidate, b: FactQueryCandidate): number {
+  if (a.fact.activeAt !== b.fact.activeAt) return a.fact.activeAt ? -1 : 1;
+  return (b.meta.valid_from || 0) - (a.meta.valid_from || 0)
+    || (b.entry.timestamp || 0) - (a.entry.timestamp || 0);
+}
+
 async function collectFactQueryMatches(
   store: MemoryStore,
   scopeFilter: string[] | undefined,
   query: string | undefined,
   factKey: string | undefined,
-): Promise<MemoryEntry[]> {
-  const matches: MemoryEntry[] = [];
+  atMs: number,
+  includeHistory: boolean,
+  limit: number,
+  workspaceBoundary?: WorkspaceBoundaryConfig | null,
+): Promise<FactQueryCandidate[]> {
+  const matches: FactQueryCandidate[] = [];
   const seenIds = new Set<string>();
 
   for (let offset = 0; ; offset += FACT_QUERY_PAGE_SIZE) {
@@ -252,13 +268,24 @@ async function collectFactQueryMatches(
     if (page.length === 0) break;
 
     let newRows = 0;
+    const pageMatches: FactQueryCandidate[] = [];
     for (const entry of page) {
       if (seenIds.has(entry.id)) continue;
       seenIds.add(entry.id);
       newRows += 1;
       if (isTemporalFactEntry(entry) && factQueryMatches(entry, query, factKey)) {
-        matches.push(entry);
+        const meta = parseSmartMetadata(entry.metadata, entry);
+        const fact = serializeFactEntry(entry, atMs);
+        if (meta.valid_from <= atMs && (includeHistory || fact.activeAt)) {
+          pageMatches.push({ entry, meta, fact });
+        }
       }
+    }
+
+    matches.push(...filterUserMdExclusiveRecallResults(pageMatches, workspaceBoundary));
+    matches.sort(compareFactQueryCandidates);
+    if (matches.length > limit) {
+      matches.length = limit;
     }
 
     if (page.length < FACT_QUERY_PAGE_SIZE || newRows === 0) break;
@@ -986,20 +1013,13 @@ export function registerMemoryFactQueryTool(
               resolvedScopes.scopeFilter,
               query,
               factKey,
+              atMs,
+              includeHistory,
+              safeLimit,
+              runtimeContext.workspaceBoundary,
             );
 
             const facts = entries
-              .map((entry) => {
-                const meta = parseSmartMetadata(entry.metadata, entry);
-                return { entry, meta, fact: serializeFactEntry(entry, atMs) };
-              })
-              .filter(({ meta, fact }) => meta.valid_from <= atMs && (includeHistory || fact.activeAt))
-              .sort((a, b) => {
-                if (a.fact.activeAt !== b.fact.activeAt) return a.fact.activeAt ? -1 : 1;
-                return (b.meta.valid_from || 0) - (a.meta.valid_from || 0)
-                  || (b.entry.timestamp || 0) - (a.entry.timestamp || 0);
-              })
-              .slice(0, safeLimit)
               .map(({ fact }) => fact);
 
             const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -18,6 +18,8 @@ import {
   appendRelation,
   buildSmartMetadata,
   deriveFactKey,
+  isMemoryActiveAt,
+  isMemoryExpired,
   parseSmartMetadata,
   stringifySmartMetadata,
 } from "./smart-metadata.js";
@@ -153,6 +155,68 @@ function formatReflectionResolvePreview(candidates: Array<{ entry: MemoryEntry; 
     `Reflection resolve preview: ${candidates.length} candidate(s). No changes made.`,
     ...lines,
   ].join("\n");
+}
+
+function parseFactQueryTimestamp(value: unknown): number {
+  if (typeof value !== "string" || value.trim().length === 0) return Date.now();
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid at timestamp: ${value}`);
+  }
+  return parsed;
+}
+
+function formatFactTimestamp(value: number | undefined): string | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? new Date(value).toISOString()
+    : undefined;
+}
+
+function factQueryMatches(entry: MemoryEntry, query: string | undefined, factKey: string | undefined): boolean {
+  const meta = parseSmartMetadata(entry.metadata, entry);
+  const normalizedFactKey = factKey?.trim().toLowerCase();
+  if (normalizedFactKey && meta.fact_key?.toLowerCase() !== normalizedFactKey) return false;
+
+  const normalizedQuery = query?.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  return [
+    meta.fact_key,
+    meta.memory_category,
+    meta.l0_abstract,
+    meta.l1_overview,
+    entry.text,
+  ].some((value) => typeof value === "string" && value.toLowerCase().includes(normalizedQuery));
+}
+
+function isTemporalFactEntry(entry: MemoryEntry): boolean {
+  const meta = parseSmartMetadata(entry.metadata, entry);
+  return Boolean(
+    meta.fact_key ||
+    meta.supersedes ||
+    meta.superseded_by ||
+    meta.invalidated_at ||
+    meta.valid_until,
+  );
+}
+
+function serializeFactEntry(entry: MemoryEntry, atMs: number) {
+  const meta = parseSmartMetadata(entry.metadata, entry);
+  const activeAt = isMemoryActiveAt(meta, atMs) && !isMemoryExpired(meta, atMs);
+  return {
+    id: entry.id,
+    text: entry.text,
+    scope: entry.scope,
+    category: entry.category,
+    memoryCategory: meta.memory_category,
+    factKey: meta.fact_key,
+    activeAt,
+    validFrom: formatFactTimestamp(meta.valid_from),
+    validUntil: formatFactTimestamp(meta.valid_until),
+    invalidatedAt: formatFactTimestamp(meta.invalidated_at),
+    supersedes: meta.supersedes,
+    supersededBy: meta.superseded_by,
+  };
 }
 
 const _warnedMissingAgentId = new Set<string>();
@@ -824,6 +888,114 @@ export function registerMemoryRecallAliasTool(
       });
     },
     { name: alias },
+  );
+}
+
+export function registerMemoryFactQueryTool(
+  api: OpenClawPluginApi,
+  context: ToolContext,
+) {
+  api.registerTool(
+    (toolCtx) => {
+      const runtimeContext = resolveToolContext(context, toolCtx);
+      return {
+        name: "memory_fact_query",
+        label: "Memory Fact Query",
+        description:
+          "Deterministically query current or historical temporal facts by fact key or text without semantic reranking.",
+        parameters: Type.Object({
+          query: Type.Optional(Type.String({ description: "Text to match against fact keys and fact summaries." })),
+          factKey: Type.Optional(Type.String({ description: "Exact temporal fact key, such as preferences:drink." })),
+          at: Type.Optional(Type.String({ description: "ISO timestamp/date for as-of lookup. Defaults to now." })),
+          scope: Type.Optional(Type.String({ description: "Optional scope filter." })),
+          includeHistory: Type.Optional(Type.Boolean({ description: "Include inactive superseded/expired facts (default false)." })),
+          limit: Type.Optional(Type.Number({ description: "Maximum facts to return (default 10, max 100)." })),
+        }),
+        async execute(_toolCallId, params, _signal, _onUpdate, runtimeCtx) {
+          const {
+            query,
+            factKey,
+            at,
+            scope,
+            includeHistory = false,
+            limit = 10,
+          } = params as {
+            query?: string;
+            factKey?: string;
+            at?: string;
+            scope?: string;
+            includeHistory?: boolean;
+            limit?: number;
+          };
+
+          try {
+            const safeLimit = clampInt(limit, 1, 100);
+            const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
+            const resolvedScopes = resolveReadableToolScopeFilter(runtimeContext.scopeManager, agentId, scope);
+            const atMs = parseFactQueryTimestamp(at);
+            const entries = await runtimeContext.store.list(
+              resolvedScopes.scopeFilter,
+              undefined,
+              Math.max(safeLimit * 10, 100),
+              0,
+            );
+
+            const facts = entries
+              .filter(isTemporalFactEntry)
+              .filter((entry) => factQueryMatches(entry, query, factKey))
+              .map((entry) => ({ entry, fact: serializeFactEntry(entry, atMs) }))
+              .filter(({ fact }) => includeHistory || fact.activeAt)
+              .sort((a, b) => {
+                if (a.fact.activeAt !== b.fact.activeAt) return a.fact.activeAt ? -1 : 1;
+                return (b.entry.timestamp || 0) - (a.entry.timestamp || 0);
+              })
+              .slice(0, safeLimit)
+              .map(({ fact }) => fact);
+
+            const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
+            const lines = facts.map((fact, index) => {
+              const status = fact.activeAt ? "active" : "historical";
+              const datePart = [fact.validFrom ? `from=${fact.validFrom}` : undefined, fact.validUntil ? `until=${fact.validUntil}` : undefined]
+                .filter(Boolean)
+                .join(" ");
+              return `${index + 1}. [${status}] ${fact.factKey ?? fact.memoryCategory ?? fact.category} ${datePart} ${truncateText(normalizeInlineText(fact.text), 180)}`.trim();
+            });
+
+            return {
+              content: [{
+                type: "text",
+                text: [
+                  ignoredScopeNotice,
+                  lines.length > 0
+                    ? `Fact query returned ${facts.length} result(s) as of ${new Date(atMs).toISOString()}:\n${lines.join("\n")}`
+                    : `Fact query returned 0 result(s) as of ${new Date(atMs).toISOString()}.`,
+                ].filter(Boolean).join("\n"),
+              }],
+              details: {
+                action: "fact_query",
+                query,
+                factKey,
+                asOf: new Date(atMs).toISOString(),
+                includeHistory,
+                count: facts.length,
+                ignoredScope: resolvedScopes.ignoredScope,
+                accessibleScopes: resolvedScopes.accessibleScopes,
+                facts,
+              },
+            };
+          } catch (error) {
+            return {
+              content: [{
+                type: "text",
+                text: `Fact query failed: ${error instanceof Error ? error.message : String(error)}`,
+              }],
+              details: { error: "fact_query_failed", message: String(error) },
+            };
+          }
+        },
+      };
+    },
+    { name: "memory_fact_query" },
   );
 }
 
@@ -2602,6 +2774,7 @@ export function registerAllMemoryTools(
   registerMemoryRecallTool(api, context);
   registerMemoryRecallAliasTool(api, context, "memory_search");
   registerMemoryRecallAliasTool(api, context, "memory_get");
+  registerMemoryFactQueryTool(api, context);
   registerMemoryStoreTool(api, context);
   registerMemoryForgetTool(api, context);
   registerMemoryUpdateTool(api, context);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -205,15 +205,16 @@ function factQueryMatches(entry: MemoryEntry, query: string | undefined, factKey
   ].some((value) => typeof value === "string" && value.toLowerCase().includes(normalizedQuery));
 }
 
-function isTemporalFactEntry(entry: MemoryEntry): boolean {
-  const meta = parseSmartMetadata(entry.metadata, entry);
+function isTemporalFactEntry(entry: MemoryEntry, hasFactKeySelector: boolean): boolean {
+  const rawMetadata = parseMetadataObject(entry.metadata);
+  if (hasFactKeySelector) return true;
+
   return Boolean(
-    meta.fact_key ||
-    hasExplicitMetadataField(entry, "valid_from") ||
-    meta.supersedes ||
-    meta.superseded_by ||
-    meta.invalidated_at ||
-    meta.valid_until,
+    hasExplicitMetadataField(entry, "supersedes") ||
+    hasExplicitMetadataField(entry, "superseded_by") ||
+    hasExplicitMetadataField(entry, "invalidated_at") ||
+    hasExplicitMetadataField(entry, "valid_until") ||
+    rawMetadata.memory_temporal_type === "dynamic",
   );
 }
 
@@ -262,6 +263,7 @@ async function collectFactQueryMatches(
 ): Promise<FactQueryCandidate[]> {
   const matches: FactQueryCandidate[] = [];
   const seenIds = new Set<string>();
+  const hasFactKeySelector = Boolean(factKey?.trim());
 
   for (let offset = 0; ; offset += FACT_QUERY_PAGE_SIZE) {
     const page = await store.list(scopeFilter, undefined, FACT_QUERY_PAGE_SIZE, offset);
@@ -273,7 +275,7 @@ async function collectFactQueryMatches(
       if (seenIds.has(entry.id)) continue;
       seenIds.add(entry.id);
       newRows += 1;
-      if (isTemporalFactEntry(entry) && factQueryMatches(entry, query, factKey)) {
+      if (isTemporalFactEntry(entry, hasFactKeySelector) && factQueryMatches(entry, query, factKey)) {
         const meta = parseSmartMetadata(entry.metadata, entry);
         const fact = serializeFactEntry(entry, atMs);
         if (meta.valid_from <= atMs && (includeHistory || fact.activeAt)) {
@@ -1005,14 +1007,28 @@ export function registerMemoryFactQueryTool(
 
           try {
             const safeLimit = clampInt(limit, 1, 100);
+            const trimmedQuery = query?.trim();
+            const trimmedFactKey = factKey?.trim();
+            if (!trimmedQuery && !trimmedFactKey) {
+              return {
+                content: [{
+                  type: "text",
+                  text: "Fact query requires a query or exact factKey selector.",
+                }],
+                details: {
+                  action: "fact_query",
+                  error: "missing_selector",
+                },
+              };
+            }
             const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
             const resolvedScopes = resolveReadableToolScopeFilter(runtimeContext.scopeManager, agentId, scope);
             const atMs = parseFactQueryTimestamp(at);
             const entries = await collectFactQueryMatches(
               runtimeContext.store,
               resolvedScopes.scopeFilter,
-              query,
-              factKey,
+              trimmedQuery,
+              trimmedFactKey,
               atMs,
               includeHistory,
               safeLimit,
@@ -1043,8 +1059,8 @@ export function registerMemoryFactQueryTool(
               }],
               details: {
                 action: "fact_query",
-                query,
-                factKey,
+                query: trimmedQuery,
+                factKey: trimmedFactKey,
                 asOf: new Date(atMs).toISOString(),
                 includeHistory,
                 count: facts.length,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -172,6 +172,22 @@ function formatFactTimestamp(value: number | undefined): string | undefined {
     : undefined;
 }
 
+function parseMetadataObject(rawMetadata: string | undefined): Record<string, unknown> {
+  if (!rawMetadata) return {};
+  try {
+    const parsed = JSON.parse(rawMetadata);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function hasExplicitMetadataField(entry: MemoryEntry, field: string): boolean {
+  return Object.prototype.hasOwnProperty.call(parseMetadataObject(entry.metadata), field);
+}
+
 function factQueryMatches(entry: MemoryEntry, query: string | undefined, factKey: string | undefined): boolean {
   const meta = parseSmartMetadata(entry.metadata, entry);
   const normalizedFactKey = factKey?.trim().toLowerCase();
@@ -193,6 +209,7 @@ function isTemporalFactEntry(entry: MemoryEntry): boolean {
   const meta = parseSmartMetadata(entry.metadata, entry);
   return Boolean(
     meta.fact_key ||
+    hasExplicitMetadataField(entry, "valid_from") ||
     meta.supersedes ||
     meta.superseded_by ||
     meta.invalidated_at ||
@@ -217,6 +234,37 @@ function serializeFactEntry(entry: MemoryEntry, atMs: number) {
     supersedes: meta.supersedes,
     supersededBy: meta.superseded_by,
   };
+}
+
+const FACT_QUERY_PAGE_SIZE = 500;
+
+async function collectFactQueryMatches(
+  store: MemoryStore,
+  scopeFilter: string[] | undefined,
+  query: string | undefined,
+  factKey: string | undefined,
+): Promise<MemoryEntry[]> {
+  const matches: MemoryEntry[] = [];
+  const seenIds = new Set<string>();
+
+  for (let offset = 0; ; offset += FACT_QUERY_PAGE_SIZE) {
+    const page = await store.list(scopeFilter, undefined, FACT_QUERY_PAGE_SIZE, offset);
+    if (page.length === 0) break;
+
+    let newRows = 0;
+    for (const entry of page) {
+      if (seenIds.has(entry.id)) continue;
+      seenIds.add(entry.id);
+      newRows += 1;
+      if (isTemporalFactEntry(entry) && factQueryMatches(entry, query, factKey)) {
+        matches.push(entry);
+      }
+    }
+
+    if (page.length < FACT_QUERY_PAGE_SIZE || newRows === 0) break;
+  }
+
+  return matches;
 }
 
 const _warnedMissingAgentId = new Set<string>();
@@ -933,21 +981,23 @@ export function registerMemoryFactQueryTool(
             const agentId = resolveRuntimeAgentId(runtimeContext.agentId, runtimeCtx);
             const resolvedScopes = resolveReadableToolScopeFilter(runtimeContext.scopeManager, agentId, scope);
             const atMs = parseFactQueryTimestamp(at);
-            const entries = await runtimeContext.store.list(
+            const entries = await collectFactQueryMatches(
+              runtimeContext.store,
               resolvedScopes.scopeFilter,
-              undefined,
-              Math.max(safeLimit * 10, 100),
-              0,
+              query,
+              factKey,
             );
 
             const facts = entries
-              .filter(isTemporalFactEntry)
-              .filter((entry) => factQueryMatches(entry, query, factKey))
-              .map((entry) => ({ entry, fact: serializeFactEntry(entry, atMs) }))
-              .filter(({ fact }) => includeHistory || fact.activeAt)
+              .map((entry) => {
+                const meta = parseSmartMetadata(entry.metadata, entry);
+                return { entry, meta, fact: serializeFactEntry(entry, atMs) };
+              })
+              .filter(({ meta, fact }) => meta.valid_from <= atMs && (includeHistory || fact.activeAt))
               .sort((a, b) => {
                 if (a.fact.activeAt !== b.fact.activeAt) return a.fact.activeAt ? -1 : 1;
-                return (b.entry.timestamp || 0) - (a.entry.timestamp || 0);
+                return (b.meta.valid_from || 0) - (a.meta.valid_from || 0)
+                  || (b.entry.timestamp || 0) - (a.entry.timestamp || 0);
               })
               .slice(0, safeLimit)
               .map(({ fact }) => fact);

--- a/test/memory-fact-query.test.mjs
+++ b/test/memory-fact-query.test.mjs
@@ -44,7 +44,7 @@ function makeEntry({
   };
 }
 
-function createTool(entries) {
+function createTool(entries, contextOverrides = {}) {
   const toolFactories = {};
   const api = {
     registerTool(factory, meta) {
@@ -74,6 +74,7 @@ function createTool(entries) {
     retriever: {},
     embedder: {},
     agentId: "main",
+    ...contextOverrides,
   });
 
   return toolFactories.memory_fact_query({ agentId: "main" });
@@ -255,4 +256,40 @@ test("memory_fact_query orders as-of matches by valid_from before entry timestam
   assert.equal(result.details.count, 2);
   assert.equal(result.details.facts[0].id, "newer-valid-from");
   assert.equal(result.details.facts[1].id, "older-valid-from");
+});
+
+test("memory_fact_query filters USER.md-exclusive facts from output and details", async () => {
+  const entries = [
+    makeEntry({
+      id: "profile-only",
+      text: "User profile: timezone is Asia/Shanghai",
+      validFrom: Date.parse("2026-01-01T00:00:00Z"),
+      memoryCategory: "profile",
+    }),
+    makeEntry({
+      id: "regular-fact",
+      text: "Workspace timezone test fixture remains visible",
+      factKey: "entities:workspace timezone fixture",
+      validFrom: Date.parse("2026-01-02T00:00:00Z"),
+    }),
+  ];
+  const tool = createTool(entries, {
+    workspaceBoundary: {
+      userMdExclusive: {
+        enabled: true,
+      },
+    },
+  });
+
+  const result = await tool.execute(null, {
+    query: "timezone",
+    at: "2026-01-15T00:00:00Z",
+    includeHistory: true,
+    limit: 10,
+  }, undefined, undefined, { agentId: "main" });
+
+  assert.equal(result.details.count, 1);
+  assert.equal(result.details.facts[0].id, "regular-fact");
+  assert.doesNotMatch(result.content[0].text, /Asia\/Shanghai/);
+  assert.ok(!result.details.facts.some((fact) => fact.id === "profile-only"));
 });

--- a/test/memory-fact-query.test.mjs
+++ b/test/memory-fact-query.test.mjs
@@ -10,7 +10,16 @@ const {
 const { createScopeManager } = jiti("../src/scopes.ts");
 const { registerMemoryFactQueryTool } = jiti("../src/tools.ts");
 
-function makeEntry({ id, text, factKey, validFrom, invalidatedAt, validUntil }) {
+function makeEntry({
+  id,
+  text,
+  factKey,
+  validFrom,
+  invalidatedAt,
+  validUntil,
+  timestamp = validFrom,
+  memoryCategory = "entities",
+}) {
   return {
     id,
     text,
@@ -18,13 +27,13 @@ function makeEntry({ id, text, factKey, validFrom, invalidatedAt, validUntil }) 
     category: "fact",
     scope: "global",
     importance: 0.8,
-    timestamp: validFrom,
+    timestamp,
     metadata: stringifySmartMetadata(
       buildSmartMetadata(
-        { text, category: "fact", importance: 0.8, timestamp: validFrom },
+        { text, category: "fact", importance: 0.8, timestamp },
         {
           l0_abstract: text,
-          memory_category: "entities",
+          memory_category: memoryCategory,
           fact_key: factKey,
           valid_from: validFrom,
           invalidated_at: invalidatedAt,
@@ -55,8 +64,11 @@ function createTool(entries) {
   registerMemoryFactQueryTool(api, {
     scopeManager,
     store: {
-      async list(scopeFilter) {
-        return entries.filter((entry) => !scopeFilter || scopeFilter.includes(entry.scope));
+      async list(scopeFilter, _category, limit = 20, offset = 0) {
+        return entries
+          .filter((entry) => !scopeFilter || scopeFilter.includes(entry.scope))
+          .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))
+          .slice(offset, offset + limit);
       },
     },
     retriever: {},
@@ -133,4 +145,114 @@ test("memory_fact_query hides expired facts unless history is requested", async 
   assert.equal(history.details.count, 1);
   assert.equal(history.details.facts[0].id, "expired-fact");
   assert.equal(history.details.facts[0].activeAt, false);
+});
+
+test("memory_fact_query scans paginated store results before applying the result limit", async () => {
+  const targetFrom = Date.parse("2026-01-01T00:00:00Z");
+  const entries = [
+    makeEntry({
+      id: "historical-target",
+      text: "Workspace canonical branch: trunk",
+      factKey: "entities:workspace canonical branch",
+      validFrom: targetFrom,
+    }),
+  ];
+
+  for (let i = 0; i < 525; i += 1) {
+    entries.push(makeEntry({
+      id: `newer-${i}`,
+      text: `Unrelated deployment note ${i}`,
+      factKey: `entities:unrelated ${i}`,
+      validFrom: Date.parse("2026-02-01T00:00:00Z") + i,
+    }));
+  }
+
+  const tool = createTool(entries);
+  const result = await tool.execute(null, {
+    factKey: "entities:workspace canonical branch",
+    at: "2026-03-01T00:00:00Z",
+    limit: 1,
+  }, undefined, undefined, { agentId: "main" });
+
+  assert.equal(result.details.count, 1);
+  assert.equal(result.details.facts[0].id, "historical-target");
+});
+
+test("memory_fact_query includeHistory excludes facts that are not valid yet", async () => {
+  const entries = [
+    makeEntry({
+      id: "expired-fact",
+      text: "Launch window: January",
+      factKey: "entities:launch window",
+      validFrom: Date.parse("2026-01-01T00:00:00Z"),
+      validUntil: Date.parse("2026-01-10T00:00:00Z"),
+    }),
+    makeEntry({
+      id: "future-fact",
+      text: "Launch window: February",
+      factKey: "entities:launch window",
+      validFrom: Date.parse("2026-02-01T00:00:00Z"),
+    }),
+  ];
+  const tool = createTool(entries);
+
+  const result = await tool.execute(null, {
+    factKey: "entities:launch window",
+    at: "2026-01-15T00:00:00Z",
+    includeHistory: true,
+  }, undefined, undefined, { agentId: "main" });
+
+  assert.equal(result.details.count, 1);
+  assert.equal(result.details.facts[0].id, "expired-fact");
+});
+
+test("memory_fact_query treats explicit valid_from metadata as temporal without a fact key", async () => {
+  const entries = [
+    makeEntry({
+      id: "valid-from-only",
+      text: "The workspace runs nightly cleanup at 02:00",
+      validFrom: Date.parse("2026-01-01T00:00:00Z"),
+      memoryCategory: "patterns",
+    }),
+  ];
+  const tool = createTool(entries);
+
+  const result = await tool.execute(null, {
+    query: "nightly cleanup",
+    at: "2026-01-15T00:00:00Z",
+  }, undefined, undefined, { agentId: "main" });
+
+  assert.equal(result.details.count, 1);
+  assert.equal(result.details.facts[0].id, "valid-from-only");
+});
+
+test("memory_fact_query orders as-of matches by valid_from before entry timestamp", async () => {
+  const entries = [
+    makeEntry({
+      id: "older-valid-from",
+      text: "Retention policy: 30 days",
+      factKey: "entities:retention policy",
+      validFrom: Date.parse("2026-01-01T00:00:00Z"),
+      timestamp: Date.parse("2026-03-01T00:00:00Z"),
+    }),
+    makeEntry({
+      id: "newer-valid-from",
+      text: "Retention policy: 60 days",
+      factKey: "entities:retention policy",
+      validFrom: Date.parse("2026-02-01T00:00:00Z"),
+      timestamp: Date.parse("2026-02-01T00:00:00Z"),
+    }),
+  ];
+  const tool = createTool(entries);
+
+  const result = await tool.execute(null, {
+    factKey: "entities:retention policy",
+    at: "2026-03-15T00:00:00Z",
+    includeHistory: true,
+    limit: 2,
+  }, undefined, undefined, { agentId: "main" });
+
+  assert.equal(result.details.count, 2);
+  assert.equal(result.details.facts[0].id, "newer-valid-from");
+  assert.equal(result.details.facts[1].id, "older-valid-from");
 });

--- a/test/memory-fact-query.test.mjs
+++ b/test/memory-fact-query.test.mjs
@@ -17,6 +17,8 @@ function makeEntry({
   validFrom,
   invalidatedAt,
   validUntil,
+  supersedes,
+  memoryTemporalType,
   timestamp = validFrom,
   memoryCategory = "entities",
 }) {
@@ -38,6 +40,8 @@ function makeEntry({
           valid_from: validFrom,
           invalidated_at: invalidatedAt,
           valid_until: validUntil,
+          supersedes,
+          memory_temporal_type: memoryTemporalType,
         },
       ),
     ),
@@ -96,6 +100,7 @@ test("memory_fact_query returns the fact active at the requested date", async ()
       text: "MyQuant strategy version: v12.0",
       factKey: "entities:myquant strategy version",
       validFrom: newFrom,
+      supersedes: "old-version",
     }),
   ];
   const tool = createTool(entries);
@@ -207,13 +212,14 @@ test("memory_fact_query includeHistory excludes facts that are not valid yet", a
   assert.equal(result.details.facts[0].id, "expired-fact");
 });
 
-test("memory_fact_query treats explicit valid_from metadata as temporal without a fact key", async () => {
+test("memory_fact_query treats explicitly dynamic metadata as temporal without a fact key", async () => {
   const entries = [
     makeEntry({
       id: "valid-from-only",
       text: "The workspace runs nightly cleanup at 02:00",
       validFrom: Date.parse("2026-01-01T00:00:00Z"),
       memoryCategory: "patterns",
+      memoryTemporalType: "dynamic",
     }),
   ];
   const tool = createTool(entries);
@@ -225,6 +231,47 @@ test("memory_fact_query treats explicit valid_from metadata as temporal without 
 
   assert.equal(result.details.count, 1);
   assert.equal(result.details.facts[0].id, "valid-from-only");
+});
+
+test("memory_fact_query requires an explicit query or factKey selector", async () => {
+  const tool = createTool([
+    makeEntry({
+      id: "broad-list-target",
+      text: "Workspace canonical branch: trunk",
+      factKey: "entities:workspace canonical branch",
+      validFrom: Date.parse("2026-01-01T00:00:00Z"),
+    }),
+  ]);
+
+  const result = await tool.execute(null, {}, undefined, undefined, { agentId: "main" });
+
+  assert.equal(result.details.error, "missing_selector");
+  assert.match(result.content[0].text, /requires a query or exact factKey/);
+});
+
+test("memory_fact_query text search does not treat ordinary smart metadata as temporal facts", async () => {
+  const ordinaryEntry = makeEntry({
+    id: "ordinary-smart-memory",
+    text: "Workspace timezone test fixture remains visible",
+    factKey: "entities:workspace timezone fixture",
+    validFrom: Date.parse("2026-01-01T00:00:00Z"),
+  });
+  const temporalEntry = makeEntry({
+    id: "dynamic-temporal-memory",
+    text: "Workspace timezone rotates tomorrow",
+    factKey: "entities:workspace timezone dynamic",
+    validFrom: Date.parse("2026-01-02T00:00:00Z"),
+    memoryTemporalType: "dynamic",
+  });
+  const tool = createTool([ordinaryEntry, temporalEntry]);
+
+  const result = await tool.execute(null, {
+    query: "workspace timezone",
+    at: "2026-01-15T00:00:00Z",
+    includeHistory: true,
+  }, undefined, undefined, { agentId: "main" });
+
+  assert.deepEqual(result.details.facts.map((fact) => fact.id), ["dynamic-temporal-memory"]);
 });
 
 test("memory_fact_query orders as-of matches by valid_from before entry timestamp", async () => {
@@ -265,12 +312,14 @@ test("memory_fact_query filters USER.md-exclusive facts from output and details"
       text: "User profile: timezone is Asia/Shanghai",
       validFrom: Date.parse("2026-01-01T00:00:00Z"),
       memoryCategory: "profile",
+      memoryTemporalType: "dynamic",
     }),
     makeEntry({
       id: "regular-fact",
       text: "Workspace timezone test fixture remains visible",
       factKey: "entities:workspace timezone fixture",
       validFrom: Date.parse("2026-01-02T00:00:00Z"),
+      memoryTemporalType: "dynamic",
     }),
   ];
   const tool = createTool(entries, {

--- a/test/memory-fact-query.test.mjs
+++ b/test/memory-fact-query.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const {
+  buildSmartMetadata,
+  stringifySmartMetadata,
+} = jiti("../src/smart-metadata.ts");
+const { createScopeManager } = jiti("../src/scopes.ts");
+const { registerMemoryFactQueryTool } = jiti("../src/tools.ts");
+
+function makeEntry({ id, text, factKey, validFrom, invalidatedAt, validUntil }) {
+  return {
+    id,
+    text,
+    vector: [],
+    category: "fact",
+    scope: "global",
+    importance: 0.8,
+    timestamp: validFrom,
+    metadata: stringifySmartMetadata(
+      buildSmartMetadata(
+        { text, category: "fact", importance: 0.8, timestamp: validFrom },
+        {
+          l0_abstract: text,
+          memory_category: "entities",
+          fact_key: factKey,
+          valid_from: validFrom,
+          invalidated_at: invalidatedAt,
+          valid_until: validUntil,
+        },
+      ),
+    ),
+  };
+}
+
+function createTool(entries) {
+  const toolFactories = {};
+  const api = {
+    registerTool(factory, meta) {
+      toolFactories[meta.name] = factory;
+    },
+  };
+  const scopeManager = createScopeManager({
+    default: "global",
+    definitions: {
+      global: { description: "Shared" },
+    },
+    agentAccess: {
+      main: ["global"],
+    },
+  });
+
+  registerMemoryFactQueryTool(api, {
+    scopeManager,
+    store: {
+      async list(scopeFilter) {
+        return entries.filter((entry) => !scopeFilter || scopeFilter.includes(entry.scope));
+      },
+    },
+    retriever: {},
+    embedder: {},
+    agentId: "main",
+  });
+
+  return toolFactories.memory_fact_query({ agentId: "main" });
+}
+
+test("memory_fact_query returns the fact active at the requested date", async () => {
+  const oldFrom = Date.parse("2026-01-01T00:00:00Z");
+  const newFrom = Date.parse("2026-02-01T00:00:00Z");
+  const entries = [
+    makeEntry({
+      id: "old-version",
+      text: "MyQuant strategy version: v11.1",
+      factKey: "entities:myquant strategy version",
+      validFrom: oldFrom,
+      invalidatedAt: newFrom,
+    }),
+    makeEntry({
+      id: "current-version",
+      text: "MyQuant strategy version: v12.0",
+      factKey: "entities:myquant strategy version",
+      validFrom: newFrom,
+    }),
+  ];
+  const tool = createTool(entries);
+
+  const historical = await tool.execute(null, {
+    factKey: "entities:myquant strategy version",
+    at: "2026-01-15T00:00:00Z",
+  }, undefined, undefined, { agentId: "main" });
+
+  assert.equal(historical.details.count, 1);
+  assert.equal(historical.details.facts[0].id, "old-version");
+  assert.equal(historical.details.facts[0].activeAt, true);
+
+  const current = await tool.execute(null, {
+    query: "myquant strategy version",
+    at: "2026-03-01T00:00:00Z",
+  }, undefined, undefined, { agentId: "main" });
+
+  assert.equal(current.details.count, 1);
+  assert.equal(current.details.facts[0].id, "current-version");
+});
+
+test("memory_fact_query hides expired facts unless history is requested", async () => {
+  const entries = [
+    makeEntry({
+      id: "expired-fact",
+      text: "Temporary deployment freeze until Friday",
+      factKey: "entities:deployment freeze",
+      validFrom: Date.parse("2026-01-01T00:00:00Z"),
+      validUntil: Date.parse("2026-01-10T00:00:00Z"),
+    }),
+  ];
+  const tool = createTool(entries);
+
+  const current = await tool.execute(null, {
+    query: "deployment freeze",
+    at: "2026-01-15T00:00:00Z",
+  }, undefined, undefined, { agentId: "main" });
+
+  assert.equal(current.details.count, 0);
+
+  const history = await tool.execute(null, {
+    query: "deployment freeze",
+    at: "2026-01-15T00:00:00Z",
+    includeHistory: true,
+  }, undefined, undefined, { agentId: "main" });
+
+  assert.equal(history.details.count, 1);
+  assert.equal(history.details.facts[0].id, "expired-fact");
+  assert.equal(history.details.facts[0].activeAt, false);
+});

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -80,7 +80,7 @@ assert.ok(
   Object.prototype.hasOwnProperty.call(manifest.configSchema.properties.llm.properties, "auth"),
   "configSchema should declare llm.auth",
 );
-for (const toolName of ["memory_recall", "memory_search", "memory_get", "memory_store"]) {
+for (const toolName of ["memory_recall", "memory_search", "memory_get", "memory_fact_query", "memory_store"]) {
   assert.ok(
     manifest.contracts.tools.includes(toolName),
     `contracts.tools should declare ${toolName}`,


### PR DESCRIPTION
## Summary
- add a read-only memory_fact_query tool for deterministic temporal fact lookup
- filter facts by active/as-of time using existing temporal metadata
- register manifest and CI coverage for the new tool

Refs #725

## Verification
- node --test test/memory-fact-query.test.mjs
- node test/plugin-manifest-regression.mjs
- node scripts/verify-ci-test-manifest.mjs
- npm run build