### PR TITLE
Trace embed_query as an operation stage

### DIFF
--- a/dist/src/retrieval-trace.js
+++ b/dist/src/retrieval-trace.js
@@ -16,13 +16,14 @@ export class TraceCollector {
      * @param name - Stage identifier (e.g. "vector_search")
      * @param entryIds - IDs of entries entering this stage
      */
-    startStage(name, entryIds) {
+    startStage(name, entryIds, kind = "pipeline") {
         // Auto-close any unclosed previous stage (defensive)
         if (this._pending) {
             this.endStage([...this._pending.inputIds]);
         }
         this._pending = {
             name,
+            kind,
             inputIds: new Set(entryIds),
             startTime: Date.now(),
         };
@@ -35,7 +36,7 @@ export class TraceCollector {
     endStage(survivingIds, scores) {
         if (!this._pending)
             return;
-        const { name, inputIds, startTime } = this._pending;
+        const { name, kind, inputIds, startTime } = this._pending;
         const survivingSet = new Set(survivingIds);
         const droppedIds = [];
         for (const id of inputIds) {
@@ -57,6 +58,7 @@ export class TraceCollector {
         }
         this._stages.push({
             name,
+            kind,
             inputCount: inputIds.size,
             outputCount: survivingIds.length,
             droppedIds,
@@ -90,6 +92,10 @@ export class TraceCollector {
         const lines = [];
         lines.push(`Retrieval trace (${this._stages.length} stages):`);
         for (const stage of this._stages) {
+            if (stage.kind === "operation") {
+                lines.push(`  ${stage.name}: completed ${stage.durationMs}ms`);
+                continue;
+            }
             const dropped = stage.inputCount - stage.outputCount;
             const scoreStr = stage.scoreRange
                 ? ` scores=[${stage.scoreRange[0].toFixed(3)}, ${stage.scoreRange[1].toFixed(3)}]`

--- a/dist/src/retriever.js
+++ b/dist/src/retriever.js
@@ -479,7 +479,9 @@ export class MemoryRetriever {
         let failureStage = "vector.embedQuery";
         try {
             const candidatePoolSize = Math.max(this.config.candidatePoolSize, limit * 2);
+            trace?.startStage("embed_query", [], "operation");
             const queryVector = await this.embedder.embedQuery(query, signal);
+            trace?.endStage([]);
             failureStage = "vector.vectorSearch";
             const results = await this.store.vectorSearch(queryVector, candidatePoolSize, this.config.minScore, scopeFilter, { excludeInactive: true });
             const filtered = category
@@ -632,7 +634,9 @@ export class MemoryRetriever {
         let failureStage = "hybrid.embedQuery";
         try {
             const candidatePoolSize = Math.max(this.config.candidatePoolSize, limit * 2);
+            trace?.startStage("embed_query", [], "operation");
             const queryVector = await this.embedder.embedQuery(query, signal);
+            trace?.endStage([]);
             const bm25Query = this.buildBM25Query(query, source);
             if (diagnostics) {
                 diagnostics.bm25Query = bm25Query;

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -1643,6 +1643,10 @@ export function registerMemoryDebugTool(api, context) {
                         `  Stages:`,
                     ];
                     for (const stage of trace.stages) {
+                        if (stage.kind === "operation") {
+                            traceLines.push(`    ${stage.name}: completed ${stage.durationMs}ms`);
+                            continue;
+                        }
                         const dropped = Math.max(0, stage.inputCount - stage.outputCount);
                         const scoreStr = stage.scoreRange
                             ? ` scores=[${stage.scoreRange[0].toFixed(3)}, ${stage.scoreRange[1].toFixed(3)}]`

--- a/src/retrieval-trace.ts
+++ b/src/retrieval-trace.ts
@@ -12,6 +12,8 @@
 export interface RetrievalStageResult {
   /** Stage name, e.g. "vector_search", "bm25_search", "rrf_fusion" */
   name: string;
+  /** Stage kind. Operation stages measure work that does not transform entries. */
+  kind?: "pipeline" | "operation";
   /** Number of entries entering this stage */
   inputCount: number;
   /** Number of entries surviving this stage */
@@ -45,6 +47,7 @@ export interface RetrievalTrace {
 
 interface PendingStage {
   name: string;
+  kind: "pipeline" | "operation";
   inputIds: Set<string>;
   startTime: number;
 }
@@ -63,13 +66,18 @@ export class TraceCollector {
    * @param name - Stage identifier (e.g. "vector_search")
    * @param entryIds - IDs of entries entering this stage
    */
-  startStage(name: string, entryIds: string[]): void {
+  startStage(
+    name: string,
+    entryIds: string[],
+    kind: "pipeline" | "operation" = "pipeline",
+  ): void {
     // Auto-close any unclosed previous stage (defensive)
     if (this._pending) {
       this.endStage([...this._pending.inputIds]);
     }
     this._pending = {
       name,
+      kind,
       inputIds: new Set(entryIds),
       startTime: Date.now(),
     };
@@ -83,7 +91,7 @@ export class TraceCollector {
   endStage(survivingIds: string[], scores?: number[]): void {
     if (!this._pending) return;
 
-    const { name, inputIds, startTime } = this._pending;
+    const { name, kind, inputIds, startTime } = this._pending;
     const survivingSet = new Set(survivingIds);
 
     const droppedIds: string[] = [];
@@ -106,6 +114,7 @@ export class TraceCollector {
 
     this._stages.push({
       name,
+      kind,
       inputCount: inputIds.size,
       outputCount: survivingIds.length,
       droppedIds,
@@ -143,6 +152,10 @@ export class TraceCollector {
     const lines: string[] = [];
     lines.push(`Retrieval trace (${this._stages.length} stages):`);
     for (const stage of this._stages) {
+      if (stage.kind === "operation") {
+        lines.push(`  ${stage.name}: completed ${stage.durationMs}ms`);
+        continue;
+      }
       const dropped = stage.inputCount - stage.outputCount;
       const scoreStr = stage.scoreRange
         ? ` scores=[${stage.scoreRange[0].toFixed(3)}, ${stage.scoreRange[1].toFixed(3)}]`

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -811,7 +811,9 @@ export class MemoryRetriever {
     let failureStage: RetrievalDiagnostics["failureStage"] = "vector.embedQuery";
     try {
       const candidatePoolSize = Math.max(this.config.candidatePoolSize, limit * 2);
+      trace?.startStage("embed_query", [], "operation");
       const queryVector = await this.embedder.embedQuery(query, signal);
+      trace?.endStage([]);
       failureStage = "vector.vectorSearch";
       const results = await this.store.vectorSearch(
         queryVector,
@@ -1004,7 +1006,9 @@ export class MemoryRetriever {
     let failureStage: RetrievalDiagnostics["failureStage"] = "hybrid.embedQuery";
     try {
       const candidatePoolSize = Math.max(this.config.candidatePoolSize, limit * 2);
+      trace?.startStage("embed_query", [], "operation");
       const queryVector = await this.embedder.embedQuery(query, signal);
+      trace?.endStage([]);
       const bm25Query = this.buildBM25Query(query, source);
       if (diagnostics) {
         diagnostics.bm25Query = bm25Query;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2123,6 +2123,12 @@ export function registerMemoryDebugTool(
               `  Stages:`,
             ];
             for (const stage of trace.stages) {
+              if (stage.kind === "operation") {
+                traceLines.push(
+                  `    ${stage.name}: completed ${stage.durationMs}ms`,
+                );
+                continue;
+              }
               const dropped = Math.max(0, stage.inputCount - stage.outputCount);
               const scoreStr = stage.scoreRange
                 ? ` scores=[${stage.scoreRange[0].toFixed(3)}, ${stage.scoreRange[1].toFixed(3)}]`

--- a/test/retrieval-trace.test.mjs
+++ b/test/retrieval-trace.test.mjs
@@ -68,6 +68,19 @@ describe("TraceCollector", () => {
     assert.equal(trace.finalCount, 0);
   });
 
+  it("tracks operation-only stages", () => {
+    const tc = new TraceCollector();
+    tc.startStage("embed_query", [], "operation");
+    tc.endStage([]);
+
+    const trace = tc.finalize("q", "hybrid");
+    assert.equal(trace.stages[0].name, "embed_query");
+    assert.equal(trace.stages[0].kind, "operation");
+    assert.equal(trace.stages[0].inputCount, 0);
+    assert.equal(trace.stages[0].outputCount, 0);
+    assert.ok(tc.summarize().includes("embed_query: completed"));
+  });
+
   it("auto-closes unclosed stage on finalize", () => {
     const tc = new TraceCollector();
     tc.startStage("vector_search", ["a", "b"]);


### PR DESCRIPTION
## What Problem This Solves

`memory_debug` trace output currently does not show time spent in `embedder.embedQuery()`, so expensive query embedding time is hidden inside vector/hybrid retrieval.

## Changes

- Add operation-only trace stages via `TraceCollector.startStage(name, ids, "operation")`.
- Wrap vector and hybrid `embedder.embedQuery(query, signal)` with an `embed_query` operation stage.
- Format operation stages as `embed_query: completed <ms>` instead of entry counts.
- Add focused TraceCollector coverage and rebuild dist outputs.

## Validation

- `npm run build`
- `node --test test/retrieval-trace.test.mjs`