### PR TITLE
Add an optional model override for memoryReflection

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1173,7 +1173,8 @@ async function generateReflectionText(params) {
                 const modelRefFromConfig = llmConfig?.model;
                 // Model resolution chain: agent-specific primary model ref > global llm.model fallback.
                 // The typeof guard ensures a non-string value (e.g. number) does not reach splitProviderModel as-is.
-                const modelRef = resolveAgentPrimaryModelRef(params.cfg, params.agentId)
+                const modelRef = params.model
+                    ?? resolveAgentPrimaryModelRef(params.cfg, params.agentId)
                     ?? (typeof modelRefFromConfig === "string" ? modelRefFromConfig : undefined);
                 // Provider resolution chain: parsed from modelRef (e.g. "minimax/MiniMax-M2.7") > inferred from baseURL.
                 // inferProviderFromBaseURL uses .endsWith(".suffix") to prevent subdomain spoofing.
@@ -3320,6 +3321,7 @@ const memoryLanceDBProPlugin = {
             const reflectionTimeoutMs = config.memoryReflection?.timeoutMs ?? DEFAULT_REFLECTION_TIMEOUT_MS;
             const reflectionThinkLevel = config.memoryReflection?.thinkLevel ?? DEFAULT_REFLECTION_THINK_LEVEL;
             const reflectionAgentId = asNonEmptyString(config.memoryReflection?.agentId);
+            const reflectionModel = asNonEmptyString(config.memoryReflection?.model);
             const reflectionErrorReminderMaxEntries = parsePositiveInt(config.memoryReflection?.errorReminderMaxEntries) ?? DEFAULT_REFLECTION_ERROR_REMINDER_MAX_ENTRIES;
             const reflectionDedupeErrorSignals = config.memoryReflection?.dedupeErrorSignals !== false;
             const reflectionInjectMode = config.memoryReflection?.injectMode ?? "inheritance+derived";
@@ -3665,6 +3667,7 @@ const memoryLanceDBProPlugin = {
                         maxInputChars: reflectionMaxInputChars,
                         cfg,
                         agentId: reflectionRunAgentId,
+                        model: reflectionModel,
                         workspaceDir,
                         timeoutMs: reflectionTimeoutMs,
                         thinkLevel: reflectionThinkLevel,
@@ -4572,6 +4575,7 @@ export function parsePluginConfig(value) {
                 writeLegacyCombined: memoryReflectionRaw.writeLegacyCombined === true,
                 injectMode: reflectionInjectMode,
                 agentId: asNonEmptyString(memoryReflectionRaw.agentId),
+                model: asNonEmptyString(memoryReflectionRaw.model),
                 messageCount: reflectionMessageCount,
                 maxInputChars: parsePositiveInt(memoryReflectionRaw.maxInputChars) ?? DEFAULT_REFLECTION_MAX_INPUT_CHARS,
                 timeoutMs: parsePositiveInt(memoryReflectionRaw.timeoutMs) ?? DEFAULT_REFLECTION_TIMEOUT_MS,

--- a/index.ts
+++ b/index.ts
@@ -277,6 +277,7 @@ interface PluginConfig {
     writeLegacyCombined?: boolean;
     injectMode?: ReflectionInjectMode;
     agentId?: string;
+    model?: string;
     messageCount?: number;
     maxInputChars?: number;
     timeoutMs?: number;
@@ -1592,6 +1593,7 @@ async function generateReflectionText(params: {
   maxInputChars: number;
   cfg: unknown;
   agentId: string;
+  model?: string;
   workspaceDir: string;
   timeoutMs: number;
   thinkLevel: ReflectionThinkLevel;
@@ -1632,7 +1634,8 @@ async function generateReflectionText(params: {
         // Model resolution chain: agent-specific primary model ref > global llm.model fallback.
         // The typeof guard ensures a non-string value (e.g. number) does not reach splitProviderModel as-is.
         const modelRef =
-          (resolveAgentPrimaryModelRef(params.cfg, params.agentId) as string | undefined)
+          params.model
+          ?? (resolveAgentPrimaryModelRef(params.cfg, params.agentId) as string | undefined)
           ?? (typeof modelRefFromConfig === "string" ? modelRefFromConfig : undefined);
 
         // Provider resolution chain: parsed from modelRef (e.g. "minimax/MiniMax-M2.7") > inferred from baseURL.
@@ -4320,6 +4323,7 @@ const memoryLanceDBProPlugin = {
       const reflectionTimeoutMs = config.memoryReflection?.timeoutMs ?? DEFAULT_REFLECTION_TIMEOUT_MS;
       const reflectionThinkLevel = config.memoryReflection?.thinkLevel ?? DEFAULT_REFLECTION_THINK_LEVEL;
       const reflectionAgentId = asNonEmptyString(config.memoryReflection?.agentId);
+      const reflectionModel = asNonEmptyString(config.memoryReflection?.model);
       const reflectionErrorReminderMaxEntries =
         parsePositiveInt(config.memoryReflection?.errorReminderMaxEntries) ?? DEFAULT_REFLECTION_ERROR_REMINDER_MAX_ENTRIES;
       const reflectionDedupeErrorSignals = config.memoryReflection?.dedupeErrorSignals !== false;
@@ -4705,6 +4709,7 @@ const memoryLanceDBProPlugin = {
             maxInputChars: reflectionMaxInputChars,
             cfg,
             agentId: reflectionRunAgentId,
+            model: reflectionModel,
             workspaceDir,
             timeoutMs: reflectionTimeoutMs,
             thinkLevel: reflectionThinkLevel,
@@ -5758,6 +5763,7 @@ export function parsePluginConfig(value: unknown): PluginConfig {
         writeLegacyCombined: memoryReflectionRaw.writeLegacyCombined === true,
         injectMode: reflectionInjectMode,
         agentId: asNonEmptyString(memoryReflectionRaw.agentId),
+        model: asNonEmptyString(memoryReflectionRaw.model),
         messageCount: reflectionMessageCount,
         maxInputChars: parsePositiveInt(memoryReflectionRaw.maxInputChars) ?? DEFAULT_REFLECTION_MAX_INPUT_CHARS,
         timeoutMs: parsePositiveInt(memoryReflectionRaw.timeoutMs) ?? DEFAULT_REFLECTION_TIMEOUT_MS,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1398,6 +1398,10 @@
             "type": "string",
             "description": "Optional dedicated agent id used to run reflection generation (for example: memory-distiller)."
           },
+          "model": {
+            "type": "string",
+            "description": "Optional provider/model override used to generate the reflection. Falls back to the reflection agent's primary model, then the plugin llm.model."
+          },
           "messageCount": {
             "type": "integer",
             "minimum": 1,
@@ -2181,6 +2185,12 @@
     "memoryReflection.agentId": {
       "label": "Reflection Agent Id",
       "help": "Optional dedicated agent id used for reflection generation (e.g. memory-distiller)",
+      "advanced": true
+    },
+    "memoryReflection.model": {
+      "label": "Reflection Model",
+      "placeholder": "anthropic/claude-sonnet-4-6",
+      "help": "Optional provider/model override for reflection generation. Falls back to the reflection agent's primary model, then llm.model.",
       "advanced": true
     },
     "memoryReflection.messageCount": {

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -241,6 +241,25 @@ assert.ok(
   (manifest.commandAliases ?? []).some((entry) => entry?.name === "dreaming"),
   "manifest should expose the dreaming runtime slash command alias while owning the memory slot",
 );
+assert.equal(
+  manifest.configSchema.properties.memoryReflection.properties.model.type,
+  "string",
+  "memoryReflection should expose an optional model override knob",
+);
+assert.equal(
+  manifest.configSchema.properties.memoryReflection.additionalProperties,
+  false,
+  "memoryReflection schema should continue to reject unknown keys after adding model",
+);
+assert.ok(
+  Object.prototype.hasOwnProperty.call(manifest.uiHints, "memoryReflection.model"),
+  "uiHints should expose the reflection model override",
+);
+assert.ok(
+  !Array.isArray(manifest.configSchema.properties.memoryReflection.required)
+    || !manifest.configSchema.properties.memoryReflection.required.includes("model"),
+  "memoryReflection.model must stay optional so omitting it preserves the existing default model resolution",
+);
 
 assert.equal(
   manifest.version,


### PR DESCRIPTION
## Problem

`memoryReflection` generates a session-background reflection on reset, but there is no way to choose which model performs that generation. It resolves the model implicitly from the running agent's primary model, then falls back to the host's global default when no `memoryReflection.agentId` is set.

For deployments whose global default is a router alias (for example an `auto` routing model), every reflection is silently free-routed to whatever the router selects, instead of a deterministic, cost-appropriate model the operator chose. The plugin's own `llm.model` is shadowed by the agent-primary resolution, so today there is no config path to control the reflection model. The schema is also `additionalProperties: false`, so `model` cannot even be set as a passthrough; it is rejected at validation.

This is a consistency gap rather than a new idea: the sibling `memoryFlush` already exposes a `model` option, and the dreaming engine reserves `dreaming.model`. `memoryReflection` is the only one of the three with no override.

## Change

Add a `memoryReflection.model` knob that takes precedence at the front of the existing resolution chain, ahead of the agent-primary and `llm.model` fallbacks. Fully opt-in and backward compatible: when unset, resolution is unchanged.

- `openclaw.plugin.json`: declare `memoryReflection.model` (string) inside the existing `additionalProperties: false` block, plus a `uiHints` entry mirroring `memoryReflection.agentId` and `dreaming.model`.
- `index.ts`: thread the value through the config type, config normalization, the reflection read site, the `generateReflectionText` call, and the `modelRef` resolution chain.
- `test/plugin-manifest-regression.mjs`: assert the new knob is present with type string, that the schema still rejects unknown keys, and that the `uiHints` entry exists.

## Resolution precedence

`memoryReflection.model`, then `resolveAgentPrimaryModelRef(...)`, then the `llm.model` fallback. If both `memoryReflection.model` and `memoryReflection.agentId` are set, the configured model wins for model selection while `agentId` still selects which agent runs the reflection. This matches the precedence and semantics of `memoryFlush.model`.

## Testing

- `npm run build` (tsc) passes.
- `node test/plugin-manifest-regression.mjs` passes, including the new assertions.
- Config normalization verified on the built output: `memoryReflection.model` set survives `parsePluginConfig` into the parsed config; absent or blank resolves to `undefined`.
- Live end to end: with `memoryReflection.model` pinned to a specific model, resetting an agent produced a reflection generation that resolved to the pinned model instead of the global default, running via the embedded runner with no fallback.
- The reflection suites show no new failures versus the same revision without this change (a few pre-existing failures in `writeLegacyCombined` / `sessionStrategy` default tests are unrelated to this PR).
