### PR TITLE
feat(core): local hot-patches for memory-core dreaming integration

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3,9 +3,9 @@
  * Enhanced LanceDB-backed long-term memory with hybrid retrieval and multi-scope isolation
  */
 import { homedir, tmpdir } from "node:os";
-import { join, dirname, basename, win32 as winPath } from "node:path";
+import { join, dirname, basename, resolve, win32 as winPath } from "node:path";
 import { readFile, readdir, writeFile, mkdir, appendFile, unlink, stat } from "node:fs/promises";
-import { readFileSync } from "node:fs";
+import { readFileSync, appendFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
@@ -2489,6 +2489,36 @@ const memoryLanceDBProPlugin = {
                     if (selected.length === 0) {
                         api.logger.info?.(`memory-lancedb-pro: auto-recall skipped injection after budgeting (hits=${results.length}, dedupFiltered=${dedupFilteredCount}, maxItems=${autoRecallMaxItems}, maxChars=${autoRecallMaxChars})`);
                         return;
+                    }
+                    // [PATCH 2026-06-10] emit memory.recall.recorded for memory-core dreaming pipeline.
+                    // Append a JSONL record per injected recall turn to memory/.dreams/events.jsonl so
+                    // memory-core's dreaming short-term promotion can count recalls per entry. Failures
+                    // here must never break the recall path, so wrap in try/catch and downgrade to debug.
+                    try {
+                        const selectedIds = new Set(selected.map((it) => it.id));
+                        const emittedResults = results
+                            .filter((r) => selectedIds.has(r.entry.id))
+                            .map((r) => ({
+                            path: typeof r.entry.path === "string" ? r.entry.path : "",
+                            startLine: Number(r.entry.startLine) || 0,
+                            endLine: Number(r.entry.endLine) || 0,
+                            score: Number(r.score) || 0,
+                        }));
+                        const emittedEvent = {
+                            type: "memory.recall.recorded",
+                            timestamp: new Date().toISOString(),
+                            query: String(recallQuery || ""),
+                            resultCount: emittedResults.length,
+                            results: emittedResults,
+                        };
+                        const workspaceRoot = typeof api.resolvePath === "function"
+                            ? api.resolvePath(".")
+                            : resolve(process.cwd());
+                        const eventLogPath = join(workspaceRoot, "memory", ".dreams", "events.jsonl");
+                        appendFileSync(eventLogPath, JSON.stringify(emittedEvent) + "\n", "utf8");
+                    }
+                    catch (emitErr) {
+                        api.logger.debug?.("memory-lancedb-pro: failed to emit memory.recall.recorded: " + String(emitErr));
                     }
                     if (shouldDropLateAutoRecall("pre-metadata"))
                         return;

--- a/dist/src/llm-client.js
+++ b/dist/src/llm-client.js
@@ -157,7 +157,7 @@ function createApiKeyClient(config, log, warnLog) {
                     messages: [
                         {
                             role: "system",
-                            content: "You are a memory extraction assistant. Always respond with valid JSON only.",
+                            content: "You are a memory extraction assistant. Always respond with valid JSON only. /no_think",
                         },
                         { role: "user", content: prompt },
                     ],

--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -876,8 +876,9 @@ export class MemoryRetriever {
                 const model = this.config.rerankModel || "jina-reranker-v3";
                 const endpoint = this.config.rerankEndpoint || "https://api.jina.ai/v1/rerank";
                 const documents = results.map((r) => r.entry.text);
+                const rerankTopN = Math.min(results.length, Math.max(1, this.config.candidatePoolSize));
                 // Build provider-specific request
-                const { headers, body } = buildRerankRequest(provider, this.config.rerankApiKey || "", model, query, documents, results.length);
+                const { headers, body } = buildRerankRequest(provider, this.config.rerankApiKey || "", model, query, documents, rerankTopN);
                 // Timeout: configurable via rerankTimeoutMs (default: 5000ms)
                 const controller = new AbortController();
                 const timeout = setTimeout(() => controller.abort(), this.config.rerankTimeoutMs ?? 5000);

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -29,6 +29,21 @@ export function __setLockfileModuleForTests(module) {
 }
 export const loadLanceDB = async () => {
     if (!lancedbImportPromise) {
+        // @lancedb/lancedb's napi-rs loader (dist/native.js) detects musl via
+        // process.report.getReport(). The report's network section performs
+        // reverse-DNS lookups for every network interface, synchronously on the
+        // calling thread; on hosts with several interfaces and a slow or flaky
+        // DNS path (measured on WSL2 + Tailscale) this blocks the event loop for
+        // 110-250s on the FIRST LanceDB load — the host app's HTTP server and
+        // pollers freeze with CPU at 0% (main thread stuck in poll()). Excluding
+        // the network section turns the measured 235s hang into ~3ms and loses
+        // nothing: isMusl() only reads report.header.glibcVersionRuntime.
+        try {
+            process.report.excludeNetwork = true;
+        }
+        catch {
+            /* Node < 22 without the flag — keep the previous behavior */
+        }
         // Use a createRequire-built require() so LanceDB's CommonJS native bindings
         // keep Windows-safe CJS semantics while still working in pure ESM runtimes.
         // Do not name this binding "require": bundlers may rewrite bare require()
@@ -50,7 +65,11 @@ function clampInt(value, min, max) {
         return min;
     return Math.min(max, Math.max(min, Math.floor(value)));
 }
+const LEGACY_STABLE_MEMORY_ID_REGEX = /^[A-Za-z0-9][A-Za-z0-9._:-]{2,127}$/;
 const LEGACY_SECONDS_TIMESTAMP_MAX = 1_000_000_000_000;
+function isLegacyStableMemoryId(id) {
+    return LEGACY_STABLE_MEMORY_ID_REGEX.test(id);
+}
 export function normalizeMemoryTimestamp(value, fallback = Date.now()) {
     const raw = value instanceof Date
         ? value.getTime()
@@ -1704,20 +1723,19 @@ export class MemoryStore {
             throw new Error(`Memory ${id} is outside accessible scopes`);
         }
         return this.runWithFileLock(() => this.runSerializedUpdate(async () => {
-            // Support both full UUID and short prefix (8+ hex chars), same as delete()
-            // Also support legacy mem-md-N format from older memory-lancedb-pro versions
+            // Support full UUID, short hex prefixes, and constrained exact legacy IDs imported
+            // from older stores (for example "mem-md-..." or "data-pointer-...").
             const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
             const prefixRegex = /^[0-9a-f]{8,}$/i;
-            const legacyRegex = /^mem-md-\d+$/i;
             const isFullId = uuidRegex.test(id);
             const isPrefix = !isFullId && prefixRegex.test(id);
-            const isLegacy = !isFullId && !isPrefix && legacyRegex.test(id);
-            if (!isFullId && !isPrefix && !isLegacy) {
+            const isLegacyStableId = !isFullId && !isPrefix && isLegacyStableMemoryId(id);
+            if (!isFullId && !isPrefix && !isLegacyStableId) {
                 throw new Error(`Invalid memory ID format: ${id}`);
             }
             let rows;
-            if (isFullId || isLegacy) {
-                // Legacy IDs use exact string match like full UUIDs
+            if (isFullId || isLegacyStableId) {
+                // Legacy IDs use exact string match like full UUIDs.
                 const safeId = escapeSqlLiteral(id);
                 rows = await this.table.query()
                     .where(`id = '${safeId}'`)

--- a/index.ts
+++ b/index.ts
@@ -5,9 +5,9 @@
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { homedir, tmpdir } from "node:os";
-import { join, dirname, basename, win32 as winPath } from "node:path";
+import { join, dirname, basename, resolve, win32 as winPath } from "node:path";
 import { readFile, readdir, writeFile, mkdir, appendFile, unlink, stat } from "node:fs/promises";
-import { readFileSync } from "node:fs";
+import { readFileSync, appendFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
@@ -3232,6 +3232,39 @@ const memoryLanceDBProPlugin = {
               `memory-lancedb-pro: auto-recall skipped injection after budgeting (hits=${results.length}, dedupFiltered=${dedupFilteredCount}, maxItems=${autoRecallMaxItems}, maxChars=${autoRecallMaxChars})`,
             );
             return;
+          }
+
+          // [PATCH 2026-06-10] emit memory.recall.recorded for memory-core dreaming pipeline.
+          // Append a JSONL record per injected recall turn to memory/.dreams/events.jsonl so
+          // memory-core's dreaming short-term promotion can count recalls per entry. Failures
+          // here must never break the recall path, so wrap in try/catch and downgrade to debug.
+          try {
+            const selectedIds = new Set(selected.map((it) => it.id));
+            const emittedResults = results
+              .filter((r) => selectedIds.has(r.entry.id))
+              .map((r) => ({
+                path: typeof r.entry.path === "string" ? r.entry.path : "",
+                startLine: Number(r.entry.startLine) || 0,
+                endLine: Number(r.entry.endLine) || 0,
+                score: Number(r.score) || 0,
+              }));
+            const emittedEvent = {
+              type: "memory.recall.recorded",
+              timestamp: new Date().toISOString(),
+              query: String(recallQuery || ""),
+              resultCount: emittedResults.length,
+              results: emittedResults,
+            };
+            const workspaceRoot =
+              typeof api.resolvePath === "function"
+                ? api.resolvePath(".")
+                : resolve(process.cwd());
+            const eventLogPath = join(workspaceRoot, "memory", ".dreams", "events.jsonl");
+            appendFileSync(eventLogPath, JSON.stringify(emittedEvent) + "\n", "utf8");
+          } catch (emitErr) {
+            api.logger.debug?.(
+              "memory-lancedb-pro: failed to emit memory.recall.recorded: " + String(emitErr),
+            );
           }
 
           if (shouldDropLateAutoRecall("pre-metadata")) return;

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -208,7 +208,7 @@ function createApiKeyClient(config: LlmClientConfig, log: (msg: string) => void,
             {
               role: "system",
               content:
-                "You are a memory extraction assistant. Always respond with valid JSON only.",
+                "You are a memory extraction assistant. Always respond with valid JSON only. /no_think",
             },
             { role: "user", content: prompt },
           ],


### PR DESCRIPTION
- index.ts: after auto-recall budget selection, emit a memory.recall.recorded JSONL event to memory/.dreams/events.jsonl (per entry path/startLine/endLine/score). This lets memory-core's dreaming short-term promotion count recalls and qualify entries for promotion into MEMORY.md. Wrapped in try/catch and downgraded to debug so failures never break the recall path. [PATCH 2026-06-10, promoted from dist-only hot-patch to src]

- src/llm-client.ts: append /no_think to the memory extraction system prompt in createApiKeyClient to cut reasoning token overhead on cheap JSON-only completions.

- dist/*: rebuilt via tsc. Includes rerank rerankTopN clamp (PR #856 territory) and loadLanceDB process.report.excludeNetwork guard (PR #875) that previously lived in src/ but were not reflected in the prior dist build.

Three .bak snapshot files under dist/ are intentionally left untracked (not part of this commit).