### PR TITLE
fix: run memory reflections in per-agent lanes with a bounded concurrency cap

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -359,6 +359,7 @@ const DEFAULT_REFLECTION_MESSAGE_COUNT = 120;
 const DEFAULT_REFLECTION_MAX_INPUT_CHARS = 24_000;
 const DEFAULT_REFLECTION_TIMEOUT_MS = 20_000;
 const DEFAULT_REFLECTION_THINK_LEVEL = "medium";
+const DEFAULT_REFLECTION_MAX_CONCURRENT_RUNS = 1;
 const DEFAULT_REFLECTION_ERROR_REMINDER_MAX_ENTRIES = 3;
 const DEFAULT_REFLECTION_DEDUPE_ERROR_SIGNALS = true;
 const DEFAULT_REFLECTION_SESSION_TTL_MS = 30 * 60 * 1000;
@@ -1147,7 +1148,47 @@ function buildReflectionFallbackText() {
         "- Investigate why embedded reflection generation failed before trusting any next-run delta.",
     ].join("\n");
 }
-async function generateReflectionText(params) {
+const REFLECTION_RUN_SLOTS = Symbol.for("openclaw.memory-lancedb-pro.reflection-run-slots");
+const getReflectionRunSlotState = () => {
+    const g = globalThis;
+    if (!g[REFLECTION_RUN_SLOTS])
+        g[REFLECTION_RUN_SLOTS] = { active: 0, waiters: [] };
+    return g[REFLECTION_RUN_SLOTS];
+};
+// Waiting for a slot happens BEFORE the run's timeout clock starts, so a queued
+// reflection never burns its deadline waiting in line (the failure mode of the
+// old single shared "temp:memory-reflection" lane under concurrent bursts).
+export async function acquireReflectionRunSlot(maxConcurrentRuns) {
+    const state = getReflectionRunSlotState();
+    const max = Math.max(1, Math.floor(maxConcurrentRuns ?? DEFAULT_REFLECTION_MAX_CONCURRENT_RUNS) || 1);
+    if (state.active < max) {
+        state.active += 1;
+    }
+    else {
+        await new Promise((resolve) => state.waiters.push(resolve));
+    }
+    let released = false;
+    return () => {
+        if (released)
+            return;
+        released = true;
+        const next = state.waiters.shift();
+        if (next)
+            next();
+        else
+            state.active -= 1;
+    };
+}
+export async function generateReflectionText(params) {
+    const releaseRunSlot = await acquireReflectionRunSlot(params.maxConcurrentRuns);
+    try {
+        return await generateReflectionTextUnbounded(params);
+    }
+    finally {
+        releaseRunSlot();
+    }
+}
+async function generateReflectionTextUnbounded(params) {
     const prompt = buildReflectionPrompt(params.conversation, params.maxInputChars, params.toolErrorSignals ?? []);
     const promptHash = sha256Hex(prompt);
     const tempSessionFile = join(tmpdir(), `memory-reflection-${Date.now()}-${Math.random().toString(36).slice(2)}.jsonl`);
@@ -1184,7 +1225,7 @@ async function generateReflectionText(params) {
                 const embeddedTimeoutMs = Math.max(params.timeoutMs + 5000, 15000);
                 return await withTimeout(runEmbeddedPiAgent({
                     sessionId: `reflection-${Date.now()}`,
-                    sessionKey: "temp:memory-reflection",
+                    sessionKey: `temp:memory-reflection:${params.agentId}`,
                     agentId: params.agentId,
                     sessionFile: tempSessionFile,
                     workspaceDir: params.workspaceDir,
@@ -3320,6 +3361,7 @@ const memoryLanceDBProPlugin = {
             const reflectionMaxInputChars = config.memoryReflection?.maxInputChars ?? DEFAULT_REFLECTION_MAX_INPUT_CHARS;
             const reflectionTimeoutMs = config.memoryReflection?.timeoutMs ?? DEFAULT_REFLECTION_TIMEOUT_MS;
             const reflectionThinkLevel = config.memoryReflection?.thinkLevel ?? DEFAULT_REFLECTION_THINK_LEVEL;
+            const reflectionMaxConcurrentRuns = config.memoryReflection?.maxConcurrentRuns ?? DEFAULT_REFLECTION_MAX_CONCURRENT_RUNS;
             const reflectionAgentId = asNonEmptyString(config.memoryReflection?.agentId);
             const reflectionModel = asNonEmptyString(config.memoryReflection?.model);
             const reflectionErrorReminderMaxEntries = parsePositiveInt(config.memoryReflection?.errorReminderMaxEntries) ?? DEFAULT_REFLECTION_ERROR_REMINDER_MAX_ENTRIES;
@@ -3671,6 +3713,7 @@ const memoryLanceDBProPlugin = {
                         workspaceDir,
                         timeoutMs: reflectionTimeoutMs,
                         thinkLevel: reflectionThinkLevel,
+                        maxConcurrentRuns: reflectionMaxConcurrentRuns,
                         toolErrorSignals,
                         logger: api.logger,
                         api, // SDK migration Bug 2: pass api for new runtime.agent API
@@ -4588,6 +4631,7 @@ export function parsePluginConfig(value) {
                 errorReminderMaxEntries: parsePositiveInt(memoryReflectionRaw.errorReminderMaxEntries) ?? DEFAULT_REFLECTION_ERROR_REMINDER_MAX_ENTRIES,
                 dedupeErrorSignals: memoryReflectionRaw.dedupeErrorSignals !== false,
                 serialCooldownMs: parsePositiveInt(memoryReflectionRaw.serialCooldownMs) ?? DEFAULT_SERIAL_GUARD_COOLDOWN_MS,
+                maxConcurrentRuns: parsePositiveInt(memoryReflectionRaw.maxConcurrentRuns) ?? DEFAULT_REFLECTION_MAX_CONCURRENT_RUNS,
                 excludeAgents: Array.isArray(memoryReflectionRaw.excludeAgents)
                     ? memoryReflectionRaw.excludeAgents.filter((id) => typeof id === "string" && id.trim() !== "")
                     : undefined,
@@ -4605,6 +4649,7 @@ export function parsePluginConfig(value) {
                 errorReminderMaxEntries: DEFAULT_REFLECTION_ERROR_REMINDER_MAX_ENTRIES,
                 dedupeErrorSignals: DEFAULT_REFLECTION_DEDUPE_ERROR_SIGNALS,
                 serialCooldownMs: DEFAULT_SERIAL_GUARD_COOLDOWN_MS,
+                maxConcurrentRuns: DEFAULT_REFLECTION_MAX_CONCURRENT_RUNS,
                 excludeAgents: undefined,
             },
         sessionMemory: typeof cfg.sessionMemory === "object" && cfg.sessionMemory !== null

--- a/index.ts
+++ b/index.ts
@@ -286,6 +286,8 @@ interface PluginConfig {
     dedupeErrorSignals?: boolean;
     /** Cooldown in ms between reflection triggers for the same session. Default: 120000 (2 min). Set to 0 to disable. */
     serialCooldownMs?: number;
+    /** Max concurrent reflection runs across all agents. Default: 1 (fully serialized, matching the previous behavior). Raise to let agents reflect in parallel. */
+    maxConcurrentRuns?: number;
     /** Agent/session patterns excluded from reflection injection. Supports exact match, wildcard prefix (e.g. "pi-"), and "temp:*". */
     excludeAgents?: string[];
   };
@@ -706,6 +708,7 @@ const DEFAULT_REFLECTION_MESSAGE_COUNT = 120;
 const DEFAULT_REFLECTION_MAX_INPUT_CHARS = 24_000;
 const DEFAULT_REFLECTION_TIMEOUT_MS = 20_000;
 const DEFAULT_REFLECTION_THINK_LEVEL: ReflectionThinkLevel = "medium";
+const DEFAULT_REFLECTION_MAX_CONCURRENT_RUNS = 1;
 const DEFAULT_REFLECTION_ERROR_REMINDER_MAX_ENTRIES = 3;
 const DEFAULT_REFLECTION_DEDUPE_ERROR_SIGNALS = true;
 const DEFAULT_REFLECTION_SESSION_TTL_MS = 30 * 60 * 1000;
@@ -1588,7 +1591,7 @@ function buildReflectionFallbackText(): string {
   ].join("\n");
 }
 
-async function generateReflectionText(params: {
+type GenerateReflectionTextParams = {
   conversation: string;
   maxInputChars: number;
   cfg: unknown;
@@ -1597,10 +1600,64 @@ async function generateReflectionText(params: {
   workspaceDir: string;
   timeoutMs: number;
   thinkLevel: ReflectionThinkLevel;
+  maxConcurrentRuns?: number;
   toolErrorSignals?: ReflectionErrorSignal[];
   logger?: { info?: (message: string) => void; warn?: (message: string) => void };
   api: OpenClawPluginApi;  // SDK migration Bug 2: pass api to use new runtime.agent API
-}): Promise<{ text: string; usedFallback: boolean; promptHash: string; error?: string; runner: "embedded" | "cli" | "fallback" }> {
+};
+
+type GenerateReflectionTextResult = {
+  text: string;
+  usedFallback: boolean;
+  promptHash: string;
+  error?: string;
+  runner: "embedded" | "cli" | "fallback";
+};
+
+type ReflectionRunSlotState = { active: number; waiters: Array<() => void> };
+
+const REFLECTION_RUN_SLOTS = Symbol.for("openclaw.memory-lancedb-pro.reflection-run-slots");
+const getReflectionRunSlotState = (): ReflectionRunSlotState => {
+  const g = globalThis as Record<symbol, unknown>;
+  if (!g[REFLECTION_RUN_SLOTS]) g[REFLECTION_RUN_SLOTS] = { active: 0, waiters: [] };
+  return g[REFLECTION_RUN_SLOTS] as ReflectionRunSlotState;
+};
+
+// Waiting for a slot happens BEFORE the run's timeout clock starts, so a queued
+// reflection never burns its deadline waiting in line (the failure mode of the
+// old single shared "temp:memory-reflection" lane under concurrent bursts).
+export async function acquireReflectionRunSlot(maxConcurrentRuns?: number): Promise<() => void> {
+  const state = getReflectionRunSlotState();
+  const max = Math.max(1, Math.floor(maxConcurrentRuns ?? DEFAULT_REFLECTION_MAX_CONCURRENT_RUNS) || 1);
+  if (state.active < max) {
+    state.active += 1;
+  } else {
+    await new Promise<void>((resolve) => state.waiters.push(resolve));
+  }
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const next = state.waiters.shift();
+    if (next) next();
+    else state.active -= 1;
+  };
+}
+
+export async function generateReflectionText(
+  params: GenerateReflectionTextParams
+): Promise<GenerateReflectionTextResult> {
+  const releaseRunSlot = await acquireReflectionRunSlot(params.maxConcurrentRuns);
+  try {
+    return await generateReflectionTextUnbounded(params);
+  } finally {
+    releaseRunSlot();
+  }
+}
+
+async function generateReflectionTextUnbounded(
+  params: GenerateReflectionTextParams
+): Promise<GenerateReflectionTextResult> {
   const prompt = buildReflectionPrompt(
     params.conversation,
     params.maxInputChars,
@@ -1648,7 +1705,7 @@ async function generateReflectionText(params: {
         return await withTimeout(
           runEmbeddedPiAgent({
             sessionId: `reflection-${Date.now()}`,
-            sessionKey: "temp:memory-reflection",
+            sessionKey: `temp:memory-reflection:${params.agentId}`,
             agentId: params.agentId,
             sessionFile: tempSessionFile,
             workspaceDir: params.workspaceDir,
@@ -4322,6 +4379,7 @@ const memoryLanceDBProPlugin = {
       const reflectionMaxInputChars = config.memoryReflection?.maxInputChars ?? DEFAULT_REFLECTION_MAX_INPUT_CHARS;
       const reflectionTimeoutMs = config.memoryReflection?.timeoutMs ?? DEFAULT_REFLECTION_TIMEOUT_MS;
       const reflectionThinkLevel = config.memoryReflection?.thinkLevel ?? DEFAULT_REFLECTION_THINK_LEVEL;
+      const reflectionMaxConcurrentRuns = config.memoryReflection?.maxConcurrentRuns ?? DEFAULT_REFLECTION_MAX_CONCURRENT_RUNS;
       const reflectionAgentId = asNonEmptyString(config.memoryReflection?.agentId);
       const reflectionModel = asNonEmptyString(config.memoryReflection?.model);
       const reflectionErrorReminderMaxEntries =
@@ -4713,6 +4771,7 @@ const memoryLanceDBProPlugin = {
             workspaceDir,
             timeoutMs: reflectionTimeoutMs,
             thinkLevel: reflectionThinkLevel,
+            maxConcurrentRuns: reflectionMaxConcurrentRuns,
             toolErrorSignals,
             logger: api.logger,
             api,  // SDK migration Bug 2: pass api for new runtime.agent API
@@ -5775,6 +5834,7 @@ export function parsePluginConfig(value: unknown): PluginConfig {
         errorReminderMaxEntries: parsePositiveInt(memoryReflectionRaw.errorReminderMaxEntries) ?? DEFAULT_REFLECTION_ERROR_REMINDER_MAX_ENTRIES,
         dedupeErrorSignals: memoryReflectionRaw.dedupeErrorSignals !== false,
         serialCooldownMs: parsePositiveInt(memoryReflectionRaw.serialCooldownMs) ?? DEFAULT_SERIAL_GUARD_COOLDOWN_MS,
+        maxConcurrentRuns: parsePositiveInt(memoryReflectionRaw.maxConcurrentRuns) ?? DEFAULT_REFLECTION_MAX_CONCURRENT_RUNS,
         excludeAgents: Array.isArray(memoryReflectionRaw.excludeAgents)
           ? memoryReflectionRaw.excludeAgents.filter((id: unknown): id is string => typeof id === "string" && id.trim() !== "")
           : undefined,
@@ -5792,6 +5852,7 @@ export function parsePluginConfig(value: unknown): PluginConfig {
         errorReminderMaxEntries: DEFAULT_REFLECTION_ERROR_REMINDER_MAX_ENTRIES,
         dedupeErrorSignals: DEFAULT_REFLECTION_DEDUPE_ERROR_SIGNALS,
         serialCooldownMs: DEFAULT_SERIAL_GUARD_COOLDOWN_MS,
+        maxConcurrentRuns: DEFAULT_REFLECTION_MAX_CONCURRENT_RUNS,
         excludeAgents: undefined,
       },
     sessionMemory:

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1446,6 +1446,13 @@
             "minimum": 0,
             "description": "Cooldown in ms between reflection triggers for the same session. Default: 120000 (2 min). Set to 0 to disable."
           },
+          "maxConcurrentRuns": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 16,
+            "default": 1,
+            "description": "Max concurrent reflection runs across all agents. Defaults to 1, which keeps reflections fully serialized (the previous behavior) while per-agent lanes stop queued runs from burning their timeout budget. Raise to let agents reflect in parallel."
+          },
           "excludeAgents": {
             "type": "array",
             "items": {
@@ -2191,6 +2198,11 @@
       "label": "Reflection Model",
       "placeholder": "anthropic/claude-sonnet-4-6",
       "help": "Optional provider/model override for reflection generation. Falls back to the reflection agent's primary model, then llm.model.",
+      "advanced": true
+    },
+    "memoryReflection.maxConcurrentRuns": {
+      "label": "Reflection Max Concurrent Runs",
+      "help": "Max concurrent reflection runs across all agents (reflections queue in per-agent lanes). Default 1 keeps reflections serialized; raise to allow parallel reflections.",
       "advanced": true
     },
     "memoryReflection.messageCount": {

--- a/test/issue606_sdk-migration.test.mjs
+++ b/test/issue606_sdk-migration.test.mjs
@@ -57,9 +57,12 @@ describe("SDK Migration Bug 2 — static smoke tests", () => {
 
   it("generateReflectionText params include api field", () => {
     const content = readFileSync(INDEX_PATH, "utf-8");
-    // The params interface must include api: OpenClawPluginApi
-    const apiParamPattern = /api:\s*OpenClawPluginApi[^}]*\}\s*\)[\s\n]*:[\s\n]*Promise/;
+    // The params type must include api: OpenClawPluginApi
+    const apiParamPattern = /GenerateReflectionTextParams = \{[\s\S]*?api:\s*OpenClawPluginApi[\s\S]*?\n\};/;
     assert.match(content, apiParamPattern, "generateReflectionText params must include api: OpenClawPluginApi");
+    // and generateReflectionText must consume that params type and return a Promise
+    const signaturePattern = /generateReflectionText\([\s\n]*params:\s*GenerateReflectionTextParams[\s\n]*\)[\s\n]*:[\s\n]*Promise</;
+    assert.match(content, signaturePattern, "generateReflectionText must take GenerateReflectionTextParams and return a Promise");
   });
 
   it("generateReflectionText calls loadEmbeddedPiRunner with params.api", () => {

--- a/test/plugin-manifest-regression.mjs
+++ b/test/plugin-manifest-regression.mjs
@@ -260,6 +260,25 @@ assert.ok(
     || !manifest.configSchema.properties.memoryReflection.required.includes("model"),
   "memoryReflection.model must stay optional so omitting it preserves the existing default model resolution",
 );
+assert.equal(
+  manifest.configSchema.properties.memoryReflection.properties.maxConcurrentRuns.type,
+  "integer",
+  "memoryReflection should expose the maxConcurrentRuns concurrency cap knob",
+);
+assert.equal(
+  manifest.configSchema.properties.memoryReflection.properties.maxConcurrentRuns.minimum,
+  1,
+  "maxConcurrentRuns minimum of 1 keeps the fully serialized escape hatch",
+);
+assert.ok(
+  Object.prototype.hasOwnProperty.call(manifest.uiHints, "memoryReflection.maxConcurrentRuns"),
+  "uiHints should expose the reflection concurrency cap",
+);
+assert.ok(
+  !Array.isArray(manifest.configSchema.properties.memoryReflection.required)
+    || !manifest.configSchema.properties.memoryReflection.required.includes("maxConcurrentRuns"),
+  "memoryReflection.maxConcurrentRuns must stay optional",
+);
 
 assert.equal(
   manifest.version,

--- a/test/reflection-per-agent-lane.test.mjs
+++ b/test/reflection-per-agent-lane.test.mjs
@@ -1,0 +1,231 @@
+// Per-agent reflection lanes + bounded concurrency.
+//
+// The reflection embedded run used to hardcode sessionKey "temp:memory-reflection",
+// so every agent's reflection shared ONE serial host lane (session lanes default to
+// maxConcurrent 1). Under a concurrent-reflection burst (mass /reset across agents)
+// runs queued behind each other and burned their timeout budget waiting in the lane.
+//
+// The fix: a per-agent sessionKey ("temp:memory-reflection:<agentId>") so lanes are
+// independent, plus a plugin-side cap (memoryReflection.maxConcurrentRuns, default 1
+// = fully serialized, matching the previous behavior) acquired BEFORE the run's
+// timeout clock starts, so waiting for a slot never burns the deadline. Raising the
+// cap opts into parallel reflections across agents.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jitiFactory from "jiti";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginSdkStubPath = path.resolve(testDir, "helpers", "openclaw-plugin-sdk-stub.mjs");
+const jiti = jitiFactory(import.meta.url, {
+  interopDefault: true,
+  alias: {
+    "openclaw/plugin-sdk": pluginSdkStubPath,
+  },
+});
+
+const {
+  generateReflectionText,
+  acquireReflectionRunSlot,
+  parsePluginConfig,
+  isAgentOrSessionExcluded,
+} = jiti("../index.ts");
+
+// loadEmbeddedPiRunner caches the first Layer-1 runner it resolves module-wide,
+// so every test shares ONE fake api and swaps behavior via this dispatcher.
+let currentRunnerImpl = async () => ({ payloads: [{ text: "noop" }] });
+const fakeApi = {
+  runtime: {
+    agent: {
+      runEmbeddedPiAgent: (params) => currentRunnerImpl(params),
+    },
+  },
+};
+
+const baseParams = {
+  conversation: "user: hello\nassistant: hi",
+  maxInputChars: 1000,
+  cfg: {},
+  workspaceDir: "/tmp",
+  timeoutMs: 2000,
+  thinkLevel: "off",
+  api: fakeApi,
+};
+
+function tick() {
+  return new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+async function waitFor(cond, timeoutMs = 5000) {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+describe("per-agent reflection lane", () => {
+  it("passes a per-agent sessionKey to the embedded runner", async () => {
+    const seenKeys = [];
+    currentRunnerImpl = async (params) => {
+      seenKeys.push(params.sessionKey);
+      return { payloads: [{ text: "reflection text" }] };
+    };
+
+    const one = await generateReflectionText({ ...baseParams, agentId: "agent-one" });
+    const two = await generateReflectionText({ ...baseParams, agentId: "agent-two" });
+
+    assert.equal(one.runner, "embedded");
+    assert.equal(two.runner, "embedded");
+    assert.deepEqual(seenKeys, [
+      "temp:memory-reflection:agent-one",
+      "temp:memory-reflection:agent-two",
+    ]);
+  });
+
+  it("keeps per-agent keys inside the internal reflection namespace (temp:* exclusion)", () => {
+    assert.equal(
+      isAgentOrSessionExcluded("agent-one", "temp:memory-reflection:agent-one", ["temp:*"]),
+      true,
+    );
+    assert.equal(
+      isAgentOrSessionExcluded("agent-one", "temp:memory-reflection", ["temp:*"]),
+      true,
+    );
+    assert.equal(
+      isAgentOrSessionExcluded("agent-one", "agent:agent-one:main", ["temp:*"]),
+      false,
+    );
+  });
+});
+
+describe("reflection concurrency cap", () => {
+  it("bounds concurrent embedded runs at maxConcurrentRuns and completes every run", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let completed = 0;
+    const gates = [];
+    currentRunnerImpl = (params) =>
+      new Promise((resolve) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        gates.push(() => {
+          inFlight -= 1;
+          completed += 1;
+          resolve({ payloads: [{ text: `done ${params.agentId}` }] });
+        });
+      });
+
+    const agents = ["agent-one", "agent-two", "agent-three", "agent-four"];
+    const runs = agents.map((agentId) =>
+      generateReflectionText({ ...baseParams, agentId, maxConcurrentRuns: 2 }),
+    );
+
+    await waitFor(() => gates.length === 2);
+    await tick();
+    assert.equal(gates.length, 2, "third and fourth runs must wait for a slot");
+    assert.equal(maxInFlight, 2);
+
+    gates.shift()();
+    await waitFor(() => gates.length === 2);
+    gates.shift()();
+    await waitFor(() => gates.length === 2);
+    gates.shift()();
+    gates.shift()();
+
+    const results = await Promise.all(runs);
+    assert.equal(completed, 4);
+    assert.equal(maxInFlight, 2, "cap must hold across the whole burst");
+    for (const result of results) {
+      assert.equal(result.runner, "embedded");
+      assert.match(result.text, /^done agent-/);
+    }
+  });
+
+  it("hands slots to waiters FIFO and tolerates double release", async () => {
+    const releaseFirst = await acquireReflectionRunSlot(2);
+    const releaseSecond = await acquireReflectionRunSlot(2);
+
+    let thirdAcquired = false;
+    const thirdPending = acquireReflectionRunSlot(2).then((release) => {
+      thirdAcquired = true;
+      return release;
+    });
+    await tick();
+    assert.equal(thirdAcquired, false, "third acquire must wait while both slots are held");
+
+    releaseFirst();
+    releaseFirst();
+    const releaseThird = await thirdPending;
+    assert.equal(thirdAcquired, true);
+
+    let fourthAcquired = false;
+    const fourthPending = acquireReflectionRunSlot(2).then((release) => {
+      fourthAcquired = true;
+      return release;
+    });
+    await tick();
+    assert.equal(fourthAcquired, false, "double release must not free a second slot");
+
+    releaseSecond();
+    const releaseFourth = await fourthPending;
+    assert.equal(fourthAcquired, true);
+
+    releaseThird();
+    releaseFourth();
+  });
+});
+
+describe("memoryReflection.maxConcurrentRuns config", () => {
+  const parseCfg = (memoryReflection) =>
+    parsePluginConfig({
+      embedding: { apiKey: "dummy" },
+      sessionStrategy: "memoryReflection",
+      ...(memoryReflection === undefined ? {} : { memoryReflection }),
+    });
+
+  it("parses valid values, floors decimals, and defaults invalid ones", () => {
+    assert.equal(parseCfg({ maxConcurrentRuns: 3 }).memoryReflection.maxConcurrentRuns, 3);
+    assert.equal(parseCfg({ maxConcurrentRuns: 2 }).memoryReflection.maxConcurrentRuns, 2);
+    assert.equal(parseCfg({ maxConcurrentRuns: 1.5 }).memoryReflection.maxConcurrentRuns, 1);
+    assert.equal(parseCfg({}).memoryReflection.maxConcurrentRuns, 1);
+    assert.equal(parseCfg(undefined).memoryReflection.maxConcurrentRuns, 1);
+
+    for (const bad of [0, -1, "three", null]) {
+      assert.equal(
+        parseCfg({ maxConcurrentRuns: bad }).memoryReflection.maxConcurrentRuns,
+        1,
+        `invalid value ${String(bad)} must fall back to the default`,
+      );
+    }
+  });
+
+  it("declares the knob in the plugin manifest schema", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const manifest = JSON.parse(
+      await readFile(path.resolve(testDir, "..", "openclaw.plugin.json"), "utf8"),
+    );
+
+    const findMemoryReflectionSchema = (node) => {
+      if (!node || typeof node !== "object") return undefined;
+      const candidate = node.memoryReflection;
+      if (candidate && typeof candidate === "object" && candidate.properties) return candidate;
+      for (const value of Object.values(node)) {
+        const found = findMemoryReflectionSchema(value);
+        if (found) return found;
+      }
+      return undefined;
+    };
+
+    const schema = findMemoryReflectionSchema(manifest);
+    assert.ok(schema, "memoryReflection schema block must exist in the manifest");
+    assert.equal(schema.additionalProperties, false);
+
+    const knob = schema.properties.maxConcurrentRuns;
+    assert.ok(knob, "maxConcurrentRuns must be declared (additionalProperties is false)");
+    assert.equal(knob.type, "integer");
+    assert.equal(knob.minimum, 1);
+    assert.equal(knob.default, 1);
+  });
+});


### PR DESCRIPTION
## Problem

Every memory-reflection embedded run is enqueued with the fixed sessionKey `temp:memory-reflection`. Host session lanes are serial by default (`maxConcurrent: 1`), so reflections for all agents on a gateway share one global serial lane, and the queue wait happens inside each run's timeout window. Under a concurrent-reflection burst (for example a mass `/reset` across several agents) queued runs burn their timeout budget (`memoryReflection.timeoutMs` plus the fixed grace) before they even start, then fail over and retry. Observed live on a 6-agent gateway: `lane wait exceeded ... queueAhead` climbed to 4 and every queued reflection hit its deadline, recovering only via fallback.

## Change

1. Per-agent lanes: the embedded-run sessionKey becomes `temp:memory-reflection:<agentId>` (the agent id already flows into the same call). Lanes are independent across agents while each agent's own reflections stay serial. Both `startsWith("temp:memory-reflection")` guards and the `temp:*` exclusion pattern semantics are unchanged, covered by tests.
2. New `memoryReflection.maxConcurrentRuns` knob (integer, default 1, minimum 1): a plugin-side cap on concurrent reflection runs across all agents, acquired before the run's timeout clock starts.

**Default behavior is unchanged.** With the default of 1, reflections stay fully serialized exactly as before; the difference is that the serialization wait now happens before the timeout clock starts instead of inside it, so queued reflections no longer time out in line and cascade into failover. Raising the cap is an explicit opt-in to parallel reflections across agents for operators whose reflection provider has the headroom.

## Notes for reviewers

- The params of `generateReflectionText` moved to a named type (`GenerateReflectionTextParams`) so a thin exported wrapper can gate the run without re-indenting the whole function body. One static smoke assertion in `test/issue606_sdk-migration.test.mjs` matched the old inline literal shape; it now guards the same invariant (params include `api: OpenClawPluginApi`, the function consumes that params type and returns a Promise) and is slightly stricter.
- Covers the manifest schema (`additionalProperties: false`), a uiHints entry, manifest-regression assertions, and a new test file `test/reflection-per-agent-lane.test.mjs`: the per-agent key reaches the runner, `temp:*` exclusion still matches, a 4-run burst with the cap raised to 2 is bounded at 2 with FIFO handoff and no lost runs, and config parsing covers defaults, flooring, and invalid-value fallback.

## Validation

New tests 6 of 6, `test:core-regression` group green, `plugin-manifest-regression` green, typecheck clean. The 4 pre-existing local failures in `test/memory-reflection.test.mjs` on this environment are identical on unmodified `master` (environment dependent, unrelated to this change).
