### PR TITLE
docs: record release dist-tag gap

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -8,6 +8,7 @@ intended for the release tracked in #812 and future beta/stable cuts.
 - Current package version: `1.1.0-beta.11`
 - Recommended first publish: beta dist-tag
 - Stable channel decision: maintainer-owned after beta smoke testing
+- Current public package snapshot: see [release-status.md](release-status.md)
 
 The current release driver is that npm users are still behind repository
 `master`: merged fixes are not available from the published `latest` package,

--- a/docs/release-status.md
+++ b/docs/release-status.md
@@ -1,0 +1,34 @@
+# Release Status
+
+This note captures the release gap tracked in #812 so maintainers can verify the
+public package channel before and after the next beta publish.
+
+## Live npm snapshot
+
+Checked on 2026-06-13:
+
+```json
+{
+  "dist-tags": {
+    "latest": "1.0.32",
+    "dev": "1.1.0-beta.5",
+    "beta": "1.1.0-beta.9"
+  },
+  "version": "1.0.32"
+}
+```
+
+The repository package version is `1.1.0-beta.11`, so npm users installing
+`memory-lancedb-pro@beta` still receive an older package than current `master`.
+
+## Target after publish
+
+After the next beta publish:
+
+- `npm view memory-lancedb-pro@beta version` should return `1.1.0-beta.11`
+- `npm view memory-lancedb-pro@beta main` should return `dist/index.js`
+- `npm view memory-lancedb-pro@beta openclaw.extensions --json` should include `./dist/index.js`
+- `npm pack --dry-run` should include compiled `dist/**/*` output and exclude `test/**/*`
+
+Stable `latest` remains a maintainer decision after the beta package is smoke
+tested on current OpenClaw.

--- a/test/release-readiness.test.mjs
+++ b/test/release-readiness.test.mjs
@@ -18,6 +18,7 @@ function escapeRegExp(value) {
 const pkg = readJson("package.json");
 const manifest = readJson("openclaw.plugin.json");
 const releaseChecklist = readText("docs/release-checklist.md");
+const releaseStatus = readText("docs/release-status.md");
 
 assert.equal(pkg.version, manifest.version, "package and plugin manifest versions must match before release");
 assert.match(pkg.version, /^1\.1\.0-beta\.\d+$/, "current release target should remain an explicit v1.1.0 beta");
@@ -40,6 +41,10 @@ assert.match(releaseChecklist, /npm run test:packaging-and-workflow/);
 assert.match(releaseChecklist, /npm pack --dry-run/);
 assert.match(releaseChecklist, /npm publish --tag beta --dry-run/);
 assert.match(releaseChecklist, /npm view memory-lancedb-pro@beta version main openclaw files --json/);
+assert.match(releaseChecklist, /release-status\.md/);
+assert.match(releaseStatus, new RegExp(`repository package version is \`${escapeRegExp(pkg.version)}\``));
+assert.match(releaseStatus, /npm view memory-lancedb-pro@beta version/);
+assert.match(releaseStatus, /dist\/index\.js/);
 
 assert.ok(
   CI_TEST_MANIFEST.some((entry) => entry.file === "test/release-readiness.test.mjs"),


### PR DESCRIPTION
## Summary
- add a release status note with the live npm dist-tag/version gap
- link the checklist to the status note
- extend release readiness coverage to require the status note content

Refs #812

## Verification
- node test/release-readiness.test.mjs
- node scripts/verify-ci-test-manifest.mjs
- npm run test:packaging-and-workflow