### PR TITLE
feat: add retrieval neighbor enrichment

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18,7 +18,7 @@ const isCliMode = () => process.env.OPENCLAW_CLI === "1";
 // Import core components
 import { MemoryStore, normalizeStoragePath } from "./src/store.js";
 import { createEmbedder, getEffectiveVectorDimensions, } from "./src/embedder.js";
-import { createRetriever, DEFAULT_RETRIEVAL_CONFIG } from "./src/retriever.js";
+import { createRetriever, normalizeRetrievalConfig, } from "./src/retriever.js";
 import { createScopeManager, resolveScopeFilter, isSystemBypassId, parseAgentIdFromSessionKey } from "./src/scopes.js";
 import { createMigrator } from "./src/migrate.js";
 import { registerAllMemoryTools } from "./src/tools.js";
@@ -224,7 +224,7 @@ function getAutoRecallRerankTimeoutMs(config, retrievalConfig, autoRecallTimeout
         return halfBudget;
     return clampInt(halfBudget, 500, 2_500);
 }
-export function buildAutoRecallRerankCostWarning(config, retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...(config.retrieval || {}) }) {
+export function buildAutoRecallRerankCostWarning(config, retrievalConfig = normalizeRetrievalConfig(config.retrieval)) {
     if (config.autoRecall !== true || config.recallMode === "off")
         return null;
     if (retrievalConfig.mode === "vector")
@@ -1687,7 +1687,7 @@ function _initPluginState(api) {
         ...DEFAULT_TIER_CONFIG,
         ...(config.tier || {}),
     });
-    const retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...config.retrieval };
+    const retrievalConfig = normalizeRetrievalConfig(config.retrieval);
     if (retrievalConfig.rerank === "cross-encoder" && retrievalConfig.rerankApiKey) {
         retrievalConfig.rerankApiKey = resolveSecretCredential(api, retrievalConfig.rerankApiKey, "retrieval.rerankApiKey");
     }
@@ -2495,7 +2495,13 @@ const memoryLanceDBProPlugin = {
                             : intent?.depth === "full"
                                 ? (r.entry.text) // full text for deep queries
                                 : (metaObj.l0_abstract || r.entry.text); // L0/L1 default
-                        const summary = sanitizeForContext(contentText).slice(0, effectivePerItemMaxChars);
+                        const neighborContext = r.neighbors && r.neighbors.length > 0
+                            ? ` Related: ${r.neighbors
+                                .map((neighbor) => sanitizeForContext(neighbor.entry.text).slice(0, 80))
+                                .filter(Boolean)
+                                .join(" | ")}`
+                            : "";
+                        const summary = sanitizeForContext(`${contentText}${neighborContext}`).slice(0, effectivePerItemMaxChars);
                         return {
                             id: r.entry.id,
                             prefix: (() => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2449,24 +2449,28 @@ const memoryLanceDBProPlugin = {
                     }
                     let stateFilteredCount = 0;
                     let suppressedFilteredCount = 0;
-                    const governanceEligible = finalResults.filter((r) => {
+                    const isAutoRecallGovernanceEligible = (r, countFiltered) => {
                         const meta = parseSmartMetadata(r.entry.metadata, r.entry);
                         if (meta.state !== "confirmed") {
-                            stateFilteredCount++;
-                            api.logger.debug(`memory-lancedb-pro: governance: filtered id=${r.entry.id} reason=state(${meta.state}) score=${r.score?.toFixed(3)} text=${r.entry.text.slice(0, 50)}`);
+                            if (countFiltered)
+                                stateFilteredCount++;
+                            api.logger.debug?.(`memory-lancedb-pro: governance: filtered id=${r.entry.id} reason=state(${meta.state}) score=${r.score?.toFixed(3)} text=${r.entry.text.slice(0, 50)}`);
                             return false;
                         }
                         if (meta.memory_layer === "archive" || meta.memory_layer === "reflection") {
-                            stateFilteredCount++;
-                            api.logger.debug(`memory-lancedb-pro: governance: filtered id=${r.entry.id} reason=layer(${meta.memory_layer}) score=${r.score?.toFixed(3)} text=${r.entry.text.slice(0, 50)}`);
+                            if (countFiltered)
+                                stateFilteredCount++;
+                            api.logger.debug?.(`memory-lancedb-pro: governance: filtered id=${r.entry.id} reason=layer(${meta.memory_layer}) score=${r.score?.toFixed(3)} text=${r.entry.text.slice(0, 50)}`);
                             return false;
                         }
                         if (isTier1Suppressed(meta, Date.now())) {
-                            suppressedFilteredCount++;
+                            if (countFiltered)
+                                suppressedFilteredCount++;
                             return false;
                         }
                         return true;
-                    });
+                    };
+                    const governanceEligible = finalResults.filter((r) => isAutoRecallGovernanceEligible(r, true));
                     if (governanceEligible.length === 0) {
                         api.logger.info?.(`memory-lancedb-pro: auto-recall skipped after governance filters (hits=${results.length}, dedupFiltered=${dedupFilteredCount}, stateFiltered=${stateFilteredCount}, suppressedFiltered=${suppressedFilteredCount})`);
                         return;
@@ -2484,6 +2488,7 @@ const memoryLanceDBProPlugin = {
                             case "full": return Math.min(autoRecallPerItemMaxChars * 3, 1000);
                         }
                     })();
+                    const renderedNeighborIds = new Set(governanceEligible.map((r) => r.entry.id));
                     const preBudgetCandidates = governanceEligible.map((r) => {
                         const metaObj = parseSmartMetadata(r.entry.metadata, r.entry);
                         const displayCategory = metaObj.memory_category || r.entry.category;
@@ -2495,8 +2500,20 @@ const memoryLanceDBProPlugin = {
                             : intent?.depth === "full"
                                 ? (r.entry.text) // full text for deep queries
                                 : (metaObj.l0_abstract || r.entry.text); // L0/L1 default
-                        const neighborContext = r.neighbors && r.neighbors.length > 0
-                            ? ` Related: ${r.neighbors
+                        const eligibleNeighbors = r.neighbors && r.neighbors.length > 0
+                            ? filterUserMdExclusiveRecallResults(r.neighbors.filter((neighbor) => {
+                                if (renderedNeighborIds.has(neighbor.entry.id))
+                                    return false;
+                                return isAutoRecallGovernanceEligible(neighbor, false);
+                            }), config.workspaceBoundary).filter((neighbor) => {
+                                if (renderedNeighborIds.has(neighbor.entry.id))
+                                    return false;
+                                renderedNeighborIds.add(neighbor.entry.id);
+                                return true;
+                            })
+                            : [];
+                        const neighborContext = eligibleNeighbors.length > 0
+                            ? ` Related: ${eligibleNeighbors
                                 .map((neighbor) => sanitizeForContext(neighbor.entry.text).slice(0, 80))
                                 .filter(Boolean)
                                 .join(" | ")}`

--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -37,12 +37,16 @@ export const DEFAULT_RETRIEVAL_CONFIG = {
     },
 };
 export function normalizeRetrievalConfig(config) {
+    const neighborEnrichment = {
+        ...DEFAULT_RETRIEVAL_CONFIG.neighborEnrichment,
+        ...(config?.neighborEnrichment || {}),
+    };
     return {
         ...DEFAULT_RETRIEVAL_CONFIG,
         ...config,
         neighborEnrichment: {
-            ...DEFAULT_RETRIEVAL_CONFIG.neighborEnrichment,
-            ...(config?.neighborEnrichment || {}),
+            enabled: Boolean(neighborEnrichment.enabled),
+            maxPerResult: clampInt(neighborEnrichment.maxPerResult, 1, 5),
         },
     };
 }
@@ -808,6 +812,7 @@ export class MemoryRetriever {
             return results;
         const maxPerResult = clampInt(config.maxPerResult, 1, 5);
         const primaryIds = new Set(results.map((result) => result.entry.id));
+        const neighborCandidateLimit = Math.min(primaryIds.size + maxPerResult + Math.max(10, maxPerResult * 4), 50);
         return await Promise.all(results.map(async (result) => {
             const resultScope = result.entry.scope || "global";
             if (scopeFilter && scopeFilter.length > 0 && !scopeFilter.includes(resultScope)) {
@@ -815,7 +820,7 @@ export class MemoryRetriever {
             }
             let candidates;
             try {
-                candidates = await this.store.bm25Search(result.entry.text, Math.min(maxPerResult + primaryIds.size + 4, 25), [resultScope], { excludeInactive: true });
+                candidates = await this.store.bm25Search(result.entry.text, neighborCandidateLimit, [resultScope], { excludeInactive: true });
             }
             catch (error) {
                 console.warn(`[Retriever] neighbor enrichment BM25 lookup failed for ${result.entry.id}: ${formatErrorMessage(error)}`);

--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -31,7 +31,21 @@ export const DEFAULT_RETRIEVAL_CONFIG = {
     reinforcementFactor: 0.5,
     maxHalfLifeMultiplier: 3,
     tagPrefixes: ["proj", "env", "team", "scope"],
+    neighborEnrichment: {
+        enabled: false,
+        maxPerResult: 2,
+    },
 };
+export function normalizeRetrievalConfig(config) {
+    return {
+        ...DEFAULT_RETRIEVAL_CONFIG,
+        ...config,
+        neighborEnrichment: {
+            ...DEFAULT_RETRIEVAL_CONFIG.neighborEnrichment,
+            ...(config?.neighborEnrichment || {}),
+        },
+    };
+}
 // ============================================================================
 // Utility Functions
 // ============================================================================
@@ -307,7 +321,6 @@ function cosineSimilarity(a, b) {
 export class MemoryRetriever {
     store;
     embedder;
-    config;
     decayEngine;
     accessTracker = null;
     lastDiagnostics = null;
@@ -316,9 +329,10 @@ export class MemoryRetriever {
     constructor(store, embedder, config = DEFAULT_RETRIEVAL_CONFIG, decayEngine = null) {
         this.store = store;
         this.embedder = embedder;
-        this.config = config;
         this.decayEngine = decayEngine;
+        this.config = normalizeRetrievalConfig(config);
     }
+    config;
     setAccessTracker(tracker) {
         this.accessTracker = tracker;
     }
@@ -757,7 +771,7 @@ export class MemoryRetriever {
             trace?.endStage(finalResults.map((r) => r.entry.id), finalResults.map((r) => r.score));
             if (diagnostics)
                 diagnostics.stageCounts.afterDiversity = deduplicated.length;
-            return finalResults;
+            return await this.enrichHybridNeighbors(finalResults, scopeFilter, category);
         }
         catch (error) {
             if (diagnostics) {
@@ -786,6 +800,55 @@ export class MemoryRetriever {
         return filtered.map((result, index) => ({
             ...result,
             rank: index + 1,
+        }));
+    }
+    async enrichHybridNeighbors(results, scopeFilter, category) {
+        const config = this.config.neighborEnrichment;
+        if (!config.enabled || results.length === 0)
+            return results;
+        const maxPerResult = clampInt(config.maxPerResult, 1, 5);
+        const primaryIds = new Set(results.map((result) => result.entry.id));
+        return await Promise.all(results.map(async (result) => {
+            const resultScope = result.entry.scope || "global";
+            if (scopeFilter && scopeFilter.length > 0 && !scopeFilter.includes(resultScope)) {
+                return result;
+            }
+            let candidates;
+            try {
+                candidates = await this.store.bm25Search(result.entry.text, Math.min(maxPerResult + primaryIds.size + 4, 25), [resultScope], { excludeInactive: true });
+            }
+            catch (error) {
+                console.warn(`[Retriever] neighbor enrichment BM25 lookup failed for ${result.entry.id}: ${formatErrorMessage(error)}`);
+                return result;
+            }
+            const neighbors = [];
+            for (const candidate of candidates) {
+                if (candidate.entry.id === result.entry.id)
+                    continue;
+                if (primaryIds.has(candidate.entry.id))
+                    continue;
+                if ((candidate.entry.scope || "global") !== resultScope)
+                    continue;
+                if (category && candidate.entry.category !== category)
+                    continue;
+                const metadata = parseSmartMetadata(candidate.entry.metadata, candidate.entry);
+                if (isMemoryExpired(metadata))
+                    continue;
+                if (this.config.filterNoise && filterNoise([candidate], (r) => r.entry.text).length === 0)
+                    continue;
+                neighbors.push({
+                    ...candidate,
+                    sources: {
+                        bm25: {
+                            score: candidate.score,
+                            rank: neighbors.length + 1,
+                        },
+                    },
+                });
+                if (neighbors.length >= maxPerResult)
+                    break;
+            }
+            return neighbors.length > 0 ? { ...result, neighbors } : result;
         }));
     }
     buildBM25Query(query, source) {
@@ -1293,11 +1356,21 @@ export class MemoryRetriever {
     }
     // Update configuration
     updateConfig(newConfig) {
-        this.config = { ...this.config, ...newConfig };
+        this.config = normalizeRetrievalConfig({
+            ...this.config,
+            ...newConfig,
+            neighborEnrichment: {
+                ...this.config.neighborEnrichment,
+                ...(newConfig.neighborEnrichment || {}),
+            },
+        });
     }
     // Get current configuration
     getConfig() {
-        return { ...this.config };
+        return {
+            ...this.config,
+            neighborEnrichment: { ...this.config.neighborEnrichment },
+        };
     }
     getLastDiagnostics() {
         if (!this.lastDiagnostics)
@@ -1358,6 +1431,6 @@ export class MemoryRetriever {
     }
 }
 export function createRetriever(store, embedder, config, options) {
-    const fullConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...config };
+    const fullConfig = normalizeRetrievalConfig(config);
     return new MemoryRetriever(store, embedder, fullConfig, options?.decayEngine ?? null);
 }

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -70,6 +70,20 @@ function sanitizeMemoryForSerialization(results) {
         importance: r.entry.importance,
         score: r.score,
         sources: r.sources,
+        ...(r.neighbors && r.neighbors.length > 0
+            ? {
+                neighbors: r.neighbors.map((neighbor) => ({
+                    id: neighbor.entry.id,
+                    text: neighbor.entry.text,
+                    category: getDisplayCategoryTag(neighbor.entry),
+                    rawCategory: neighbor.entry.category,
+                    scope: neighbor.entry.scope,
+                    importance: neighbor.entry.importance,
+                    score: neighbor.score,
+                    sources: neighbor.sources,
+                })),
+            }
+            : {}),
     }));
 }
 function isUnresolvedReflectionItem(entry) {
@@ -656,7 +670,12 @@ function createMemoryRecallTool(runtimeContext, options) {
                     const rendered = includeFullText
                         ? inline
                         : truncateText(inline, safeCharsPerItem);
-                    return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${rendered}`;
+                    const neighborText = r.neighbors && r.neighbors.length > 0
+                        ? `\n   Neighbors: ${r.neighbors
+                            .map((neighbor) => `[${neighbor.entry.id}] ${truncateText(normalizeInlineText(neighbor.entry.text), 120)}`)
+                            .join("; ")}`
+                        : "";
+                    return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${rendered}${neighborText}`;
                 })
                     .join("\n");
                 const serializedMemories = sanitizeMemoryForSerialization(results);
@@ -1637,7 +1656,10 @@ export function registerMemoryDebugTool(api, context) {
                         if (r.sources.reranked)
                             sources.push("reranked");
                         const categoryTag = getDisplayCategoryTag(r.entry);
-                        return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${r.entry.text.slice(0, 120)}${r.entry.text.length > 120 ? "..." : ""} (${(r.score * 100).toFixed(1)}%${sources.length > 0 ? `, ${sources.join("+")}` : ""})`;
+                        const neighborText = r.neighbors && r.neighbors.length > 0
+                            ? ` neighbors=${r.neighbors.map((neighbor) => neighbor.entry.id).join(",")}`
+                            : "";
+                        return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${r.entry.text.slice(0, 120)}${r.entry.text.length > 120 ? "..." : ""} (${(r.score * 100).toFixed(1)}%${sources.length > 0 ? `, ${sources.join("+")}` : ""}${neighborText})`;
                     });
                     const text = [...traceLines, ``, `Results (${results.length}):`, ...resultLines].join("\n");
                     return {
@@ -2210,6 +2232,8 @@ export function registerMemoryExplainRankTool(api, context) {
                         sourceBreakdown.push(`bm25=${r.sources.bm25.score.toFixed(3)}`);
                     if (r.sources.reranked)
                         sourceBreakdown.push(`rerank=${r.sources.reranked.score.toFixed(3)}`);
+                    if (r.neighbors && r.neighbors.length > 0)
+                        sourceBreakdown.push(`neighbors=${r.neighbors.length}`);
                     return [
                         `${idx + 1}. [${r.entry.id}] score=${r.score.toFixed(3)} ${sourceBreakdown.join(" ")}`.trim(),
                         `   state=${meta.state} layer=${meta.memory_layer} source=${meta.source} tier=${meta.tier}`,

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -61,7 +61,7 @@ function deriveManualMemoryLayer(category) {
     }
     return "working";
 }
-function sanitizeMemoryForSerialization(results) {
+function sanitizeMemoryForSerialization(results, options = {}) {
     return results.map((r) => ({
         id: r.entry.id,
         text: r.entry.text,
@@ -71,7 +71,7 @@ function sanitizeMemoryForSerialization(results) {
         importance: r.entry.importance,
         score: r.score,
         sources: r.sources,
-        ...(r.neighbors && r.neighbors.length > 0
+        ...(options.includeNeighbors && r.neighbors && r.neighbors.length > 0
             ? {
                 neighbors: r.neighbors.map((neighbor) => ({
                     id: neighbor.entry.id,
@@ -703,7 +703,7 @@ function createMemoryRecallTool(runtimeContext, options) {
                     return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${rendered}`;
                 })
                     .join("\n");
-                const serializedMemories = sanitizeMemoryForSerialization(results);
+                const serializedMemories = sanitizeMemoryForSerialization(results, { includeNeighbors: true });
                 if (includeFullText) {
                     for (let i = 0; i < results.length; i++) {
                         const metadata = parseSmartMetadata(results[i].entry.metadata, results[i].entry);

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -667,15 +667,15 @@ function createMemoryRecallTool(runtimeContext, options) {
                         ? (metadata.l2_content || metadata.l1_overview || r.entry.text)
                         : (metadata.l0_abstract || r.entry.text);
                     const inline = normalizeInlineText(base);
-                    const rendered = includeFullText
-                        ? inline
-                        : truncateText(inline, safeCharsPerItem);
                     const neighborText = r.neighbors && r.neighbors.length > 0
-                        ? `\n   Neighbors: ${r.neighbors
+                        ? ` Neighbors: ${r.neighbors
                             .map((neighbor) => `[${neighbor.entry.id}] ${truncateText(normalizeInlineText(neighbor.entry.text), 120)}`)
                             .join("; ")}`
                         : "";
-                    return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${rendered}${neighborText}`;
+                    const rendered = includeFullText
+                        ? `${inline}${neighborText}`
+                        : truncateText(`${inline}${neighborText}`, safeCharsPerItem);
+                    return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${rendered}`;
                 })
                     .join("\n");
                 const serializedMemories = sanitizeMemoryForSerialization(results);

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -15,6 +15,7 @@ import { matchesMemoryCategoryFilter, resolveToolMemoryCategory, TEMPORAL_VERSIO
 import { appendSelfImprovementEntry, countSelfImprovementEntries, DEFAULT_SELF_IMPROVEMENT_MAX_ENTRIES, ensureSelfImprovementLearningFiles, } from "./self-improvement-files.js";
 import { getDisplayCategoryTag, parseReflectionMetadata } from "./reflection-metadata.js";
 import { filterUserMdExclusiveRecallResults, isUserMdExclusiveMemory, } from "./workspace-boundary.js";
+import { isSuppressed as isTier1Suppressed } from "./auto-recall-tier1.js";
 // ============================================================================
 // Types
 // ============================================================================
@@ -85,6 +86,29 @@ function sanitizeMemoryForSerialization(results) {
             }
             : {}),
     }));
+}
+function isManualRecallNeighborGovernanceEligible(result, nowMs) {
+    const meta = parseSmartMetadata(result.entry.metadata, result.entry);
+    if (meta.state !== "confirmed")
+        return false;
+    if (meta.memory_layer === "archive" || meta.memory_layer === "reflection")
+        return false;
+    if (isTier1Suppressed(meta, nowMs))
+        return false;
+    return true;
+}
+function filterManualRecallResultNeighbors(results, workspaceBoundary, nowMs = Date.now()) {
+    return results.map((result) => {
+        if (!result.neighbors || result.neighbors.length === 0)
+            return result;
+        const neighbors = filterUserMdExclusiveRecallResults(result.neighbors.filter((neighbor) => isManualRecallNeighborGovernanceEligible(neighbor, nowMs)), workspaceBoundary);
+        if (neighbors.length === result.neighbors.length)
+            return result;
+        if (neighbors.length > 0)
+            return { ...result, neighbors };
+        const { neighbors: _neighbors, ...withoutNeighbors } = result;
+        return withoutNeighbors;
+    });
 }
 function isUnresolvedReflectionItem(entry) {
     const metadata = parseReflectionMetadata(entry.metadata);
@@ -623,13 +647,14 @@ function createMemoryRecallTool(runtimeContext, options) {
                 const resolvedScopes = resolveReadableToolScopeFilter(runtimeContext.scopeManager, agentId, scope);
                 const { scopeFilter } = resolvedScopes;
                 const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
-                const results = filterUserMdExclusiveRecallResults(await retrieveWithRetry(runtimeContext.retriever, {
+                const retrievedResults = await retrieveWithRetry(runtimeContext.retriever, {
                     query,
                     limit: safeLimit,
                     scopeFilter,
                     category,
                     source: "manual",
-                }, () => runtimeContext.store.count()), runtimeContext.workspaceBoundary);
+                }, () => runtimeContext.store.count());
+                const results = filterManualRecallResultNeighbors(filterUserMdExclusiveRecallResults(retrievedResults, runtimeContext.workspaceBoundary), runtimeContext.workspaceBoundary);
                 if (results.length === 0) {
                     return {
                         content: [{ type: "text", text: [ignoredScopeNotice, "No relevant memories found."].filter(Boolean).join("\n") }],

--- a/index.ts
+++ b/index.ts
@@ -3237,24 +3237,28 @@ const memoryLanceDBProPlugin = {
 
           let stateFilteredCount = 0;
           let suppressedFilteredCount = 0;
-          const governanceEligible = finalResults.filter((r) => {
+          const isAutoRecallGovernanceEligible = (
+            r: { entry: { id: string; text: string; metadata?: string }; score?: number },
+            countFiltered: boolean,
+          ) => {
             const meta = parseSmartMetadata(r.entry.metadata, r.entry);
             if (meta.state !== "confirmed") {
-              stateFilteredCount++;
-              api.logger.debug(`memory-lancedb-pro: governance: filtered id=${r.entry.id} reason=state(${meta.state}) score=${r.score?.toFixed(3)} text=${r.entry.text.slice(0, 50)}`);
+              if (countFiltered) stateFilteredCount++;
+              api.logger.debug?.(`memory-lancedb-pro: governance: filtered id=${r.entry.id} reason=state(${meta.state}) score=${r.score?.toFixed(3)} text=${r.entry.text.slice(0, 50)}`);
               return false;
             }
             if (meta.memory_layer === "archive" || meta.memory_layer === "reflection") {
-              stateFilteredCount++;
-              api.logger.debug(`memory-lancedb-pro: governance: filtered id=${r.entry.id} reason=layer(${meta.memory_layer}) score=${r.score?.toFixed(3)} text=${r.entry.text.slice(0, 50)}`);
+              if (countFiltered) stateFilteredCount++;
+              api.logger.debug?.(`memory-lancedb-pro: governance: filtered id=${r.entry.id} reason=layer(${meta.memory_layer}) score=${r.score?.toFixed(3)} text=${r.entry.text.slice(0, 50)}`);
               return false;
             }
             if (isTier1Suppressed(meta, Date.now())) {
-              suppressedFilteredCount++;
+              if (countFiltered) suppressedFilteredCount++;
               return false;
             }
             return true;
-          });
+          };
+          const governanceEligible = finalResults.filter((r) => isAutoRecallGovernanceEligible(r, true));
 
           if (governanceEligible.length === 0) {
             api.logger.info?.(
@@ -3275,6 +3279,7 @@ const memoryLanceDBProPlugin = {
             }
           })();
 
+          const renderedNeighborIds = new Set(governanceEligible.map((r) => r.entry.id));
           const preBudgetCandidates = governanceEligible.map((r) => {
             const metaObj = parseSmartMetadata(r.entry.metadata, r.entry);
             const displayCategory = metaObj.memory_category || r.entry.category;
@@ -3286,8 +3291,21 @@ const memoryLanceDBProPlugin = {
               : intent?.depth === "full"
                 ? (r.entry.text) // full text for deep queries
                 : (metaObj.l0_abstract || r.entry.text); // L0/L1 default
-            const neighborContext = r.neighbors && r.neighbors.length > 0
-              ? ` Related: ${r.neighbors
+            const eligibleNeighbors = r.neighbors && r.neighbors.length > 0
+              ? filterUserMdExclusiveRecallResults(
+                r.neighbors.filter((neighbor) => {
+                  if (renderedNeighborIds.has(neighbor.entry.id)) return false;
+                  return isAutoRecallGovernanceEligible(neighbor, false);
+                }),
+                config.workspaceBoundary,
+              ).filter((neighbor) => {
+                if (renderedNeighborIds.has(neighbor.entry.id)) return false;
+                renderedNeighborIds.add(neighbor.entry.id);
+                return true;
+              })
+              : [];
+            const neighborContext = eligibleNeighbors.length > 0
+              ? ` Related: ${eligibleNeighbors
                 .map((neighbor) => sanitizeForContext(neighbor.entry.text).slice(0, 80))
                 .filter(Boolean)
                 .join(" | ")}`

--- a/index.ts
+++ b/index.ts
@@ -26,7 +26,12 @@ import {
   getEffectiveVectorDimensions,
 } from "./src/embedder.js";
 import type { ChunkerAstConfig, CodeChunkLanguage } from "./src/chunker.js";
-import { createRetriever, DEFAULT_RETRIEVAL_CONFIG, type RetrievalConfig } from "./src/retriever.js";
+import {
+  createRetriever,
+  normalizeRetrievalConfig,
+  type RetrievalConfig,
+  type RetrievalConfigInput,
+} from "./src/retriever.js";
 import { createScopeManager, resolveScopeFilter, isSystemBypassId, parseAgentIdFromSessionKey } from "./src/scopes.js";
 import { createMigrator } from "./src/migrate.js";
 import { registerAllMemoryTools } from "./src/tools.js";
@@ -180,6 +185,10 @@ interface PluginConfig {
     timeDecayHalfLifeDays?: number;
     reinforcementFactor?: number;
     maxHalfLifeMultiplier?: number;
+    neighborEnrichment?: {
+      enabled?: boolean;
+      maxPerResult?: number;
+    };
     /** Disable LanceDB native vector search and rank scanned rows with JS cosine. */
     disableNativeCosine?: boolean;
   };
@@ -517,7 +526,9 @@ function getAutoRecallRerankTimeoutMs(
 
 export function buildAutoRecallRerankCostWarning(
   config: PluginConfig,
-  retrievalConfig: RetrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...(config.retrieval || {}) } as RetrievalConfig,
+  retrievalConfig: RetrievalConfig = normalizeRetrievalConfig(
+    config.retrieval as RetrievalConfigInput | undefined,
+  ),
 ): string | null {
   if (config.autoRecall !== true || config.recallMode === "off") return null;
   if (retrievalConfig.mode === "vector") return null;
@@ -2257,7 +2268,9 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
     ...DEFAULT_TIER_CONFIG,
     ...(config.tier || {}),
   });
-  const retrievalConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...config.retrieval } as RetrievalConfig & {
+  const retrievalConfig = normalizeRetrievalConfig(
+    config.retrieval as RetrievalConfigInput | undefined,
+  ) as RetrievalConfig & {
     rerankApiKey?: SecretCredential;
   };
   if (retrievalConfig.rerank === "cross-encoder" && retrievalConfig.rerankApiKey) {
@@ -3273,7 +3286,13 @@ const memoryLanceDBProPlugin = {
               : intent?.depth === "full"
                 ? (r.entry.text) // full text for deep queries
                 : (metaObj.l0_abstract || r.entry.text); // L0/L1 default
-            const summary = sanitizeForContext(contentText).slice(0, effectivePerItemMaxChars);
+            const neighborContext = r.neighbors && r.neighbors.length > 0
+              ? ` Related: ${r.neighbors
+                .map((neighbor) => sanitizeForContext(neighbor.entry.text).slice(0, 80))
+                .filter(Boolean)
+                .join(" | ")}`
+              : "";
+            const summary = sanitizeForContext(`${contentText}${neighborContext}`).slice(0, effectivePerItemMaxChars);
             return {
               id: r.entry.id,
               prefix: (() => {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -637,6 +637,29 @@
             "default": true,
             "description": "Filter out noise memories (agent denials, meta-questions, boilerplate)"
           },
+          "neighborEnrichment": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {
+              "enabled": false,
+              "maxPerResult": 2
+            },
+            "description": "Default-off retrieval-time BM25 neighbor enrichment for hybrid search results.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Attach bounded same-scope BM25 neighbors to each top-level hybrid retrieval result."
+              },
+              "maxPerResult": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 5,
+                "default": 2,
+                "description": "Maximum supplemental neighbors to attach per top-level result."
+              }
+            }
+          },
           "disableNativeCosine": {
             "type": "boolean",
             "default": false,
@@ -1894,6 +1917,16 @@
     "retrieval.candidatePoolSize": {
       "label": "Candidate Pool Size",
       "help": "Number of candidates to fetch before fusion and reranking",
+      "advanced": true
+    },
+    "retrieval.neighborEnrichment.enabled": {
+      "label": "Neighbor Enrichment",
+      "help": "Attach bounded same-scope BM25 neighbors to hybrid retrieval results without changing the top-level count.",
+      "advanced": true
+    },
+    "retrieval.neighborEnrichment.maxPerResult": {
+      "label": "Neighbor Limit",
+      "help": "Maximum supplemental neighbors attached to each hybrid retrieval result.",
       "advanced": true
     },
     "retrieval.disableNativeCosine": {

--- a/scripts/ci-test-manifest.mjs
+++ b/scripts/ci-test-manifest.mjs
@@ -30,6 +30,7 @@ export const CI_TEST_MANIFEST = [
   { group: "cli-smoke", runner: "node", file: "test/functional-e2e.mjs" },
   { group: "storage-and-schema", runner: "node", file: "test/per-agent-auto-recall.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/retriever-rerank-regression.mjs" },
+  { group: "core-regression", runner: "node", file: "test/retriever-neighbor-enrichment.test.mjs", args: ["--test"] },
   { group: "core-regression", runner: "node", file: "test/smart-memory-lifecycle.mjs" },
   { group: "core-regression", runner: "node", file: "test/smart-extractor-branches.mjs" },
   { group: "core-regression", runner: "node", file: "test/smart-extractor-batch-embed.test.mjs" },

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -241,12 +241,16 @@ export const DEFAULT_RETRIEVAL_CONFIG: RetrievalConfig = {
 export function normalizeRetrievalConfig(
   config?: RetrievalConfigInput,
 ): RetrievalConfig {
+  const neighborEnrichment = {
+    ...DEFAULT_RETRIEVAL_CONFIG.neighborEnrichment,
+    ...(config?.neighborEnrichment || {}),
+  };
   return {
     ...DEFAULT_RETRIEVAL_CONFIG,
     ...config,
     neighborEnrichment: {
-      ...DEFAULT_RETRIEVAL_CONFIG.neighborEnrichment,
-      ...(config?.neighborEnrichment || {}),
+      enabled: Boolean(neighborEnrichment.enabled),
+      maxPerResult: clampInt(neighborEnrichment.maxPerResult, 1, 5),
     },
   };
 }
@@ -1228,6 +1232,10 @@ export class MemoryRetriever {
 
     const maxPerResult = clampInt(config.maxPerResult, 1, 5);
     const primaryIds = new Set(results.map((result) => result.entry.id));
+    const neighborCandidateLimit = Math.min(
+      primaryIds.size + maxPerResult + Math.max(10, maxPerResult * 4),
+      50,
+    );
 
     return await Promise.all(results.map(async (result) => {
       const resultScope = result.entry.scope || "global";
@@ -1239,7 +1247,7 @@ export class MemoryRetriever {
       try {
         candidates = await this.store.bm25Search(
           result.entry.text,
-          Math.min(maxPerResult + primaryIds.size + 4, 25),
+          neighborCandidateLimit,
           [resultScope],
           { excludeInactive: true },
         );

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -97,7 +97,19 @@ export interface RetrievalConfig {
    *  Queries containing these prefixes (e.g. "proj:AIF") will use BM25-only + mustContain
    *  to avoid semantic false positives from vector search. */
   tagPrefixes: string[];
+  /** Default-off retrieval-time BM25 neighbors attached after MMR in hybrid mode. */
+  neighborEnrichment: NeighborEnrichmentConfig;
 }
+
+export interface NeighborEnrichmentConfig {
+  enabled: boolean;
+  maxPerResult: number;
+}
+
+export type RetrievalConfigInput =
+  Partial<Omit<RetrievalConfig, "neighborEnrichment">> & {
+    neighborEnrichment?: Partial<NeighborEnrichmentConfig>;
+  };
 
 export interface RetrievalContext {
   query: string;
@@ -120,6 +132,13 @@ export interface RetrievalResult extends MemorySearchResult {
     bm25?: { score: number; rank: number };
     fused?: { score: number };
     reranked?: { score: number };
+  };
+  neighbors?: RetrievalNeighbor[];
+}
+
+export interface RetrievalNeighbor extends MemorySearchResult {
+  sources: {
+    bm25: { score: number; rank: number };
   };
 }
 
@@ -213,7 +232,24 @@ export const DEFAULT_RETRIEVAL_CONFIG: RetrievalConfig = {
   reinforcementFactor: 0.5,
   maxHalfLifeMultiplier: 3,
   tagPrefixes: ["proj", "env", "team", "scope"],
+  neighborEnrichment: {
+    enabled: false,
+    maxPerResult: 2,
+  },
 };
+
+export function normalizeRetrievalConfig(
+  config?: RetrievalConfigInput,
+): RetrievalConfig {
+  return {
+    ...DEFAULT_RETRIEVAL_CONFIG,
+    ...config,
+    neighborEnrichment: {
+      ...DEFAULT_RETRIEVAL_CONFIG.neighborEnrichment,
+      ...(config?.neighborEnrichment || {}),
+    },
+  };
+}
 
 // ============================================================================
 // Utility Functions
@@ -561,9 +597,13 @@ export class MemoryRetriever {
   constructor(
     private store: MemoryStore,
     private embedder: Embedder,
-    private config: RetrievalConfig = DEFAULT_RETRIEVAL_CONFIG,
+    config: RetrievalConfigInput = DEFAULT_RETRIEVAL_CONFIG,
     private decayEngine: DecayEngine | null = null,
-  ) { }
+  ) {
+    this.config = normalizeRetrievalConfig(config);
+  }
+
+  private config: RetrievalConfig;
 
   setAccessTracker(tracker: AccessTracker): void {
     this.accessTracker = tracker;
@@ -1125,7 +1165,7 @@ export class MemoryRetriever {
       trace?.endStage(finalResults.map((r) => r.entry.id), finalResults.map((r) => r.score));
       if (diagnostics) diagnostics.stageCounts.afterDiversity = deduplicated.length;
 
-      return finalResults;
+      return await this.enrichHybridNeighbors(finalResults, scopeFilter, category);
     } catch (error) {
       if (diagnostics) {
         diagnostics.failureStage = extractFailureStage(error) ?? failureStage;
@@ -1175,6 +1215,65 @@ export class MemoryRetriever {
     return filtered.map((result, index) => ({
       ...result,
       rank: index + 1,
+    }));
+  }
+
+  private async enrichHybridNeighbors(
+    results: RetrievalResult[],
+    scopeFilter?: string[],
+    category?: string,
+  ): Promise<RetrievalResult[]> {
+    const config = this.config.neighborEnrichment;
+    if (!config.enabled || results.length === 0) return results;
+
+    const maxPerResult = clampInt(config.maxPerResult, 1, 5);
+    const primaryIds = new Set(results.map((result) => result.entry.id));
+
+    return await Promise.all(results.map(async (result) => {
+      const resultScope = result.entry.scope || "global";
+      if (scopeFilter && scopeFilter.length > 0 && !scopeFilter.includes(resultScope)) {
+        return result;
+      }
+
+      let candidates: MemorySearchResult[];
+      try {
+        candidates = await this.store.bm25Search(
+          result.entry.text,
+          Math.min(maxPerResult + primaryIds.size + 4, 25),
+          [resultScope],
+          { excludeInactive: true },
+        );
+      } catch (error) {
+        console.warn(
+          `[Retriever] neighbor enrichment BM25 lookup failed for ${result.entry.id}: ${formatErrorMessage(error)}`,
+        );
+        return result;
+      }
+
+      const neighbors: RetrievalNeighbor[] = [];
+      for (const candidate of candidates) {
+        if (candidate.entry.id === result.entry.id) continue;
+        if (primaryIds.has(candidate.entry.id)) continue;
+        if ((candidate.entry.scope || "global") !== resultScope) continue;
+        if (category && candidate.entry.category !== category) continue;
+
+        const metadata = parseSmartMetadata(candidate.entry.metadata, candidate.entry);
+        if (isMemoryExpired(metadata)) continue;
+        if (this.config.filterNoise && filterNoise([candidate], (r) => r.entry.text).length === 0) continue;
+
+        neighbors.push({
+          ...candidate,
+          sources: {
+            bm25: {
+              score: candidate.score,
+              rank: neighbors.length + 1,
+            },
+          },
+        });
+        if (neighbors.length >= maxPerResult) break;
+      }
+
+      return neighbors.length > 0 ? { ...result, neighbors } : result;
     }));
   }
 
@@ -1800,13 +1899,23 @@ export class MemoryRetriever {
   }
 
   // Update configuration
-  updateConfig(newConfig: Partial<RetrievalConfig>): void {
-    this.config = { ...this.config, ...newConfig };
+  updateConfig(newConfig: RetrievalConfigInput): void {
+    this.config = normalizeRetrievalConfig({
+      ...this.config,
+      ...newConfig,
+      neighborEnrichment: {
+        ...this.config.neighborEnrichment,
+        ...(newConfig.neighborEnrichment || {}),
+      },
+    });
   }
 
   // Get current configuration
   getConfig(): RetrievalConfig {
-    return { ...this.config };
+    return {
+      ...this.config,
+      neighborEnrichment: { ...this.config.neighborEnrichment },
+    };
   }
 
   getLastDiagnostics(): RetrievalDiagnostics | null {
@@ -1889,9 +1998,9 @@ export interface RetrieverLifecycleOptions {
 export function createRetriever(
   store: MemoryStore,
   embedder: Embedder,
-  config?: Partial<RetrievalConfig>,
+  config?: RetrievalConfigInput,
   options?: { decayEngine?: DecayEngine | null },
 ): MemoryRetriever {
-  const fullConfig = { ...DEFAULT_RETRIEVAL_CONFIG, ...config };
+  const fullConfig = normalizeRetrievalConfig(config);
   return new MemoryRetriever(store, embedder, fullConfig, options?.decayEngine ?? null);
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -112,7 +112,10 @@ function deriveManualMemoryLayer(category: MemoryCategory): "durable" | "working
   return "working";
 }
 
-function sanitizeMemoryForSerialization(results: RetrievalResult[]) {
+function sanitizeMemoryForSerialization(
+  results: RetrievalResult[],
+  options: { includeNeighbors?: boolean } = {},
+) {
   return results.map((r) => ({
     id: r.entry.id,
     text: r.entry.text,
@@ -122,7 +125,7 @@ function sanitizeMemoryForSerialization(results: RetrievalResult[]) {
     importance: r.entry.importance,
     score: r.score,
     sources: r.sources,
-    ...(r.neighbors && r.neighbors.length > 0
+    ...(options.includeNeighbors && r.neighbors && r.neighbors.length > 0
       ? {
         neighbors: r.neighbors.map((neighbor) => ({
           id: neighbor.entry.id,
@@ -936,7 +939,7 @@ function createMemoryRecallTool(
             })
             .join("\n");
 
-          const serializedMemories = sanitizeMemoryForSerialization(results);
+          const serializedMemories = sanitizeMemoryForSerialization(results, { includeNeighbors: true });
           if (includeFullText) {
             for (let i = 0; i < results.length; i++) {
               const metadata = parseSmartMetadata(results[i].entry.metadata, results[i].entry);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -121,6 +121,20 @@ function sanitizeMemoryForSerialization(results: RetrievalResult[]) {
     importance: r.entry.importance,
     score: r.score,
     sources: r.sources,
+    ...(r.neighbors && r.neighbors.length > 0
+      ? {
+        neighbors: r.neighbors.map((neighbor) => ({
+          id: neighbor.entry.id,
+          text: neighbor.entry.text,
+          category: getDisplayCategoryTag(neighbor.entry),
+          rawCategory: neighbor.entry.category,
+          scope: neighbor.entry.scope,
+          importance: neighbor.entry.importance,
+          score: neighbor.score,
+          sources: neighbor.sources,
+        })),
+      }
+      : {}),
   }));
 }
 
@@ -877,7 +891,12 @@ function createMemoryRecallTool(
               const rendered = includeFullText
                 ? inline
                 : truncateText(inline, safeCharsPerItem);
-              return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${rendered}`;
+              const neighborText = r.neighbors && r.neighbors.length > 0
+                ? `\n   Neighbors: ${r.neighbors
+                  .map((neighbor) => `[${neighbor.entry.id}] ${truncateText(normalizeInlineText(neighbor.entry.text), 120)}`)
+                  .join("; ")}`
+                : "";
+              return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${rendered}${neighborText}`;
             })
             .join("\n");
 
@@ -2105,7 +2124,10 @@ export function registerMemoryDebugTool(
               if (r.sources.bm25) sources.push("BM25");
               if (r.sources.reranked) sources.push("reranked");
               const categoryTag = getDisplayCategoryTag(r.entry);
-              return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${r.entry.text.slice(0, 120)}${r.entry.text.length > 120 ? "..." : ""} (${(r.score * 100).toFixed(1)}%${sources.length > 0 ? `, ${sources.join("+")}` : ""})`;
+              const neighborText = r.neighbors && r.neighbors.length > 0
+                ? ` neighbors=${r.neighbors.map((neighbor) => neighbor.entry.id).join(",")}`
+                : "";
+              return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${r.entry.text.slice(0, 120)}${r.entry.text.length > 120 ? "..." : ""} (${(r.score * 100).toFixed(1)}%${sources.length > 0 ? `, ${sources.join("+")}` : ""}${neighborText})`;
             });
 
             const text = [...traceLines, ``, `Results (${results.length}):`, ...resultLines].join("\n");
@@ -2834,6 +2856,7 @@ export function registerMemoryExplainRankTool(
             if (r.sources.vector) sourceBreakdown.push(`vec=${r.sources.vector.score.toFixed(3)}`);
             if (r.sources.bm25) sourceBreakdown.push(`bm25=${r.sources.bm25.score.toFixed(3)}`);
             if (r.sources.reranked) sourceBreakdown.push(`rerank=${r.sources.reranked.score.toFixed(3)}`);
+            if (r.neighbors && r.neighbors.length > 0) sourceBreakdown.push(`neighbors=${r.neighbors.length}`);
             return [
               `${idx + 1}. [${r.entry.id}] score=${r.score.toFixed(3)} ${sourceBreakdown.join(" ")}`.trim(),
               `   state=${meta.state} layer=${meta.memory_layer} source=${meta.source} tier=${meta.tier}`,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -888,15 +888,15 @@ function createMemoryRecallTool(
                 ? (metadata.l2_content || metadata.l1_overview || r.entry.text)
                 : (metadata.l0_abstract || r.entry.text);
               const inline = normalizeInlineText(base);
-              const rendered = includeFullText
-                ? inline
-                : truncateText(inline, safeCharsPerItem);
               const neighborText = r.neighbors && r.neighbors.length > 0
-                ? `\n   Neighbors: ${r.neighbors
+                ? ` Neighbors: ${r.neighbors
                   .map((neighbor) => `[${neighbor.entry.id}] ${truncateText(normalizeInlineText(neighbor.entry.text), 120)}`)
                   .join("; ")}`
                 : "";
-              return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${rendered}${neighborText}`;
+              const rendered = includeFullText
+                ? `${inline}${neighborText}`
+                : truncateText(`${inline}${neighborText}`, safeCharsPerItem);
+              return `${i + 1}. [${r.entry.id}] [${categoryTag}] ${rendered}`;
             })
             .join("\n");
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -44,6 +44,7 @@ import {
   isUserMdExclusiveMemory,
   type WorkspaceBoundaryConfig,
 } from "./workspace-boundary.js";
+import { isSuppressed as isTier1Suppressed } from "./auto-recall-tier1.js";
 
 // ============================================================================
 // Types
@@ -136,6 +137,37 @@ function sanitizeMemoryForSerialization(results: RetrievalResult[]) {
       }
       : {}),
   }));
+}
+
+function isManualRecallNeighborGovernanceEligible(
+  result: RetrievalResult,
+  nowMs: number,
+): boolean {
+  const meta = parseSmartMetadata(result.entry.metadata, result.entry);
+  if (meta.state !== "confirmed") return false;
+  if (meta.memory_layer === "archive" || meta.memory_layer === "reflection") return false;
+  if (isTier1Suppressed(meta, nowMs)) return false;
+  return true;
+}
+
+function filterManualRecallResultNeighbors(
+  results: RetrievalResult[],
+  workspaceBoundary?: WorkspaceBoundaryConfig,
+  nowMs = Date.now(),
+): RetrievalResult[] {
+  return results.map((result) => {
+    if (!result.neighbors || result.neighbors.length === 0) return result;
+
+    const neighbors = filterUserMdExclusiveRecallResults(
+      result.neighbors.filter((neighbor) => isManualRecallNeighborGovernanceEligible(neighbor, nowMs)),
+      workspaceBoundary,
+    );
+    if (neighbors.length === result.neighbors.length) return result;
+    if (neighbors.length > 0) return { ...result, neighbors };
+
+    const { neighbors: _neighbors, ...withoutNeighbors } = result;
+    return withoutNeighbors;
+  });
 }
 
 function isUnresolvedReflectionItem(entry: MemoryEntry): boolean {
@@ -835,13 +867,17 @@ function createMemoryRecallTool(
           const { scopeFilter } = resolvedScopes;
           const ignoredScopeNotice = formatIgnoredScopeNotice(resolvedScopes);
 
-          const results = filterUserMdExclusiveRecallResults(await retrieveWithRetry(runtimeContext.retriever, {
+          const retrievedResults = await retrieveWithRetry(runtimeContext.retriever, {
             query,
             limit: safeLimit,
             scopeFilter,
             category,
             source: "manual",
-          }, () => runtimeContext.store.count()), runtimeContext.workspaceBoundary);
+          }, () => runtimeContext.store.count());
+          const results = filterManualRecallResultNeighbors(
+            filterUserMdExclusiveRecallResults(retrievedResults, runtimeContext.workspaceBoundary),
+            runtimeContext.workspaceBoundary,
+          );
 
           if (results.length === 0) {
             return {

--- a/test/recall-text-cleanup.test.mjs
+++ b/test/recall-text-cleanup.test.mjs
@@ -26,7 +26,11 @@ const origCreateEmbedder = embedderModuleForMock.createEmbedder;
 const pluginModule = jiti("../index.ts");
 const memoryLanceDBProPlugin = pluginModule.default || pluginModule;
 const resetRegistration = pluginModule.resetRegistration ?? (() => {});
-const { registerMemoryRecallTool, registerMemoryStoreTool } = jiti("../src/tools.ts");
+const {
+  registerMemoryExplainRankTool,
+  registerMemoryRecallTool,
+  registerMemoryStoreTool,
+} = jiti("../src/tools.ts");
 const { MemoryRetriever } = jiti("../src/retriever.js");
 const { buildSmartMetadata, stringifySmartMetadata } = jiti("../src/smart-metadata.ts");
 
@@ -505,6 +509,27 @@ describe("recall text cleanup", () => {
     );
     assert.doesNotMatch(JSON.stringify(res.details.memories), /neighbor-user-md|称呼偏好：宙斯/);
     assert.doesNotMatch(JSON.stringify(res.details.memories), /neighbor-pending|neighbor-archive|neighbor-reflection|neighbor-suppressed/);
+  });
+
+  it("omits unfiltered neighbors from non-recall serialized tool details", async () => {
+    const tool = createTool(registerMemoryExplainRankTool, {
+      ...makeRecallContext(makeNeighborGovernanceResults()),
+      workspaceBoundary: {
+        userMdExclusive: {
+          enabled: true,
+        },
+      },
+    });
+    const res = await tool.execute(null, {
+      query: "neighbor governance",
+      limit: 2,
+    });
+
+    assert.equal(res.details.results.length, 2);
+    assert.equal(res.details.results[0].neighbors, undefined);
+    assert.equal(res.details.results[1].neighbors, undefined);
+    assert.doesNotMatch(JSON.stringify(res.details.results), /neighbor-user-md|称呼偏好：宙斯/);
+    assert.doesNotMatch(JSON.stringify(res.details.results), /neighbor-pending|neighbor-archive|neighbor-reflection|neighbor-suppressed/);
   });
 
   it("removes retrieval metadata from every rendered memory_recall line", async () => {

--- a/test/recall-text-cleanup.test.mjs
+++ b/test/recall-text-cleanup.test.mjs
@@ -473,6 +473,40 @@ describe("recall text cleanup", () => {
     assert.equal(res.details.memories[0].neighbors.length, 1);
   });
 
+  it("filters boundary-sensitive and governance-ineligible neighbors from memory_recall output and details", async () => {
+    const tool = createTool(registerMemoryRecallTool, {
+      ...makeRecallContext(makeNeighborGovernanceResults()),
+      workspaceBoundary: {
+        userMdExclusive: {
+          enabled: true,
+        },
+      },
+    });
+    const res = await tool.execute(null, {
+      query: "neighbor governance",
+      limit: 2,
+      maxCharsPerItem: 1000,
+    });
+
+    assert.match(res.content[0].text, /neighbor-shared/);
+    assert.match(res.content[0].text, /neighbor-unique/);
+    assert.doesNotMatch(res.content[0].text, /neighbor-user-md|称呼偏好：宙斯/);
+    assert.doesNotMatch(res.content[0].text, /neighbor-pending|pending neighbor should not appear/);
+    assert.doesNotMatch(res.content[0].text, /neighbor-archive|archive neighbor should not appear/);
+    assert.doesNotMatch(res.content[0].text, /neighbor-reflection|reflection neighbor should not appear/);
+    assert.doesNotMatch(res.content[0].text, /neighbor-suppressed|suppressed neighbor should not appear/);
+
+    assert.deepEqual(
+      res.details.memories.map((memory) => memory.neighbors?.map((neighbor) => neighbor.id) ?? []),
+      [
+        ["neighbor-shared"],
+        ["neighbor-shared", "neighbor-unique"],
+      ],
+    );
+    assert.doesNotMatch(JSON.stringify(res.details.memories), /neighbor-user-md|称呼偏好：宙斯/);
+    assert.doesNotMatch(JSON.stringify(res.details.memories), /neighbor-pending|neighbor-archive|neighbor-reflection|neighbor-suppressed/);
+  });
+
   it("removes retrieval metadata from every rendered memory_recall line", async () => {
     const tool = createTool(registerMemoryRecallTool, makeRecallContext(makeExpandedResults()));
     const res = await tool.execute(null, { query: "test with multiple memories" });

--- a/test/recall-text-cleanup.test.mjs
+++ b/test/recall-text-cleanup.test.mjs
@@ -300,6 +300,46 @@ function makeGovernanceFilteredResults() {
   ];
 }
 
+function makeNeighborGovernanceResults() {
+  const now = Date.now();
+  const result = (id, text, metadataOverrides = {}, neighbors = []) => ({
+    entry: {
+      id,
+      text,
+      category: "fact",
+      scope: "global",
+      importance: 0.7,
+      timestamp: now,
+      metadata: confirmedMetadata(metadataOverrides),
+    },
+    score: 0.9,
+    sources: { vector: { score: 0.9, rank: 1 } },
+    ...(neighbors.length > 0 ? { neighbors } : {}),
+  });
+  const userMdExclusiveNeighbor = result("neighbor-user-md", "称呼偏好：宙斯", {
+    l0_abstract: "称呼偏好：宙斯",
+    l1_overview: "## Addressing\n- Preferred form of address: 宙斯",
+    l2_content: "用户希望以后被称呼为“宙斯”。",
+    memory_category: "preferences",
+    fact_key: "preferences:称呼偏好",
+  });
+  const sharedNeighbor = result("neighbor-shared", "shared neighbor should appear once");
+  return [
+    result("primary-1", "primary one", {}, [
+      sharedNeighbor,
+      result("neighbor-pending", "pending neighbor should not appear", { state: "pending", memory_layer: "working" }),
+      result("neighbor-archive", "archive neighbor should not appear", { state: "archived", memory_layer: "archive" }),
+      result("neighbor-reflection", "reflection neighbor should not appear", { memory_layer: "reflection" }),
+      result("neighbor-suppressed", "suppressed neighbor should not appear", { suppressed_until_ms: now + 60_000 }),
+      userMdExclusiveNeighbor,
+    ]),
+    result("primary-2", "primary two", {}, [
+      sharedNeighbor,
+      result("neighbor-unique", "unique safe neighbor"),
+    ]),
+  ];
+}
+
 function makeRecallContext(results = makeResults()) {
   return {
     retriever: {
@@ -720,6 +760,77 @@ describe("recall text cleanup", () => {
     assert.match(output.prependContext, /confirmed durable memory/);
     assert.doesNotMatch(output.prependContext, /pending memory should not auto-recall/);
     assert.doesNotMatch(output.prependContext, /archived memory should not auto-recall/);
+  });
+
+  it("applies auto-recall governance and dedupe to related neighbor snippets", async () => {
+    const mockResults = makeNeighborGovernanceResults();
+    const retrieverMod = jiti("../src/retriever.js");
+    retrieverMod.createRetriever = function mockCreateRetriever() {
+      return {
+        async retrieve() {
+          return mockResults;
+        },
+        getConfig() {
+          return { mode: "hybrid" };
+        },
+        setAccessTracker() {},
+        setStatsCollector() {},
+      };
+    };
+    const embedderMod = jiti("../src/embedder.js");
+    embedderMod.createEmbedder = function mockCreateEmbedder() {
+      return {
+        async embedQuery() {
+          return new Float32Array(384).fill(0);
+        },
+        async embedPassage() {
+          return new Float32Array(384).fill(0);
+        },
+      };
+    };
+
+    const harness = createPluginApiHarness({
+      resolveRoot: workspaceDir,
+      pluginConfig: {
+        dbPath: path.join(workspaceDir, "db"),
+        embedding: { apiKey: "test-api-key" },
+        smartExtraction: false,
+        autoCapture: false,
+        autoRecall: true,
+        autoRecallMinLength: 1,
+        autoRecallMaxItems: 5,
+        autoRecallMaxChars: 3000,
+        autoRecallPerItemMaxChars: 1000,
+        workspaceBoundary: {
+          userMdExclusive: {
+            enabled: true,
+          },
+        },
+        selfImprovement: { enabled: false, beforeResetNote: false, ensureLearningFiles: false },
+      },
+    });
+    memoryLanceDBProPlugin.register(harness.api);
+    const autoRecallHook = getAutoRecallHook(harness.eventHandlers);
+    const output = await autoRecallHook(
+      { prompt: "Please recall related details for this task." },
+      { sessionId: "auto-neighbor-governance", sessionKey: "agent:main:session:auto-neighbor-governance", agentId: "main" }
+    );
+
+    assert.ok(output);
+    assert.match(output.prependContext, /primary one/);
+    assert.match(output.prependContext, /primary two/);
+    assert.match(output.prependContext, /shared neighbor should appear once/);
+    assert.match(output.prependContext, /unique safe neighbor/);
+    assert.equal(
+      (output.prependContext.match(/shared neighbor should appear once/g) || []).length,
+      1,
+      "duplicate neighbor ids should render once across auto-recall lines",
+    );
+    assert.doesNotMatch(output.prependContext, /pending neighbor should not appear/);
+    assert.doesNotMatch(output.prependContext, /archive neighbor should not appear/);
+    assert.doesNotMatch(output.prependContext, /reflection neighbor should not appear/);
+    assert.doesNotMatch(output.prependContext, /suppressed neighbor should not appear/);
+    assert.doesNotMatch(output.prependContext, /称呼偏好：宙斯/);
   });
 
   it("filters USER.md-exclusive facts from memory_recall output", async () => {

--- a/test/recall-text-cleanup.test.mjs
+++ b/test/recall-text-cleanup.test.mjs
@@ -148,6 +148,43 @@ function makeExpandedResults() {
   ];
 }
 
+function makeNeighborSummaryResults() {
+  return [
+    {
+      entry: {
+        id: "m-neighbor-primary",
+        text: "primary alpha",
+        category: "fact",
+        scope: "global",
+        importance: 0.7,
+        timestamp: Date.now(),
+        metadata: confirmedMetadata(),
+      },
+      score: 0.82,
+      sources: {
+        vector: { score: 0.82, rank: 1 },
+      },
+      neighbors: [
+        {
+          entry: {
+            id: "n1",
+            text: "neighbor beta detail should share the same per item budget instead of expanding the summary line",
+            category: "fact",
+            scope: "global",
+            importance: 0.6,
+            timestamp: Date.now(),
+            metadata: confirmedMetadata(),
+          },
+          score: 0.7,
+          sources: {
+            bm25: { score: 0.7, rank: 1 },
+          },
+        },
+      ],
+    },
+  ];
+}
+
 function makeUserMdExclusiveResults() {
   return [
     ...makeResults(),
@@ -417,6 +454,23 @@ describe("recall text cleanup", () => {
     assert.equal(typeof res.details.memories[1].score, "number");
     assert.ok(res.details.memories[1].sources.vector);
     assert.ok(res.details.memories[1].sources.bm25);
+  });
+
+  it("keeps memory_recall neighbor summaries within the per-item character budget", async () => {
+    const tool = createTool(registerMemoryRecallTool, makeRecallContext(makeNeighborSummaryResults()));
+    const res = await tool.execute(null, {
+      query: "neighbor budget",
+      maxCharsPerItem: 60,
+    });
+
+    const line = extractRenderedMemoryRecallLines(res.content[0].text)[0];
+    const summary = line.replace(/^1\. \[m-neighbor-primary\] \[fact:global\] /, "");
+
+    assert.match(summary, /Neighbors:/);
+    assert.ok(summary.length <= 60, `expected ${summary.length} chars to stay within the configured budget`);
+    assert.match(summary, /…$/);
+    assert.doesNotMatch(summary, /expanding the summary line/);
+    assert.equal(res.details.memories[0].neighbors.length, 1);
   });
 
   it("removes retrieval metadata from every rendered memory_recall line", async () => {

--- a/test/retriever-neighbor-enrichment.test.mjs
+++ b/test/retriever-neighbor-enrichment.test.mjs
@@ -1,0 +1,183 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+
+const {
+  createRetriever,
+  DEFAULT_RETRIEVAL_CONFIG,
+} = jiti("../src/retriever.ts");
+const { parsePluginConfig } = jiti("../index.ts");
+
+const now = Date.now();
+
+function entry(id, text, scope = "team-a", category = "fact") {
+  return {
+    id,
+    text,
+    scope,
+    category,
+    timestamp: now,
+    importance: 0.8,
+    vector: [1, 0, 0],
+    metadata: "{}",
+  };
+}
+
+const primary = entry("primary", "primary plan mentions alpha module");
+const sameScopeNeighbor = entry("neighbor-a", "alpha module follow-up detail");
+const otherScopeNeighbor = entry("neighbor-b", "alpha module other scope detail", "team-b");
+const otherCategoryNeighbor = entry("neighbor-c", "alpha module decision detail", "team-a", "decision");
+
+function createStore(options = {}) {
+  const bm25Calls = [];
+  return {
+    bm25Calls,
+    hasFtsSupport: true,
+    async vectorSearch(_vector, _limit, _minScore, scopeFilter) {
+      assert.deepEqual(scopeFilter, ["team-a", "team-b"]);
+      return [{ entry: primary, score: 0.9 }];
+    },
+    async bm25Search(query, limit, scopeFilter, searchOptions) {
+      bm25Calls.push({ query, limit, scopeFilter, options: searchOptions });
+      if (query === "primary query") {
+        assert.deepEqual(scopeFilter, ["team-a", "team-b"]);
+        return [{ entry: primary, score: 0.8 }];
+      }
+      if (query === primary.text) {
+        if (options.throwOnNeighborLookup) {
+          throw new Error("neighbor fts unavailable");
+        }
+        assert.deepEqual(scopeFilter, ["team-a"]);
+        return [
+          { entry: primary, score: 0.99 },
+          { entry: sameScopeNeighbor, score: 0.82 },
+          { entry: otherScopeNeighbor, score: 0.81 },
+          { entry: otherCategoryNeighbor, score: 0.8 },
+        ].slice(0, limit);
+      }
+      return [];
+    },
+    async hasId(id) {
+      return [primary, sameScopeNeighbor, otherScopeNeighbor, otherCategoryNeighbor]
+        .some((candidate) => candidate.id === id);
+    },
+  };
+}
+
+const embedder = {
+  async embedQuery() {
+    return [1, 0, 0];
+  },
+};
+
+function createConfig(overrides = {}) {
+  return {
+    ...DEFAULT_RETRIEVAL_CONFIG,
+    mode: "hybrid",
+    rerank: "none",
+    filterNoise: false,
+    minScore: 0,
+    hardMinScore: 0,
+    queryExpansion: false,
+    ...overrides,
+  };
+}
+
+describe("retrieval neighbor enrichment", () => {
+  it("keeps hybrid retrieval unchanged when neighbor enrichment is disabled", async () => {
+    const store = createStore();
+    const retriever = createRetriever(store, embedder, createConfig());
+
+    const results = await retriever.retrieve({
+      query: "primary query",
+      limit: 3,
+      scopeFilter: ["team-a", "team-b"],
+      category: "fact",
+    });
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].entry.id, "primary");
+    assert.equal(results[0].neighbors, undefined);
+    assert.equal(store.bm25Calls.length, 1, "disabled mode should not issue neighbor BM25 lookups");
+  });
+
+  it("attaches same-scope BM25 neighbors after MMR in hybrid retrieval", async () => {
+    const store = createStore();
+    const retriever = createRetriever(store, embedder, createConfig({
+      neighborEnrichment: {
+        enabled: true,
+        maxPerResult: 2,
+      },
+    }));
+
+    const results = await retriever.retrieve({
+      query: "primary query",
+      limit: 3,
+      scopeFilter: ["team-a", "team-b"],
+      category: "fact",
+    });
+
+    assert.equal(results.length, 1, "neighbors should not increase top-level result count");
+    assert.deepEqual(
+      results[0].neighbors?.map((neighbor) => neighbor.entry.id),
+      ["neighbor-a"],
+      "neighbors should exclude the primary result and stay within active scope/category boundaries",
+    );
+    assert.equal(results[0].neighbors?.[0].sources.bm25.rank, 1);
+    assert.equal(store.bm25Calls.length, 2, "enabled mode should issue a supplemental BM25 lookup");
+  });
+
+  it("returns primary hybrid results when supplemental neighbor lookup fails", async () => {
+    const store = createStore({ throwOnNeighborLookup: true });
+    const retriever = createRetriever(store, embedder, createConfig({
+      neighborEnrichment: {
+        enabled: true,
+        maxPerResult: 2,
+      },
+    }));
+    const originalWarn = console.warn;
+    const warnings = [];
+    console.warn = (message) => warnings.push(String(message));
+
+    try {
+      const results = await retriever.retrieve({
+        query: "primary query",
+        limit: 3,
+        scopeFilter: ["team-a", "team-b"],
+        category: "fact",
+      });
+
+      assert.equal(results.length, 1);
+      assert.equal(results[0].entry.id, "primary");
+      assert.equal(results[0].neighbors, undefined);
+      assert.equal(store.bm25Calls.length, 2, "primary BM25 succeeds and supplemental lookup is attempted");
+      assert.match(warnings.join("\n"), /neighbor enrichment BM25 lookup failed/);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it("parses partial nested neighbor enrichment config with safe defaults", () => {
+    const parsed = parsePluginConfig({
+      embedding: {
+        provider: "openai-compatible",
+        apiKey: "test-key",
+        model: "text-embedding-3-small",
+      },
+      retrieval: {
+        neighborEnrichment: {
+          enabled: true,
+        },
+      },
+    });
+
+    const retriever = createRetriever(createStore(), embedder, parsed.retrieval);
+    const config = retriever.getConfig();
+    assert.deepEqual(config.neighborEnrichment, {
+      enabled: true,
+      maxPerResult: 2,
+    });
+  });
+});

--- a/test/retriever-neighbor-enrichment.test.mjs
+++ b/test/retriever-neighbor-enrichment.test.mjs
@@ -127,6 +127,7 @@ describe("retrieval neighbor enrichment", () => {
     );
     assert.equal(results[0].neighbors?.[0].sources.bm25.rank, 1);
     assert.equal(store.bm25Calls.length, 2, "enabled mode should issue a supplemental BM25 lookup");
+    assert.equal(store.bm25Calls[1].limit, 13, "supplemental lookup should reserve slack after primary-id exclusion");
   });
 
   it("returns primary hybrid results when supplemental neighbor lookup fails", async () => {
@@ -178,6 +179,31 @@ describe("retrieval neighbor enrichment", () => {
     assert.deepEqual(config.neighborEnrichment, {
       enabled: true,
       maxPerResult: 2,
+    });
+  });
+
+  it("normalizes neighbor enrichment bounds in returned retriever config", () => {
+    const retriever = createRetriever(createStore(), embedder, createConfig({
+      neighborEnrichment: {
+        enabled: true,
+        maxPerResult: 99,
+      },
+    }));
+
+    assert.deepEqual(retriever.getConfig().neighborEnrichment, {
+      enabled: true,
+      maxPerResult: 5,
+    });
+
+    retriever.updateConfig({
+      neighborEnrichment: {
+        maxPerResult: 0,
+      },
+    });
+
+    assert.deepEqual(retriever.getConfig().neighborEnrichment, {
+      enabled: true,
+      maxPerResult: 1,
     });
   });
 });


### PR DESCRIPTION
## Summary
- add default-off hybrid retrieval neighbor enrichment using same-scope BM25 lookups
- attach bounded neighbors as supplemental recall context without changing top-level result counts
- add config schema/UI fields and focused regression coverage

Refs #538
Refs #445

## Verification
- node --test test/retriever-neighbor-enrichment.test.mjs
- node test/retriever-rerank-regression.mjs
- node scripts/verify-ci-test-manifest.mjs
- node test/plugin-manifest-regression.mjs
- npm run build
- npm run test:core-regression
- npm run test:packaging-and-workflow