### PR TITLE
fix: cap auto-recall rerank timeout

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2253,6 +2253,7 @@ const memoryLanceDBProPlugin = {
             });
             const AUTO_RECALL_TIMEOUT_MS = parsePositiveInt(config.autoRecallTimeoutMs) ?? 5_000; // configurable; default raised from 3s to 5s for remote embedding APIs behind proxies
             api.on("before_prompt_build", async (event, ctx) => {
+                const autoRecallDeadlineMs = Date.now() + AUTO_RECALL_TIMEOUT_MS;
                 // Skip auto-recall for sub-agent sessions — their context comes from the parent.
                 const sessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : "";
                 if (sessionKey.includes(":subagent:"))
@@ -2349,7 +2350,10 @@ const memoryLanceDBProPlugin = {
                         source: "auto-recall",
                         signal: autoRecallAbortController.signal,
                         ...(autoRecallRerankTimeoutMs !== undefined
-                            ? { rerankTimeoutMs: autoRecallRerankTimeoutMs }
+                            ? {
+                                rerankTimeoutMs: autoRecallRerankTimeoutMs,
+                                rerankDeadlineMs: autoRecallDeadlineMs,
+                            }
                             : {}),
                     }), config.workspaceBoundary);
                     if (shouldDropLateAutoRecall("post-retrieve"))

--- a/dist/index.js
+++ b/dist/index.js
@@ -165,8 +165,10 @@ function getAutoRecallRerankTimeoutMs(config, retrievalConfig, autoRecallTimeout
     if (!Number.isFinite(autoRecallTimeoutMs) || autoRecallTimeoutMs <= 0)
         return undefined;
     const halfBudget = Math.floor(autoRecallTimeoutMs / 2);
+    if (halfBudget < 100)
+        return 0;
     if (autoRecallTimeoutMs <= 1_000)
-        return Math.max(100, halfBudget);
+        return halfBudget;
     return clampInt(halfBudget, 500, 2_500);
 }
 export function buildAutoRecallRerankCostWarning(config, retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...(config.retrieval || {}) }) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -157,6 +157,18 @@ function getAutoRecallRetrieveLimit(autoRecallMaxItems) {
 function getAutoRecallRerankInputLimit(retrieveLimit) {
     return clampInt(retrieveLimit, 1, 20) * 2;
 }
+function getAutoRecallRerankTimeoutMs(config, retrievalConfig, autoRecallTimeoutMs) {
+    if (retrievalConfig.rerank !== "cross-encoder" || !retrievalConfig.rerankApiKey)
+        return undefined;
+    if (typeof config.retrieval?.rerankTimeoutMs === "number")
+        return undefined;
+    if (!Number.isFinite(autoRecallTimeoutMs) || autoRecallTimeoutMs <= 0)
+        return undefined;
+    const halfBudget = Math.floor(autoRecallTimeoutMs / 2);
+    if (autoRecallTimeoutMs <= 1_000)
+        return Math.max(100, halfBudget);
+    return clampInt(halfBudget, 500, 2_500);
+}
 export function buildAutoRecallRerankCostWarning(config, retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...(config.retrieval || {}) }) {
     if (config.autoRecall !== true || config.recallMode === "off")
         return null;
@@ -2322,6 +2334,7 @@ const memoryLanceDBProPlugin = {
                     const retrieveLimit = getAutoRecallRetrieveLimit(autoRecallMaxItems);
                     const retrievalConfig = retriever.getConfig();
                     const rerankInputLimit = getAutoRecallRerankInputLimit(retrieveLimit);
+                    const autoRecallRerankTimeoutMs = getAutoRecallRerankTimeoutMs(config, retrievalConfig, AUTO_RECALL_TIMEOUT_MS);
                     // Adaptive intent analysis (zero-LLM-cost pattern matching)
                     const intent = recallMode === "adaptive" ? analyzeIntent(recallQuery) : undefined;
                     if (intent) {
@@ -2333,6 +2346,9 @@ const memoryLanceDBProPlugin = {
                         scopeFilter: accessibleScopes,
                         source: "auto-recall",
                         signal: autoRecallAbortController.signal,
+                        ...(autoRecallRerankTimeoutMs !== undefined
+                            ? { rerankTimeoutMs: autoRecallRerankTimeoutMs }
+                            : {}),
                     }), config.workspaceBoundary);
                     if (shouldDropLateAutoRecall("post-retrieve"))
                         return;

--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -874,6 +874,10 @@ export class MemoryRetriever {
         };
         if (this.config.rerank === "cross-encoder" && hasApiKey) {
             try {
+                if (timeoutOverrideMs !== undefined && timeoutOverrideMs <= 0) {
+                    recordFallback("timeout", "Rerank API skipped because caller timeout budget is exhausted");
+                    throw new Error("skip-remote-rerank-timeout-budget");
+                }
                 const model = this.config.rerankModel || "jina-reranker-v3";
                 const endpoint = this.config.rerankEndpoint || "https://api.jina.ai/v1/rerank";
                 const documents = results.map((r) => r.entry.text);
@@ -940,7 +944,10 @@ export class MemoryRetriever {
                 }
             }
             catch (error) {
-                if (error instanceof Error && error.name === "AbortError") {
+                if (error instanceof Error && error.message === "skip-remote-rerank-timeout-budget") {
+                    // Caller supplied a zero/negative per-call timeout to reserve the outer budget.
+                }
+                else if (error instanceof Error && error.name === "AbortError") {
                     const message = `Rerank API timed out (${timeoutOverrideMs ?? this.config.rerankTimeoutMs ?? 5000}ms)`;
                     recordFallback("timeout", message);
                     console.warn(`${message}, falling back to cosine`);

--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -338,7 +338,7 @@ export class MemoryRetriever {
         return this.store.hasFtsSupport;
     }
     async retrieve(context) {
-        const { query, limit, scopeFilter, category, source, signal, rerankTimeoutMs } = context;
+        const { query, limit, scopeFilter, category, source, signal, rerankTimeoutMs, rerankDeadlineMs } = context;
         const safeLimit = clampInt(limit, 1, 20);
         this.lastDiagnostics = null;
         const diagnostics = {
@@ -384,7 +384,7 @@ export class MemoryRetriever {
                 results = await this.vectorOnlyRetrieval(query, safeLimit, scopeFilter, category, trace, diagnostics, signal);
             }
             else {
-                results = await this.hybridRetrieval(query, safeLimit, scopeFilter, category, trace, source, diagnostics, signal, rerankTimeoutMs);
+                results = await this.hybridRetrieval(query, safeLimit, scopeFilter, category, trace, source, diagnostics, signal, rerankTimeoutMs, rerankDeadlineMs);
             }
             diagnostics.finalResultCount = results.length;
             diagnostics.dropSummary = buildDropSummary(diagnostics);
@@ -607,7 +607,7 @@ export class MemoryRetriever {
             diagnostics.stageCounts.afterDiversity = deduplicated.length;
         return finalResults;
     }
-    async hybridRetrieval(query, limit, scopeFilter, category, trace, source, diagnostics, signal, rerankTimeoutMs) {
+    async hybridRetrieval(query, limit, scopeFilter, category, trace, source, diagnostics, signal, rerankTimeoutMs, rerankDeadlineMs) {
         let failureStage = "hybrid.embedQuery";
         try {
             const candidatePoolSize = Math.max(this.config.candidatePoolSize, limit * 2);
@@ -697,7 +697,7 @@ export class MemoryRetriever {
             failureStage = "hybrid.rerank";
             if (this.config.rerank !== "none") {
                 trace?.startStage("rerank", filtered.map((r) => r.entry.id));
-                reranked = await this.rerankResults(query, queryVector, rerankInput, diagnostics, rerankTimeoutMs);
+                reranked = await this.rerankResults(query, queryVector, rerankInput, diagnostics, rerankTimeoutMs, rerankDeadlineMs);
                 trace?.endStage(reranked.map((r) => r.entry.id), reranked.map((r) => r.score));
             }
             else {
@@ -860,7 +860,7 @@ export class MemoryRetriever {
      * Rerank results using cross-encoder API (Jina, Pinecone, or compatible).
      * Falls back to cosine similarity if API is unavailable or fails.
      */
-    async rerankResults(query, queryVector, results, diagnostics, timeoutOverrideMs) {
+    async rerankResults(query, queryVector, results, diagnostics, timeoutOverrideMs, deadlineMs) {
         if (results.length === 0) {
             return results;
         }
@@ -874,7 +874,14 @@ export class MemoryRetriever {
         };
         if (this.config.rerank === "cross-encoder" && hasApiKey) {
             try {
+                const remainingDeadlineMs = deadlineMs !== undefined
+                    ? Math.floor(deadlineMs - Date.now())
+                    : undefined;
                 if (timeoutOverrideMs !== undefined && timeoutOverrideMs <= 0) {
+                    recordFallback("timeout", "Rerank API skipped because caller timeout budget is exhausted");
+                    throw new Error("skip-remote-rerank-timeout-budget");
+                }
+                if (remainingDeadlineMs !== undefined && remainingDeadlineMs < 100) {
                     recordFallback("timeout", "Rerank API skipped because caller timeout budget is exhausted");
                     throw new Error("skip-remote-rerank-timeout-budget");
                 }
@@ -884,7 +891,10 @@ export class MemoryRetriever {
                 const rerankTopN = Math.min(results.length, Math.max(1, this.config.candidatePoolSize));
                 // Build provider-specific request
                 const { headers, body } = buildRerankRequest(provider, this.config.rerankApiKey || "", model, query, documents, rerankTopN);
-                const effectiveTimeoutMs = timeoutOverrideMs ?? this.config.rerankTimeoutMs ?? 5000;
+                const configuredTimeoutMs = timeoutOverrideMs ?? this.config.rerankTimeoutMs ?? 5000;
+                const effectiveTimeoutMs = remainingDeadlineMs !== undefined
+                    ? Math.min(configuredTimeoutMs, remainingDeadlineMs)
+                    : configuredTimeoutMs;
                 // Timeout: configurable via rerankTimeoutMs (default: 5000ms)
                 const controller = new AbortController();
                 const timeout = setTimeout(() => controller.abort(), effectiveTimeoutMs);

--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -338,7 +338,7 @@ export class MemoryRetriever {
         return this.store.hasFtsSupport;
     }
     async retrieve(context) {
-        const { query, limit, scopeFilter, category, source, signal } = context;
+        const { query, limit, scopeFilter, category, source, signal, rerankTimeoutMs } = context;
         const safeLimit = clampInt(limit, 1, 20);
         this.lastDiagnostics = null;
         const diagnostics = {
@@ -384,7 +384,7 @@ export class MemoryRetriever {
                 results = await this.vectorOnlyRetrieval(query, safeLimit, scopeFilter, category, trace, diagnostics, signal);
             }
             else {
-                results = await this.hybridRetrieval(query, safeLimit, scopeFilter, category, trace, source, diagnostics, signal);
+                results = await this.hybridRetrieval(query, safeLimit, scopeFilter, category, trace, source, diagnostics, signal, rerankTimeoutMs);
             }
             diagnostics.finalResultCount = results.length;
             diagnostics.dropSummary = buildDropSummary(diagnostics);
@@ -607,7 +607,7 @@ export class MemoryRetriever {
             diagnostics.stageCounts.afterDiversity = deduplicated.length;
         return finalResults;
     }
-    async hybridRetrieval(query, limit, scopeFilter, category, trace, source, diagnostics, signal) {
+    async hybridRetrieval(query, limit, scopeFilter, category, trace, source, diagnostics, signal, rerankTimeoutMs) {
         let failureStage = "hybrid.embedQuery";
         try {
             const candidatePoolSize = Math.max(this.config.candidatePoolSize, limit * 2);
@@ -697,7 +697,7 @@ export class MemoryRetriever {
             failureStage = "hybrid.rerank";
             if (this.config.rerank !== "none") {
                 trace?.startStage("rerank", filtered.map((r) => r.entry.id));
-                reranked = await this.rerankResults(query, queryVector, rerankInput, diagnostics);
+                reranked = await this.rerankResults(query, queryVector, rerankInput, diagnostics, rerankTimeoutMs);
                 trace?.endStage(reranked.map((r) => r.entry.id), reranked.map((r) => r.score));
             }
             else {
@@ -860,7 +860,7 @@ export class MemoryRetriever {
      * Rerank results using cross-encoder API (Jina, Pinecone, or compatible).
      * Falls back to cosine similarity if API is unavailable or fails.
      */
-    async rerankResults(query, queryVector, results, diagnostics) {
+    async rerankResults(query, queryVector, results, diagnostics, timeoutOverrideMs) {
         if (results.length === 0) {
             return results;
         }
@@ -880,9 +880,10 @@ export class MemoryRetriever {
                 const rerankTopN = Math.min(results.length, Math.max(1, this.config.candidatePoolSize));
                 // Build provider-specific request
                 const { headers, body } = buildRerankRequest(provider, this.config.rerankApiKey || "", model, query, documents, rerankTopN);
+                const effectiveTimeoutMs = timeoutOverrideMs ?? this.config.rerankTimeoutMs ?? 5000;
                 // Timeout: configurable via rerankTimeoutMs (default: 5000ms)
                 const controller = new AbortController();
-                const timeout = setTimeout(() => controller.abort(), this.config.rerankTimeoutMs ?? 5000);
+                const timeout = setTimeout(() => controller.abort(), effectiveTimeoutMs);
                 let response;
                 try {
                     response = await fetch(endpoint, {
@@ -940,7 +941,7 @@ export class MemoryRetriever {
             }
             catch (error) {
                 if (error instanceof Error && error.name === "AbortError") {
-                    const message = `Rerank API timed out (${this.config.rerankTimeoutMs ?? 5000}ms)`;
+                    const message = `Rerank API timed out (${timeoutOverrideMs ?? this.config.rerankTimeoutMs ?? 5000}ms)`;
                     recordFallback("timeout", message);
                     console.warn(`${message}, falling back to cosine`);
                 }

--- a/index.ts
+++ b/index.ts
@@ -433,7 +433,8 @@ function getAutoRecallRerankTimeoutMs(
   if (!Number.isFinite(autoRecallTimeoutMs) || autoRecallTimeoutMs <= 0) return undefined;
 
   const halfBudget = Math.floor(autoRecallTimeoutMs / 2);
-  if (autoRecallTimeoutMs <= 1_000) return Math.max(100, halfBudget);
+  if (halfBudget < 100) return 0;
+  if (autoRecallTimeoutMs <= 1_000) return halfBudget;
   return clampInt(halfBudget, 500, 2_500);
 }
 

--- a/index.ts
+++ b/index.ts
@@ -2500,6 +2500,8 @@ const memoryLanceDBProPlugin = {
       category?: string;
       source?: "manual" | "auto-recall" | "cli";
       signal?: AbortSignal;
+      rerankTimeoutMs?: number;
+      rerankDeadlineMs?: number;
     }) {
       let results = await retriever.retrieve(params);
       if (results.length === 0) {
@@ -2958,6 +2960,7 @@ const memoryLanceDBProPlugin = {
 
       const AUTO_RECALL_TIMEOUT_MS = parsePositiveInt(config.autoRecallTimeoutMs) ?? 5_000; // configurable; default raised from 3s to 5s for remote embedding APIs behind proxies
       api.on("before_prompt_build", async (event: any, ctx: any) => {
+        const autoRecallDeadlineMs = Date.now() + AUTO_RECALL_TIMEOUT_MS;
         // Skip auto-recall for sub-agent sessions — their context comes from the parent.
         const sessionKey = typeof ctx.sessionKey === "string" ? ctx.sessionKey : "";
         if (sessionKey.includes(":subagent:")) return;
@@ -3080,7 +3083,10 @@ const memoryLanceDBProPlugin = {
             source: "auto-recall",
             signal: autoRecallAbortController.signal,
             ...(autoRecallRerankTimeoutMs !== undefined
-              ? { rerankTimeoutMs: autoRecallRerankTimeoutMs }
+              ? {
+                rerankTimeoutMs: autoRecallRerankTimeoutMs,
+                rerankDeadlineMs: autoRecallDeadlineMs,
+              }
               : {}),
           }), config.workspaceBoundary);
 

--- a/index.ts
+++ b/index.ts
@@ -423,6 +423,20 @@ function getAutoRecallRerankInputLimit(retrieveLimit: number): number {
   return clampInt(retrieveLimit, 1, 20) * 2;
 }
 
+function getAutoRecallRerankTimeoutMs(
+  config: PluginConfig,
+  retrievalConfig: RetrievalConfig,
+  autoRecallTimeoutMs: number,
+): number | undefined {
+  if (retrievalConfig.rerank !== "cross-encoder" || !retrievalConfig.rerankApiKey) return undefined;
+  if (typeof config.retrieval?.rerankTimeoutMs === "number") return undefined;
+  if (!Number.isFinite(autoRecallTimeoutMs) || autoRecallTimeoutMs <= 0) return undefined;
+
+  const halfBudget = Math.floor(autoRecallTimeoutMs / 2);
+  if (autoRecallTimeoutMs <= 1_000) return Math.max(100, halfBudget);
+  return clampInt(halfBudget, 500, 2_500);
+}
+
 export function buildAutoRecallRerankCostWarning(
   config: PluginConfig,
   retrievalConfig: RetrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...(config.retrieval || {}) },
@@ -3044,6 +3058,11 @@ const memoryLanceDBProPlugin = {
           const retrieveLimit = getAutoRecallRetrieveLimit(autoRecallMaxItems);
           const retrievalConfig = retriever.getConfig();
           const rerankInputLimit = getAutoRecallRerankInputLimit(retrieveLimit);
+          const autoRecallRerankTimeoutMs = getAutoRecallRerankTimeoutMs(
+            config,
+            retrievalConfig,
+            AUTO_RECALL_TIMEOUT_MS,
+          );
 
           // Adaptive intent analysis (zero-LLM-cost pattern matching)
           const intent = recallMode === "adaptive" ? analyzeIntent(recallQuery) : undefined;
@@ -3059,6 +3078,9 @@ const memoryLanceDBProPlugin = {
             scopeFilter: accessibleScopes,
             source: "auto-recall",
             signal: autoRecallAbortController.signal,
+            ...(autoRecallRerankTimeoutMs !== undefined
+              ? { rerankTimeoutMs: autoRecallRerankTimeoutMs }
+              : {}),
           }), config.workspaceBoundary);
 
           if (shouldDropLateAutoRecall("post-retrieve")) return;

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -108,6 +108,8 @@ export interface RetrievalContext {
   source?: "manual" | "auto-recall" | "cli";
   /** Optional cancellation signal for callers with an outer timeout budget. */
   signal?: AbortSignal;
+  /** Optional per-call rerank timeout. Lets callers reserve time for fallback work inside an outer budget. */
+  rerankTimeoutMs?: number;
 }
 
 export interface RetrievalResult extends MemorySearchResult {
@@ -586,7 +588,7 @@ export class MemoryRetriever {
   }
 
   async retrieve(context: RetrievalContext): Promise<RetrievalResult[]> {
-    const { query, limit, scopeFilter, category, source, signal } = context;
+    const { query, limit, scopeFilter, category, source, signal, rerankTimeoutMs } = context;
     const safeLimit = clampInt(limit, 1, 20);
     this.lastDiagnostics = null;
     const diagnostics: RetrievalDiagnostics = {
@@ -657,6 +659,7 @@ export class MemoryRetriever {
           source,
           diagnostics,
           signal,
+          rerankTimeoutMs,
         );
       }
 
@@ -944,6 +947,7 @@ export class MemoryRetriever {
     source?: RetrievalContext["source"],
     diagnostics?: RetrievalDiagnostics,
     signal?: AbortSignal,
+    rerankTimeoutMs?: number,
   ): Promise<RetrievalResult[]> {
     let failureStage: RetrievalDiagnostics["failureStage"] = "hybrid.embedQuery";
     try {
@@ -1056,7 +1060,7 @@ export class MemoryRetriever {
       failureStage = "hybrid.rerank";
       if (this.config.rerank !== "none") {
         trace?.startStage("rerank", filtered.map((r) => r.entry.id));
-        reranked = await this.rerankResults(query, queryVector, rerankInput, diagnostics);
+        reranked = await this.rerankResults(query, queryVector, rerankInput, diagnostics, rerankTimeoutMs);
         trace?.endStage(reranked.map((r) => r.entry.id), reranked.map((r) => r.score));
       } else {
         reranked = filtered;
@@ -1267,6 +1271,7 @@ export class MemoryRetriever {
     queryVector: number[],
     results: RetrievalResult[],
     diagnostics?: RetrievalDiagnostics,
+    timeoutOverrideMs?: number,
   ): Promise<RetrievalResult[]> {
     if (results.length === 0) {
       return results;
@@ -1305,9 +1310,11 @@ export class MemoryRetriever {
           rerankTopN,
         );
 
+        const effectiveTimeoutMs = timeoutOverrideMs ?? this.config.rerankTimeoutMs ?? 5000;
+
         // Timeout: configurable via rerankTimeoutMs (default: 5000ms)
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), this.config.rerankTimeoutMs ?? 5000);
+        const timeout = setTimeout(() => controller.abort(), effectiveTimeoutMs);
 
         let response: Response;
         try {
@@ -1383,7 +1390,7 @@ export class MemoryRetriever {
         }
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {
-          const message = `Rerank API timed out (${this.config.rerankTimeoutMs ?? 5000}ms)`;
+          const message = `Rerank API timed out (${timeoutOverrideMs ?? this.config.rerankTimeoutMs ?? 5000}ms)`;
           recordFallback("timeout", message);
           console.warn(`${message}, falling back to cosine`);
         } else {

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -110,6 +110,8 @@ export interface RetrievalContext {
   signal?: AbortSignal;
   /** Optional per-call rerank timeout. Lets callers reserve time for fallback work inside an outer budget. */
   rerankTimeoutMs?: number;
+  /** Optional absolute deadline for remote rerank. Caps timeout after embedding/search consume caller budget. */
+  rerankDeadlineMs?: number;
 }
 
 export interface RetrievalResult extends MemorySearchResult {
@@ -588,7 +590,7 @@ export class MemoryRetriever {
   }
 
   async retrieve(context: RetrievalContext): Promise<RetrievalResult[]> {
-    const { query, limit, scopeFilter, category, source, signal, rerankTimeoutMs } = context;
+    const { query, limit, scopeFilter, category, source, signal, rerankTimeoutMs, rerankDeadlineMs } = context;
     const safeLimit = clampInt(limit, 1, 20);
     this.lastDiagnostics = null;
     const diagnostics: RetrievalDiagnostics = {
@@ -660,6 +662,7 @@ export class MemoryRetriever {
           diagnostics,
           signal,
           rerankTimeoutMs,
+          rerankDeadlineMs,
         );
       }
 
@@ -948,6 +951,7 @@ export class MemoryRetriever {
     diagnostics?: RetrievalDiagnostics,
     signal?: AbortSignal,
     rerankTimeoutMs?: number,
+    rerankDeadlineMs?: number,
   ): Promise<RetrievalResult[]> {
     let failureStage: RetrievalDiagnostics["failureStage"] = "hybrid.embedQuery";
     try {
@@ -1060,7 +1064,7 @@ export class MemoryRetriever {
       failureStage = "hybrid.rerank";
       if (this.config.rerank !== "none") {
         trace?.startStage("rerank", filtered.map((r) => r.entry.id));
-        reranked = await this.rerankResults(query, queryVector, rerankInput, diagnostics, rerankTimeoutMs);
+        reranked = await this.rerankResults(query, queryVector, rerankInput, diagnostics, rerankTimeoutMs, rerankDeadlineMs);
         trace?.endStage(reranked.map((r) => r.entry.id), reranked.map((r) => r.score));
       } else {
         reranked = filtered;
@@ -1272,6 +1276,7 @@ export class MemoryRetriever {
     results: RetrievalResult[],
     diagnostics?: RetrievalDiagnostics,
     timeoutOverrideMs?: number,
+    deadlineMs?: number,
   ): Promise<RetrievalResult[]> {
     if (results.length === 0) {
       return results;
@@ -1291,7 +1296,14 @@ export class MemoryRetriever {
 
     if (this.config.rerank === "cross-encoder" && hasApiKey) {
       try {
+        const remainingDeadlineMs = deadlineMs !== undefined
+          ? Math.floor(deadlineMs - Date.now())
+          : undefined;
         if (timeoutOverrideMs !== undefined && timeoutOverrideMs <= 0) {
+          recordFallback("timeout", "Rerank API skipped because caller timeout budget is exhausted");
+          throw new Error("skip-remote-rerank-timeout-budget");
+        }
+        if (remainingDeadlineMs !== undefined && remainingDeadlineMs < 100) {
           recordFallback("timeout", "Rerank API skipped because caller timeout budget is exhausted");
           throw new Error("skip-remote-rerank-timeout-budget");
         }
@@ -1315,7 +1327,10 @@ export class MemoryRetriever {
           rerankTopN,
         );
 
-        const effectiveTimeoutMs = timeoutOverrideMs ?? this.config.rerankTimeoutMs ?? 5000;
+        const configuredTimeoutMs = timeoutOverrideMs ?? this.config.rerankTimeoutMs ?? 5000;
+        const effectiveTimeoutMs = remainingDeadlineMs !== undefined
+          ? Math.min(configuredTimeoutMs, remainingDeadlineMs)
+          : configuredTimeoutMs;
 
         // Timeout: configurable via rerankTimeoutMs (default: 5000ms)
         const controller = new AbortController();

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -1291,6 +1291,11 @@ export class MemoryRetriever {
 
     if (this.config.rerank === "cross-encoder" && hasApiKey) {
       try {
+        if (timeoutOverrideMs !== undefined && timeoutOverrideMs <= 0) {
+          recordFallback("timeout", "Rerank API skipped because caller timeout budget is exhausted");
+          throw new Error("skip-remote-rerank-timeout-budget");
+        }
+
         const model = this.config.rerankModel || "jina-reranker-v3";
         const endpoint =
           this.config.rerankEndpoint || "https://api.jina.ai/v1/rerank";
@@ -1389,7 +1394,9 @@ export class MemoryRetriever {
           );
         }
       } catch (error) {
-        if (error instanceof Error && error.name === "AbortError") {
+        if (error instanceof Error && error.message === "skip-remote-rerank-timeout-budget") {
+          // Caller supplied a zero/negative per-call timeout to reserve the outer budget.
+        } else if (error instanceof Error && error.name === "AbortError") {
           const message = `Rerank API timed out (${timeoutOverrideMs ?? this.config.rerankTimeoutMs ?? 5000}ms)`;
           recordFallback("timeout", message);
           console.warn(`${message}, falling back to cosine`);

--- a/test/auto-recall-timeout.test.mjs
+++ b/test/auto-recall-timeout.test.mjs
@@ -360,6 +360,64 @@ describe("auto-recall timeout", () => {
     assert.equal(capturedContext?.rerankTimeoutMs, 2500);
   });
 
+  it("skips remote rerank timeout budget for very small auto-recall budgets", async () => {
+    let capturedContext;
+
+    activeCreateRetriever = function mockCreateRetriever() {
+      return {
+        async retrieve(context) {
+          capturedContext = context;
+          return [];
+        },
+        getConfig() {
+          return {
+            mode: "hybrid",
+            rerank: "cross-encoder",
+            rerankApiKey: "rerank-key",
+            rerankProvider: "jina",
+          };
+        },
+        setAccessTracker() {},
+        setStatsCollector() {},
+      };
+    };
+    activeCreateEmbedder = function mockCreateEmbedder() {
+      return {
+        async embedQuery() {
+          return new Float32Array(384).fill(0);
+        },
+        async embedPassage() {
+          return new Float32Array(384).fill(0);
+        },
+      };
+    };
+
+    const harness = createPluginApiHarness({
+      resolveRoot: workspaceDir,
+      pluginConfig: {
+        dbPath: path.join(workspaceDir, "db"),
+        embedding: { apiKey: "test-api-key" },
+        smartExtraction: false,
+        autoCapture: false,
+        autoRecall: true,
+        autoRecallMinLength: 1,
+        autoRecallTimeoutMs: 1,
+        selfImprovement: { enabled: false, beforeResetNote: false, ensureLearningFiles: false },
+      },
+    });
+
+    memoryLanceDBProPlugin.register(harness.api);
+
+    const autoRecallHook = getAutoRecallHook(harness.eventHandlers);
+    await autoRecallHook(
+      { prompt: "Please recall what I mentioned before about this task." },
+      { sessionId: "auto-rerank-tiny-budget", sessionKey: "agent:main:session:auto-rerank-tiny-budget", agentId: "main" },
+    );
+
+    assert.equal(capturedContext?.source, "auto-recall");
+    assert.equal(capturedContext?.rerankTimeoutMs, 0);
+  });
+
   it("returns context before auto-recall metadata patch settles", async () => {
     const logs = { info: [], warn: [], debug: [] };
     const patchResolvers = [];

--- a/test/auto-recall-timeout.test.mjs
+++ b/test/auto-recall-timeout.test.mjs
@@ -351,6 +351,7 @@ describe("auto-recall timeout", () => {
     memoryLanceDBProPlugin.register(harness.api);
 
     const autoRecallHook = getAutoRecallHook(harness.eventHandlers);
+    const beforeHookMs = Date.now();
     await autoRecallHook(
       { prompt: "Please recall what I mentioned before about this task." },
       { sessionId: "auto-rerank-budget", sessionKey: "agent:main:session:auto-rerank-budget", agentId: "main" },
@@ -358,6 +359,9 @@ describe("auto-recall timeout", () => {
 
     assert.equal(capturedContext?.source, "auto-recall");
     assert.equal(capturedContext?.rerankTimeoutMs, 2500);
+    assert.equal(typeof capturedContext?.rerankDeadlineMs, "number");
+    assert.ok(capturedContext.rerankDeadlineMs > beforeHookMs);
+    assert.ok(capturedContext.rerankDeadlineMs <= beforeHookMs + 5100);
   });
 
   it("skips remote rerank timeout budget for very small auto-recall budgets", async () => {

--- a/test/auto-recall-timeout.test.mjs
+++ b/test/auto-recall-timeout.test.mjs
@@ -302,6 +302,64 @@ describe("auto-recall timeout", () => {
     );
   });
 
+  it("uses a shorter default rerank timeout inside the auto-recall budget", async () => {
+    let capturedContext;
+
+    activeCreateRetriever = function mockCreateRetriever() {
+      return {
+        async retrieve(context) {
+          capturedContext = context;
+          return [];
+        },
+        getConfig() {
+          return {
+            mode: "hybrid",
+            rerank: "cross-encoder",
+            rerankApiKey: "rerank-key",
+            rerankProvider: "jina",
+          };
+        },
+        setAccessTracker() {},
+        setStatsCollector() {},
+      };
+    };
+    activeCreateEmbedder = function mockCreateEmbedder() {
+      return {
+        async embedQuery() {
+          return new Float32Array(384).fill(0);
+        },
+        async embedPassage() {
+          return new Float32Array(384).fill(0);
+        },
+      };
+    };
+
+    const harness = createPluginApiHarness({
+      resolveRoot: workspaceDir,
+      pluginConfig: {
+        dbPath: path.join(workspaceDir, "db"),
+        embedding: { apiKey: "test-api-key" },
+        smartExtraction: false,
+        autoCapture: false,
+        autoRecall: true,
+        autoRecallMinLength: 1,
+        autoRecallTimeoutMs: 5000,
+        selfImprovement: { enabled: false, beforeResetNote: false, ensureLearningFiles: false },
+      },
+    });
+
+    memoryLanceDBProPlugin.register(harness.api);
+
+    const autoRecallHook = getAutoRecallHook(harness.eventHandlers);
+    await autoRecallHook(
+      { prompt: "Please recall what I mentioned before about this task." },
+      { sessionId: "auto-rerank-budget", sessionKey: "agent:main:session:auto-rerank-budget", agentId: "main" },
+    );
+
+    assert.equal(capturedContext?.source, "auto-recall");
+    assert.equal(capturedContext?.rerankTimeoutMs, 2500);
+  });
+
   it("returns context before auto-recall metadata patch settles", async () => {
     const logs = { info: [], warn: [], debug: [] };
     const patchResolvers = [];

--- a/test/retriever-rerank-regression.mjs
+++ b/test/retriever-rerank-regression.mjs
@@ -264,6 +264,39 @@ await runExhaustedRerankBudgetSkipsRemoteScenario();
 
 console.log("OK: exhausted rerank budget skip test passed");
 
+async function runExpiredRerankDeadlineSkipsRemoteScenario() {
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    throw new Error("remote rerank should be skipped");
+  };
+
+  try {
+    const retriever = createRetriever(fakeStore, fakeEmbedder, retrieverConfig);
+    const results = await retriever.retrieve({
+      query: "TESTMEM-20260306-092541",
+      limit: 5,
+      scopeFilter: ["global"],
+      rerankTimeoutMs: 2500,
+      rerankDeadlineMs: Date.now() - 1,
+    });
+
+    assert.ok(Array.isArray(results), "expired rerank deadline should fall back to local scoring");
+    assert.equal(fetchCalls, 0, "remote rerank fetch should not run after the caller deadline is exhausted");
+
+    const diagnostics = retriever.getLastDiagnostics();
+    assert.equal(diagnostics?.failureStage, undefined, "expired rerank deadline should not fail retrieval");
+    assert.equal(diagnostics?.rerankFallback?.reason, "timeout");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+await runExpiredRerankDeadlineSkipsRemoteScenario();
+
+console.log("OK: expired rerank deadline skip test passed");
+
 const lexicalEntry = {
   id: "lexical-regression-1",
   text: "用户测试饮料偏好是乌龙茶，不喜欢美式咖啡。",

--- a/test/retriever-rerank-regression.mjs
+++ b/test/retriever-rerank-regression.mjs
@@ -232,6 +232,38 @@ await runRerankFallbackDiagnosticsScenario();
 
 console.log("OK: rerank fallback diagnostics test passed");
 
+async function runExhaustedRerankBudgetSkipsRemoteScenario() {
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    throw new Error("remote rerank should be skipped");
+  };
+
+  try {
+    const retriever = createRetriever(fakeStore, fakeEmbedder, retrieverConfig);
+    const results = await retriever.retrieve({
+      query: "TESTMEM-20260306-092541",
+      limit: 5,
+      scopeFilter: ["global"],
+      rerankTimeoutMs: 0,
+    });
+
+    assert.ok(Array.isArray(results), "rerank fallback should resolve with a result array");
+    assert.equal(fetchCalls, 0, "remote rerank fetch should not run when per-call budget is exhausted");
+
+    const diagnostics = retriever.getLastDiagnostics();
+    assert.equal(diagnostics?.failureStage, undefined, "exhausted rerank budget should not fail retrieval");
+    assert.equal(diagnostics?.rerankFallback?.reason, "timeout");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+await runExhaustedRerankBudgetSkipsRemoteScenario();
+
+console.log("OK: exhausted rerank budget skip test passed");
+
 const lexicalEntry = {
   id: "lexical-regression-1",
   text: "用户测试饮料偏好是乌龙茶，不喜欢美式咖啡。",


### PR DESCRIPTION
## Summary
- pass a per-call rerank timeout through retrieval context
- default auto-recall reranking to a shorter timeout inside the recall budget
- preserve explicit user rerank timeout configuration

Fixes #882

## Verification
- node --test test/auto-recall-timeout.test.mjs
- node test/retriever-rerank-regression.mjs
- npm run build