### PR TITLE
fix(cli): write memory-pro JSON to stdout

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -486,6 +486,14 @@ function formatJson(obj: any): string {
   return JSON.stringify(obj, null, 2);
 }
 
+function writeStdout(text: string): void {
+  process.stdout.write(text.endsWith("\n") ? text : `${text}\n`);
+}
+
+function writeJson(obj: any): void {
+  writeStdout(formatJson(obj));
+}
+
 function formatRetrievalDiagnosticsLines(diagnostics: {
   originalQuery: string;
   bm25Query: string | null;
@@ -1298,7 +1306,7 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
         );
 
         if (options.json) {
-          console.log(formatJson(memories));
+          writeJson(memories);
         } else {
           if (memories.length === 0) {
             console.log("No memories found.");
@@ -1341,9 +1349,7 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
         );
 
         if (options.json) {
-          console.log(
-            formatJson(options.debug ? { diagnostics, results } : results),
-          );
+          writeJson(options.debug ? { diagnostics, results } : results);
         } else {
           if (options.debug && diagnostics) {
             for (const line of formatRetrievalDiagnosticsLines(diagnostics)) {
@@ -1371,9 +1377,7 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
       } catch (error) {
         const diagnostics = options.debug ? lastSearchDiagnostics : null;
         if (options.json) {
-          console.log(
-            formatJson(buildSearchErrorPayload(error, diagnostics, options.debug)),
-          );
+          writeJson(buildSearchErrorPayload(error, diagnostics, options.debug));
           process.exit(1);
         }
         if (diagnostics) {
@@ -1413,7 +1417,7 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
         };
 
         if (options.json) {
-          console.log(formatJson(summary));
+          writeJson(summary);
         } else {
           console.log(`Memory Statistics:`);
           console.log(`• Total memories: ${stats.totalCount}`);
@@ -1547,7 +1551,7 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
           await fs.writeFile(options.output, output);
           console.log(`Exported ${memories.length} memories to ${options.output}`);
         } else {
-          console.log(output);
+          writeStdout(output);
         }
       } catch (error) {
         console.error("Export failed:", error);

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -362,6 +362,12 @@ function formatObsidianMemory(memory) {
 function formatJson(obj) {
     return JSON.stringify(obj, null, 2);
 }
+function writeStdout(text) {
+    process.stdout.write(text.endsWith("\n") ? text : `${text}\n`);
+}
+function writeJson(obj) {
+    writeStdout(formatJson(obj));
+}
 function formatRetrievalDiagnosticsLines(diagnostics) {
     const topDrops = diagnostics.dropSummary.length > 0
         ? diagnostics.dropSummary
@@ -1037,7 +1043,7 @@ export function registerMemoryCLI(program, context) {
             }
             const memories = await context.store.list(scopeFilter, options.category, limit, offset);
             if (options.json) {
-                console.log(formatJson(memories));
+                writeJson(memories);
             }
             else {
                 if (memories.length === 0) {
@@ -1074,7 +1080,7 @@ export function registerMemoryCLI(program, context) {
             }
             const { results, diagnostics } = await runSearch(query, limit, scopeFilter, options.category);
             if (options.json) {
-                console.log(formatJson(options.debug ? { diagnostics, results } : results));
+                writeJson(options.debug ? { diagnostics, results } : results);
             }
             else {
                 if (options.debug && diagnostics) {
@@ -1105,7 +1111,7 @@ export function registerMemoryCLI(program, context) {
         catch (error) {
             const diagnostics = options.debug ? lastSearchDiagnostics : null;
             if (options.json) {
-                console.log(formatJson(buildSearchErrorPayload(error, diagnostics, options.debug)));
+                writeJson(buildSearchErrorPayload(error, diagnostics, options.debug));
                 process.exit(1);
             }
             if (diagnostics) {
@@ -1141,7 +1147,7 @@ export function registerMemoryCLI(program, context) {
                 },
             };
             if (options.json) {
-                console.log(formatJson(summary));
+                writeJson(summary);
             }
             else {
                 console.log(`Memory Statistics:`);
@@ -1265,7 +1271,7 @@ export function registerMemoryCLI(program, context) {
                 console.log(`Exported ${memories.length} memories to ${options.output}`);
             }
             else {
-                console.log(output);
+                writeStdout(output);
             }
         }
         catch (error) {

--- a/test/cli-smoke.mjs
+++ b/test/cli-smoke.mjs
@@ -17,17 +17,29 @@ Module._initPaths();
 const jiti = jitiFactory(import.meta.url, { interopDefault: true });
 
 async function captureStdout(run) {
-  const chunks = [];
+  const stdoutChunks = [];
+  const logChunks = [];
   const originalLog = console.log;
+  const originalWrite = process.stdout.write;
   console.log = (...args) => {
-    chunks.push(args.join(" "));
+    logChunks.push(args.join(" "));
+  };
+  process.stdout.write = function write(chunk, encoding, callback) {
+    stdoutChunks.push(Buffer.isBuffer(chunk) ? chunk.toString(encoding) : String(chunk));
+    if (typeof encoding === "function") {
+      encoding();
+    } else if (typeof callback === "function") {
+      callback();
+    }
+    return true;
   };
   try {
     await run();
   } finally {
+    process.stdout.write = originalWrite;
     console.log = originalLog;
   }
-  return chunks.join("\n");
+  return { stdout: stdoutChunks.join(""), logs: logChunks.join("\n") };
 }
 
 async function createSourceDb(sourceDbPath) {
@@ -163,6 +175,21 @@ async function runCliSmoke() {
   ]);
   assert.match(out2, /Import completed: 0 imported, 1 skipped/, out2);
 
+  const listOutput = await captureStdout(async () => {
+    await program.parseAsync([
+      "node",
+      "openclaw",
+      "memory-pro",
+      "list",
+      "--scope",
+      "agent:smoke",
+      "--json",
+    ]);
+  });
+
+  assert.equal(listOutput.logs, "", "memory-pro list --json should not use console.log");
+  assert.equal(JSON.parse(listOutput.stdout)[0].id, importId);
+
   const vaultPath = path.join(workDir, "obsidian-vault");
   const outObsidian = await captureLogs([
     "node",
@@ -278,7 +305,9 @@ async function runCliSmoke() {
     ]);
   });
 
-  assert.match(searchOutput, /search_regression_1/);
+  assert.equal(searchOutput.logs, "", "memory-pro search --json should not use console.log");
+  assert.match(searchOutput.stdout, /search_regression_1/);
+  assert.equal(JSON.parse(searchOutput.stdout)[0].entry.id, "search_regression_1");
 
   const lexicalStore = new MemoryStore({
     dbPath: path.join(workDir, "lexical-db"),

--- a/test/functional-e2e.mjs
+++ b/test/functional-e2e.mjs
@@ -46,16 +46,28 @@ async function createLegacyDb(baseDir, rows) {
 
 async function captureStdout(run) {
   const logs = [];
+  const stdout = [];
   const originalLog = console.log;
+  const originalWrite = process.stdout.write;
   console.log = (...args) => {
     logs.push(args.join(" "));
+  };
+  process.stdout.write = function write(chunk, encoding, callback) {
+    stdout.push(Buffer.isBuffer(chunk) ? chunk.toString(encoding) : String(chunk));
+    if (typeof encoding === "function") {
+      encoding();
+    } else if (typeof callback === "function") {
+      callback();
+    }
+    return true;
   };
   try {
     await run();
   } finally {
+    process.stdout.write = originalWrite;
     console.log = originalLog;
   }
-  return logs.join("\n");
+  return stdout.join("") || logs.join("\n");
 }
 
 async function runFunctionalE2E() {


### PR DESCRIPTION
## Summary

- write `memory-pro` machine-readable JSON payloads directly to stdout instead of `console.log`
- keep human-facing CLI output on `console.log`
- update CLI smoke/e2e tests to distinguish direct stdout from console/log output for JSON commands
- include rebuilt `dist/cli.js` so packaged runtime output stays fresh

## Root cause

OpenClaw routes console/log output to stderr in JSON mode so diagnostics do not corrupt machine-readable stdout. `memory-pro list/search/stats/export --json` was still emitting payloads with `console.log(formatJson(...))`, so the JSON payload followed the diagnostic stream and could be captured by `2>stderr.log` along with plugin loader logs.

That inverted the intended stream contract:

- diagnostics/logs: stderr
- machine-readable JSON payloads: stdout

This patch adds `writeStdout()` / `writeJson()` helpers and uses them for JSON payload branches so the payload bypasses console capture/routing.

## Tests

- `npm run test:cli-smoke`
- `npm run build`
- `npm run verify-package-runtime`

## Notes

This fixes the `memory-pro` payload side of the stdout/stderr issue. If OpenClaw core still emits plugin startup chatter on stdout before plugin command dispatch, that should be handled separately in OpenClaw core (same class as openclaw/openclaw#81536).