### PR TITLE
fix: mirror smart-extraction persisted memories to markdown

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1786,6 +1786,9 @@ function _initPluginState(api) {
         api.logger.info(`memory-lancedb-pro: CLAWTEAM_MEMORY_SCOPE added scopes: ${clawteamScopes.join(", ")}`);
     }
     const migrator = createMigrator(store);
+    // Created here (ahead of SmartExtractor) because SmartExtractor's onPersisted
+    // callback below closes over it.
+    const mdMirror = createMdMirrorWriter(api, config);
     let smartExtractor = null;
     if (config.smartExtraction !== false) {
         try {
@@ -1828,6 +1831,7 @@ function _initPluginState(api) {
                 workspaceBoundary: config.workspaceBoundary,
                 admissionControl: config.admissionControl,
                 onAdmissionRejected: admissionRejectionAuditWriter ?? undefined,
+                onPersisted: mdMirror ?? undefined,
                 log: (msg) => api.logger.info(msg),
                 debugLog: (msg) => api.logger.debug(msg),
                 noiseBank,
@@ -1874,6 +1878,7 @@ function _initPluginState(api) {
         scopeManager,
         migrator,
         smartExtractor,
+        mdMirror,
         extractionRateLimiter,
         reflectionErrorStateBySession,
         reflectionDerivedBySession,
@@ -1991,7 +1996,7 @@ const memoryLanceDBProPlugin = {
             _registeredApisMap.delete(api); // dual-track rollback: Map un-claim
             throw err;
         }
-        const { config, resolvedDbPath, vectorDim, store, embedder, retriever, canonicalCorpusIndexer, dreamingEngine, dreamingScheduler, scopeManager, migrator, smartExtractor, decayEngine, tierManager, extractionRateLimiter, reflectionErrorStateBySession, reflectionDerivedBySession, reflectionDerivedSuppressionBySession, reflectionByAgentCache, recallHistory, turnCounter, autoCaptureSeenTextCount, autoCapturePendingIngressTexts, autoCaptureRecentTexts, } = singleton;
+        const { config, resolvedDbPath, vectorDim, store, embedder, retriever, canonicalCorpusIndexer, dreamingEngine, dreamingScheduler, scopeManager, migrator, smartExtractor, mdMirror, decayEngine, tierManager, extractionRateLimiter, reflectionErrorStateBySession, reflectionDerivedBySession, reflectionDerivedSuppressionBySession, reflectionByAgentCache, recallHistory, turnCounter, autoCaptureSeenTextCount, autoCapturePendingIngressTexts, autoCaptureRecentTexts, } = singleton;
         warnForDisabledChannelPlugin(api.config, api.logger);
         async function sleep(ms, signal) {
             if (signal?.aborted) {
@@ -2273,10 +2278,8 @@ const memoryLanceDBProPlugin = {
             }
             api.logger.debug(`memory-lancedb-pro: ingress before_message_write agent=${ctx.agentId || event.agentId || "unknown"} sessionKey=${ctx.sessionKey || event.sessionKey || "unknown"} role=${role} ${summarizeMessageContent(message?.content)}`);
         });
-        // ========================================================================
-        // Markdown Mirror
-        // ========================================================================
-        const mdMirror = createMdMirrorWriter(api, config);
+        // mdMirror comes from the singleton state (created once in _initPluginState
+        // so SmartExtractor's onPersisted callback can close over the same instance).
         // ========================================================================
         // Register Tools
         // ========================================================================
@@ -2942,7 +2945,7 @@ const memoryLanceDBProPlugin = {
                                 // issue #417 Fix #10: prevent hook crash on LLM API errors / network timeouts
                                 let stats = null;
                                 try {
-                                    stats = await smartExtractor.extractAndPersist(conversationText, sessionKey, { scope: defaultScope, scopeFilter: accessibleScopes });
+                                    stats = await smartExtractor.extractAndPersist(conversationText, sessionKey, { scope: defaultScope, scopeFilter: accessibleScopes, agentId });
                                 }
                                 catch (err) {
                                     api.logger.error(`memory-lancedb-pro: smart-extract failed for agent ${agentId}: ${String(err)}`);

--- a/dist/src/smart-extractor.js
+++ b/dist/src/smart-extractor.js
@@ -179,6 +179,7 @@ export class SmartExtractor {
     admissionController;
     persistAdmissionAudit;
     onAdmissionRejected;
+    onPersisted;
     constructor(store, embedder, llm, config = {}) {
         this.store = store;
         this.embedder = embedder;
@@ -190,10 +191,27 @@ export class SmartExtractor {
             config.admissionControl?.enabled === true &&
                 config.admissionControl.auditMetadata !== false;
         this.onAdmissionRejected = config.onAdmissionRejected;
+        this.onPersisted = config.onPersisted;
         this.admissionController =
             config.admissionControl?.enabled === true
                 ? new AdmissionController(this.store, this.llm, config.admissionControl, this.debugLog)
                 : null;
+    }
+    /**
+     * Notify the onPersisted sink (e.g. markdown mirror) after a successful
+     * create or merge. Fire-and-forget from the caller's perspective: awaited
+     * here so ordering is deterministic, but errors are swallowed so a sink
+     * failure never fails the underlying store operation.
+     */
+    async notifyPersisted(entry, source, agentId) {
+        if (!this.onPersisted)
+            return;
+        try {
+            await this.onPersisted(entry, { source, agentId });
+        }
+        catch (err) {
+            this.log(`memory-pro: smart-extractor: onPersisted callback failed for entry "${entry.text.slice(0, 40)}": ${String(err)}`);
+        }
     }
     // --------------------------------------------------------------------------
     // Main entry point
@@ -213,6 +231,7 @@ export class SmartExtractor {
         const scopeFilter = hasExplicitScopeFilter
             ? options.scopeFilter
             : [targetScope];
+        const agentId = options.agentId;
         // Step 1: LLM extraction
         const candidates = await this.extractCandidates(conversationText);
         if (candidates.length === 0) {
@@ -288,7 +307,7 @@ export class SmartExtractor {
         const pendingSupersedeInvalidations = [];
         for (const { index, candidate } of processableCandidates) {
             try {
-                await this.processCandidate(candidate, conversationText, sessionKey, stats, targetScope, scopeFilter, precomputedVectors.get(index), createEntries, pendingSupersedeInvalidations);
+                await this.processCandidate(candidate, conversationText, sessionKey, stats, targetScope, scopeFilter, precomputedVectors.get(index), createEntries, pendingSupersedeInvalidations, agentId);
             }
             catch (err) {
                 this.log(`memory-pro: smart-extractor: failed to process candidate [${candidate.category}]: ${String(err)}`);
@@ -298,6 +317,14 @@ export class SmartExtractor {
             const createdEntries = await this.bulkStoreAndValidate(createEntries);
             if (createdEntries) {
                 await this.applyPendingSupersedeInvalidations(createdEntries, pendingSupersedeInvalidations);
+                for (const created of createdEntries) {
+                    await this.notifyPersisted({
+                        text: created.text,
+                        category: created.category,
+                        scope: created.scope,
+                        timestamp: created.timestamp,
+                    }, "smart-extraction", agentId);
+                }
             }
             else if (pendingSupersedeInvalidations.length > 0) {
                 this.log("memory-pro: smart-extractor: supersede invalidation skipped because bulkStore() did not return created entries");
@@ -537,10 +564,10 @@ export class SmartExtractor {
      *   When provided (from batch pre-embedding), skips the per-candidate embed
      *   call to reduce API round-trips.
      */
-    async processCandidate(candidate, conversationText, sessionKey, stats, targetScope, scopeFilter, precomputedVector, createEntries, pendingSupersedeInvalidations) {
+    async processCandidate(candidate, conversationText, sessionKey, stats, targetScope, scopeFilter, precomputedVector, createEntries, pendingSupersedeInvalidations, agentId) {
         // Profile always merges (skip dedup — admission control still applies)
         if (ALWAYS_MERGE_CATEGORIES.has(candidate.category)) {
-            const profileResult = await this.handleProfileMerge(candidate, conversationText, sessionKey, targetScope, scopeFilter, undefined, createEntries);
+            const profileResult = await this.handleProfileMerge(candidate, conversationText, sessionKey, targetScope, scopeFilter, undefined, createEntries, agentId);
             if (profileResult === "rejected") {
                 stats.rejected = (stats.rejected ?? 0) + 1;
             }
@@ -586,7 +613,7 @@ export class SmartExtractor {
             case "merge":
                 if (dedupResult.matchId &&
                     MERGE_SUPPORTED_CATEGORIES.has(candidate.category)) {
-                    await this.handleMerge(candidate, dedupResult.matchId, targetScope, scopeFilter, dedupResult.contextLabel, admission?.audit, createEntries);
+                    await this.handleMerge(candidate, dedupResult.matchId, targetScope, scopeFilter, dedupResult.contextLabel, admission?.audit, createEntries, agentId);
                     stats.merged++;
                 }
                 else {
@@ -602,7 +629,7 @@ export class SmartExtractor {
             case "supersede":
                 if (dedupResult.matchId &&
                     TEMPORAL_VERSIONED_CATEGORIES.has(candidate.category)) {
-                    await this.handleSupersede(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, admission?.audit, createEntries, pendingSupersedeInvalidations);
+                    await this.handleSupersede(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, admission?.audit, createEntries, pendingSupersedeInvalidations, agentId);
                     stats.created++;
                     stats.superseded = (stats.superseded ?? 0) + 1;
                 }
@@ -623,7 +650,7 @@ export class SmartExtractor {
                 break;
             case "contextualize":
                 if (dedupResult.matchId) {
-                    await this.handleContextualize(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, dedupResult.contextLabel, admission?.audit, createEntries);
+                    await this.handleContextualize(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, dedupResult.contextLabel, admission?.audit, createEntries, agentId);
                     stats.created++;
                 }
                 else {
@@ -635,12 +662,12 @@ export class SmartExtractor {
                 if (dedupResult.matchId) {
                     if (TEMPORAL_VERSIONED_CATEGORIES.has(candidate.category) &&
                         dedupResult.contextLabel === "general") {
-                        await this.handleSupersede(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, admission?.audit, createEntries, pendingSupersedeInvalidations);
+                        await this.handleSupersede(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, admission?.audit, createEntries, pendingSupersedeInvalidations, agentId);
                         stats.created++;
                         stats.superseded = (stats.superseded ?? 0) + 1;
                     }
                     else {
-                        await this.handleContradict(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, dedupResult.contextLabel, admission?.audit, createEntries);
+                        await this.handleContradict(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, dedupResult.contextLabel, admission?.audit, createEntries, agentId);
                         stats.created++;
                     }
                 }
@@ -752,7 +779,7 @@ export class SmartExtractor {
     /**
      * Profile always-merge: read existing profile, merge with LLM, upsert.
      */
-    async handleProfileMerge(candidate, conversationText, sessionKey, targetScope, scopeFilter, admissionAudit, createEntries) {
+    async handleProfileMerge(candidate, conversationText, sessionKey, targetScope, scopeFilter, admissionAudit, createEntries, agentId) {
         // Find existing profile memory by category
         const embeddingText = `${candidate.abstract} ${candidate.content}`;
         const vector = await this.embedder.embed(embeddingText);
@@ -783,7 +810,7 @@ export class SmartExtractor {
             }
         });
         if (profileMatch) {
-            await this.handleMerge(candidate, profileMatch.entry.id, targetScope, scopeFilter, undefined, admissionAudit, createEntries);
+            await this.handleMerge(candidate, profileMatch.entry.id, targetScope, scopeFilter, undefined, admissionAudit, createEntries, agentId);
             return "merged";
         }
         else {
@@ -795,7 +822,7 @@ export class SmartExtractor {
     /**
      * Merge a candidate into an existing memory using LLM.
      */
-    async handleMerge(candidate, matchId, targetScope, scopeFilter, contextLabel, admissionAudit, createEntries) {
+    async handleMerge(candidate, matchId, targetScope, scopeFilter, contextLabel, admissionAudit, createEntries, agentId) {
         let existingAbstract = "";
         let existingOverview = "";
         let existingContent = "";
@@ -840,6 +867,12 @@ export class SmartExtractor {
             vector: newVector,
             metadata,
         }, scopeFilter);
+        await this.notifyPersisted({
+            text: merged.abstract,
+            category: this.mapToStoreCategory(candidate.category),
+            scope: targetScope,
+            timestamp: Date.now(),
+        }, "smart-extraction", agentId);
         // Update support stats on the merged memory
         try {
             const updatedEntry = await this.store.getById(matchId, scopeFilter);
@@ -860,7 +893,7 @@ export class SmartExtractor {
      * Handle SUPERSEDE: preserve the old record as historical but mark it as no
      * longer current, then create the new active fact.
      */
-    async handleSupersede(candidate, vector, matchId, sessionKey, targetScope, scopeFilter, admissionAudit, createEntries, pendingSupersedeInvalidations) {
+    async handleSupersede(candidate, vector, matchId, sessionKey, targetScope, scopeFilter, admissionAudit, createEntries, pendingSupersedeInvalidations, agentId) {
         const existing = await this.store.getById(matchId, scopeFilter);
         if (!existing) {
             createEntries?.push(this.buildStoreEntry(candidate, vector || [], sessionKey, targetScope));
@@ -920,6 +953,7 @@ export class SmartExtractor {
         }
         const created = await this.store.store(entry);
         await this.invalidateSupersededMemory(matchId, existing, factKey, created.id, scopeFilter);
+        await this.notifyPersisted({ text: created.text, category: created.category, scope: created.scope, timestamp: created.timestamp }, "smart-extraction", agentId);
         this.log(`memory-pro: smart-extractor: superseded [${candidate.category}] ${matchId.slice(0, 8)} -> ${created.id.slice(0, 8)}`);
     }
     async applyPendingSupersedeInvalidations(createdEntries, pendingSupersedeInvalidations) {
@@ -967,7 +1001,7 @@ export class SmartExtractor {
      * Handle CONTEXTUALIZE: create a new entry that adds situational nuance,
      * linked to the original via a relation in metadata.
      */
-    async handleContextualize(candidate, vector, matchId, sessionKey, targetScope, scopeFilter, contextLabel, admissionAudit, createEntries) {
+    async handleContextualize(candidate, vector, matchId, sessionKey, targetScope, scopeFilter, contextLabel, admissionAudit, createEntries, agentId) {
         const storeCategory = this.mapToStoreCategory(candidate.category);
         const metadata = stringifySmartMetadata(this.withAdmissionAudit({
             l0_abstract: candidate.abstract,
@@ -1000,7 +1034,8 @@ export class SmartExtractor {
             createEntries.push(entry_c);
         }
         else {
-            await this.store.store(entry_c);
+            const created = await this.store.store(entry_c);
+            await this.notifyPersisted({ text: created.text, category: created.category, scope: created.scope, timestamp: created.timestamp }, "smart-extraction", agentId);
         }
         this.log(`memory-pro: smart-extractor: contextualize [${contextLabel || "general"}] new entry linked to ${matchId.slice(0, 8)}`);
     }
@@ -1008,7 +1043,7 @@ export class SmartExtractor {
      * Handle CONTRADICT: create contradicting entry + record contradiction evidence
      * on the original memory's support stats.
      */
-    async handleContradict(candidate, vector, matchId, sessionKey, targetScope, scopeFilter, contextLabel, admissionAudit, createEntries) {
+    async handleContradict(candidate, vector, matchId, sessionKey, targetScope, scopeFilter, contextLabel, admissionAudit, createEntries, agentId) {
         // 1. Record contradiction on the existing memory
         const existing = await this.store.getById(matchId, scopeFilter);
         if (existing) {
@@ -1051,7 +1086,8 @@ export class SmartExtractor {
             createEntries.push(entry_d);
         }
         else {
-            await this.store.store(entry_d);
+            const created = await this.store.store(entry_d);
+            await this.notifyPersisted({ text: created.text, category: created.category, scope: created.scope, timestamp: created.timestamp }, "smart-extraction", agentId);
         }
         this.log(`memory-pro: smart-extractor: contradict [${contextLabel || "general"}] on ${matchId.slice(0, 8)}, new entry created`);
     }

--- a/index.ts
+++ b/index.ts
@@ -2311,6 +2311,7 @@ interface PluginSingletonState {
   scopeManager: ReturnType<typeof createScopeManager>;
   migrator: ReturnType<typeof createMigrator>;
   smartExtractor: SmartExtractor | null;
+  mdMirror: MdMirrorWriter | null;
   extractionRateLimiter: ReturnType<typeof createExtractionRateLimiter>;
   // Session Maps — persist across scope refreshes instead of being recreated
   reflectionErrorStateBySession: Map<string, ReflectionErrorState>;
@@ -2436,6 +2437,10 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
 
   const migrator = createMigrator(store);
 
+  // Created here (ahead of SmartExtractor) because SmartExtractor's onPersisted
+  // callback below closes over it.
+  const mdMirror = createMdMirrorWriter(api, config);
+
   let smartExtractor: SmartExtractor | null = null;
   if (config.smartExtraction !== false) {
     try {
@@ -2484,6 +2489,7 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
         workspaceBoundary: config.workspaceBoundary,
         admissionControl: config.admissionControl,
         onAdmissionRejected: admissionRejectionAuditWriter ?? undefined,
+        onPersisted: mdMirror ?? undefined,
         log: (msg: string) => api.logger.info(msg),
         debugLog: (msg: string) => api.logger.debug(msg),
         noiseBank,
@@ -2538,6 +2544,7 @@ function _initPluginState(api: OpenClawPluginApi): PluginSingletonState {
     scopeManager,
     migrator,
     smartExtractor,
+    mdMirror,
     extractionRateLimiter,
     reflectionErrorStateBySession,
     reflectionDerivedBySession,
@@ -2686,6 +2693,7 @@ const memoryLanceDBProPlugin = {
       scopeManager,
       migrator,
       smartExtractor,
+      mdMirror,
       decayEngine,
       tierManager,
       extractionRateLimiter,
@@ -3061,11 +3069,8 @@ const memoryLanceDBProPlugin = {
       );
     });
 
-    // ========================================================================
-    // Markdown Mirror
-    // ========================================================================
-
-    const mdMirror = createMdMirrorWriter(api, config);
+    // mdMirror comes from the singleton state (created once in _initPluginState
+    // so SmartExtractor's onPersisted callback can close over the same instance).
 
     // ========================================================================
     // Register Tools
@@ -3873,7 +3878,7 @@ const memoryLanceDBProPlugin = {
               try {
                 stats = await smartExtractor.extractAndPersist(
                   conversationText, sessionKey,
-                  { scope: defaultScope, scopeFilter: accessibleScopes },
+                  { scope: defaultScope, scopeFilter: accessibleScopes, agentId },
                 );
               } catch (err) {
                 api.logger.error(

--- a/src/smart-extractor.ts
+++ b/src/smart-extractor.ts
@@ -246,6 +246,20 @@ const VALID_DECISIONS = new Set<string>([
 // Smart Extractor
 // ============================================================================
 
+/** Entry data for a memory that was just created or merged, as persisted to the store. */
+export interface PersistedMemoryEntry {
+  text: string;
+  category: string;
+  scope: string;
+  timestamp: number;
+}
+
+/** Context describing which pipeline produced a PersistedMemoryEntry. */
+export interface PersistedMemoryMeta {
+  source: string;
+  agentId?: string;
+}
+
 export interface SmartExtractorConfig {
   /** User identifier for extraction prompt. */
   user?: string;
@@ -267,6 +281,8 @@ export interface SmartExtractorConfig {
   admissionControl?: AdmissionControlConfig;
   /** Optional sink for durable reject-audit logging. */
   onAdmissionRejected?: (entry: AdmissionRejectionAuditEntry) => Promise<void> | void;
+  /** Optional sink invoked after a memory is successfully created or merged (e.g. markdown mirror). */
+  onPersisted?: (entry: PersistedMemoryEntry, meta: PersistedMemoryMeta) => Promise<void> | void;
 }
 
 export interface ExtractPersistOptions {
@@ -280,6 +296,8 @@ export interface ExtractPersistOptions {
    * - pass a non-empty array to restrict reads to those scopes
    */
   scopeFilter?: string[];
+  /** Agent identifier forwarded to onPersisted, resolved the same way callers resolve it for other sinks. */
+  agentId?: string;
 }
 
 export class SmartExtractor {
@@ -288,6 +306,7 @@ export class SmartExtractor {
   private admissionController: AdmissionController | null;
   private persistAdmissionAudit: boolean;
   private onAdmissionRejected?: (entry: AdmissionRejectionAuditEntry) => Promise<void> | void;
+  private onPersisted?: (entry: PersistedMemoryEntry, meta: PersistedMemoryMeta) => Promise<void> | void;
 
   constructor(
     private store: MemoryStore,
@@ -301,6 +320,7 @@ export class SmartExtractor {
       config.admissionControl?.enabled === true &&
       config.admissionControl.auditMetadata !== false;
     this.onAdmissionRejected = config.onAdmissionRejected;
+    this.onPersisted = config.onPersisted;
     this.admissionController =
       config.admissionControl?.enabled === true
         ? new AdmissionController(
@@ -310,6 +330,27 @@ export class SmartExtractor {
             this.debugLog,
           )
         : null;
+  }
+
+  /**
+   * Notify the onPersisted sink (e.g. markdown mirror) after a successful
+   * create or merge. Fire-and-forget from the caller's perspective: awaited
+   * here so ordering is deterministic, but errors are swallowed so a sink
+   * failure never fails the underlying store operation.
+   */
+  private async notifyPersisted(
+    entry: PersistedMemoryEntry,
+    source: string,
+    agentId?: string,
+  ): Promise<void> {
+    if (!this.onPersisted) return;
+    try {
+      await this.onPersisted(entry, { source, agentId });
+    } catch (err) {
+      this.log(
+        `memory-pro: smart-extractor: onPersisted callback failed for entry "${entry.text.slice(0, 40)}": ${String(err)}`,
+      );
+    }
   }
 
   // --------------------------------------------------------------------------
@@ -335,6 +376,7 @@ export class SmartExtractor {
     const scopeFilter = hasExplicitScopeFilter
       ? options.scopeFilter
       : [targetScope];
+    const agentId = options.agentId;
 
     // Step 1: LLM extraction
     const candidates = await this.extractCandidates(conversationText);
@@ -441,6 +483,7 @@ export class SmartExtractor {
           precomputedVectors.get(index),
           createEntries,
           pendingSupersedeInvalidations,
+          agentId,
         );
       } catch (err) {
         this.log(
@@ -456,6 +499,18 @@ export class SmartExtractor {
           createdEntries,
           pendingSupersedeInvalidations,
         );
+        for (const created of createdEntries) {
+          await this.notifyPersisted(
+            {
+              text: created.text,
+              category: created.category,
+              scope: created.scope,
+              timestamp: created.timestamp,
+            },
+            "smart-extraction",
+            agentId,
+          );
+        }
       } else if (pendingSupersedeInvalidations.length > 0) {
         this.log(
           "memory-pro: smart-extractor: supersede invalidation skipped because bulkStore() did not return created entries",
@@ -784,6 +839,7 @@ export class SmartExtractor {
     precomputedVector?: number[],
     createEntries?: Omit<import("./store.js").MemoryEntry, "id" | "timestamp">[],
     pendingSupersedeInvalidations?: PendingSupersedeInvalidation[],
+    agentId?: string,
   ): Promise<void> {
     // Profile always merges (skip dedup — admission control still applies)
     if (ALWAYS_MERGE_CATEGORIES.has(candidate.category)) {
@@ -795,6 +851,7 @@ export class SmartExtractor {
         scopeFilter,
         undefined,
         createEntries,
+        agentId,
       );
       if (profileResult === "rejected") {
         stats.rejected = (stats.rejected ?? 0) + 1;
@@ -864,6 +921,7 @@ export class SmartExtractor {
             dedupResult.contextLabel,
             admission?.audit,
             createEntries,
+            agentId,
           );
           stats.merged++;
         } else {
@@ -895,6 +953,7 @@ export class SmartExtractor {
             admission?.audit,
             createEntries,
             pendingSupersedeInvalidations,
+            agentId,
           );
           stats.created++;
           stats.superseded = (stats.superseded ?? 0) + 1;
@@ -916,7 +975,7 @@ export class SmartExtractor {
 
       case "contextualize":
         if (dedupResult.matchId) {
-          await this.handleContextualize(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, dedupResult.contextLabel, admission?.audit, createEntries);
+          await this.handleContextualize(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, dedupResult.contextLabel, admission?.audit, createEntries, agentId);
           stats.created++;
         } else {
           createEntries?.push(this.buildStoreEntry(candidate, vector, sessionKey, targetScope, admission?.audit));
@@ -940,11 +999,12 @@ export class SmartExtractor {
               admission?.audit,
               createEntries,
               pendingSupersedeInvalidations,
+              agentId,
             );
             stats.created++;
             stats.superseded = (stats.superseded ?? 0) + 1;
           } else {
-            await this.handleContradict(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, dedupResult.contextLabel, admission?.audit, createEntries);
+            await this.handleContradict(candidate, vector, dedupResult.matchId, sessionKey, targetScope, scopeFilter, dedupResult.contextLabel, admission?.audit, createEntries, agentId);
             stats.created++;
           }
         } else {
@@ -1103,6 +1163,7 @@ export class SmartExtractor {
     scopeFilter?: string[],
     admissionAudit?: AdmissionAuditRecord,
     createEntries?: StoreEntry[],
+    agentId?: string,
   ): Promise<"merged" | "created" | "rejected"> {
     // Find existing profile memory by category
     const embeddingText = `${candidate.abstract} ${candidate.content}`;
@@ -1151,6 +1212,7 @@ export class SmartExtractor {
         undefined,
         admissionAudit,
         createEntries,
+        agentId,
       );
       return "merged";
     } else {
@@ -1171,6 +1233,7 @@ export class SmartExtractor {
     contextLabel?: string,
     admissionAudit?: AdmissionAuditRecord,
     createEntries?: StoreEntry[],
+    agentId?: string,
   ): Promise<void> {
     let existingAbstract = "";
     let existingOverview = "";
@@ -1253,6 +1316,17 @@ export class SmartExtractor {
       scopeFilter,
     );
 
+    await this.notifyPersisted(
+      {
+        text: merged.abstract,
+        category: this.mapToStoreCategory(candidate.category),
+        scope: targetScope,
+        timestamp: Date.now(),
+      },
+      "smart-extraction",
+      agentId,
+    );
+
     // Update support stats on the merged memory
     try {
       const updatedEntry = await this.store.getById(matchId, scopeFilter);
@@ -1286,6 +1360,7 @@ export class SmartExtractor {
     admissionAudit?: AdmissionAuditRecord,
     createEntries?: StoreEntry[],
     pendingSupersedeInvalidations?: PendingSupersedeInvalidation[],
+    agentId?: string,
   ): Promise<void> {
     const existing = await this.store.getById(matchId, scopeFilter);
     if (!existing) {
@@ -1360,6 +1435,11 @@ export class SmartExtractor {
       factKey,
       created.id,
       scopeFilter,
+    );
+    await this.notifyPersisted(
+      { text: created.text, category: created.category, scope: created.scope, timestamp: created.timestamp },
+      "smart-extraction",
+      agentId,
     );
 
     this.log(
@@ -1465,6 +1545,7 @@ export class SmartExtractor {
     contextLabel?: string,
     admissionAudit?: AdmissionAuditRecord,
     createEntries?: StoreEntry[],
+    agentId?: string,
   ): Promise<void> {
     const storeCategory = this.mapToStoreCategory(candidate.category);
     const metadata = stringifySmartMetadata(this.withAdmissionAudit({
@@ -1498,7 +1579,12 @@ export class SmartExtractor {
     if (createEntries) {
       createEntries.push(entry_c);
     } else {
-      await this.store.store(entry_c);
+      const created = await this.store.store(entry_c);
+      await this.notifyPersisted(
+        { text: created.text, category: created.category, scope: created.scope, timestamp: created.timestamp },
+        "smart-extraction",
+        agentId,
+      );
     }
 
     this.log(
@@ -1520,6 +1606,7 @@ export class SmartExtractor {
     contextLabel?: string,
     admissionAudit?: AdmissionAuditRecord,
     createEntries?: StoreEntry[],
+    agentId?: string,
   ): Promise<void> {
     // 1. Record contradiction on the existing memory
     const existing = await this.store.getById(matchId, scopeFilter);
@@ -1568,7 +1655,12 @@ export class SmartExtractor {
     if (createEntries) {
       createEntries.push(entry_d);
     } else {
-      await this.store.store(entry_d);
+      const created = await this.store.store(entry_d);
+      await this.notifyPersisted(
+        { text: created.text, category: created.category, scope: created.scope, timestamp: created.timestamp },
+        "smart-extraction",
+        agentId,
+      );
     }
 
     this.log(

--- a/test/smart-extractor-md-mirror.test.mjs
+++ b/test/smart-extractor-md-mirror.test.mjs
@@ -1,0 +1,279 @@
+/**
+ * Test: SmartExtractor onPersisted callback (markdown mirror integration)
+ *
+ * PROBLEM: SmartExtractor.extractAndPersist() persists memories via
+ * store.bulkStore()/store()/update() but never notified any external sink,
+ * so the markdown mirror silently never fired for smart-extraction captures
+ * (it only fired for the regex-fallback and reflection paths).
+ *
+ * This test drives the real SmartExtractor class (not a reimplementation)
+ * through a create and a merge, and asserts the onPersisted callback fires
+ * with the shape the markdown mirror writer expects.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const { SmartExtractor } = jiti("../src/smart-extractor.ts");
+
+function makeCandidate(overrides = {}) {
+  return {
+    category: "preferences",
+    abstract: "Tea preference: oolong tea",
+    overview: "## Preference\n- Likes oolong tea",
+    content: "The user likes oolong tea.",
+    ...overrides,
+  };
+}
+
+/** In-memory store: real create/getById/update semantics, no LanceDB. */
+function makeFakeStore({ vectorSearchResult = [] } = {}) {
+  const rows = new Map();
+  let nextId = 1;
+
+  return {
+    rows,
+    async vectorSearch() {
+      return vectorSearchResult;
+    },
+    async store(entry) {
+      const stored = { ...entry, id: `row-${nextId++}`, timestamp: Date.now() };
+      rows.set(stored.id, stored);
+      return stored;
+    },
+    async bulkStore(entries) {
+      return entries.map((entry) => {
+        const stored = { ...entry, id: `row-${nextId++}`, timestamp: Date.now() };
+        rows.set(stored.id, stored);
+        return stored;
+      });
+    },
+    async getById(id) {
+      return rows.get(id) ?? null;
+    },
+    async update(id, updates) {
+      const existing = rows.get(id);
+      if (!existing) return null;
+      const updated = { ...existing, ...updates };
+      rows.set(id, updated);
+      return updated;
+    },
+  };
+}
+
+function makeFakeEmbedder() {
+  return {
+    async embed() {
+      return [1, 0, 0];
+    },
+  };
+}
+
+describe("SmartExtractor onPersisted callback (mdMirror integration)", () => {
+  it("fires onPersisted after a create, with entry + meta shaped for mdMirror", async () => {
+    const store = makeFakeStore({ vectorSearchResult: [] });
+    const embedder = makeFakeEmbedder();
+    const persisted = [];
+
+    const llm = {
+      async completeJson(_prompt, mode) {
+        if (mode === "extract-candidates") {
+          return { memories: [makeCandidate()] };
+        }
+        throw new Error(`unexpected mode: ${mode}`);
+      },
+    };
+
+    const extractor = new SmartExtractor(store, embedder, llm, {
+      user: "User",
+      extractMinMessages: 1,
+      extractMaxChars: 8000,
+      defaultScope: "global",
+      log() {},
+      debugLog() {},
+      onPersisted(entry, meta) {
+        persisted.push({ entry, meta });
+      },
+    });
+
+    const stats = await extractor.extractAndPersist(
+      "The user likes oolong tea.",
+      "session-create",
+      { scope: "global", agentId: "agent-one" },
+    );
+
+    assert.equal(stats.created, 1);
+    assert.equal(persisted.length, 1, "onPersisted should fire exactly once for the create");
+
+    const [{ entry, meta }] = persisted;
+    assert.equal(entry.text, "Tea preference: oolong tea");
+    assert.equal(entry.category, "preference");
+    assert.equal(entry.scope, "global");
+    assert.equal(typeof entry.timestamp, "number");
+    assert.equal(meta.source, "smart-extraction");
+    assert.equal(meta.agentId, "agent-one");
+  });
+
+  it("fires onPersisted after a merge, mirroring the post-merge text", async () => {
+    const embedder = makeFakeEmbedder();
+    const persisted = [];
+
+    // Step 1: create the memory that will later be merged into.
+    const createStore = makeFakeStore({ vectorSearchResult: [] });
+    const createLlm = {
+      async completeJson(_prompt, mode) {
+        if (mode === "extract-candidates") {
+          return { memories: [makeCandidate()] };
+        }
+        throw new Error(`unexpected mode: ${mode}`);
+      },
+    };
+    const createExtractor = new SmartExtractor(createStore, embedder, createLlm, {
+      user: "User",
+      extractMinMessages: 1,
+      extractMaxChars: 8000,
+      defaultScope: "global",
+      log() {},
+      debugLog() {},
+      onPersisted(entry, meta) {
+        persisted.push({ entry, meta });
+      },
+    });
+    await createExtractor.extractAndPersist("The user likes oolong tea.", "session-1", {
+      scope: "global",
+      agentId: "agent-one",
+    });
+    assert.equal(persisted.length, 1, "sanity check: create step persisted once");
+
+    const [existingRow] = createStore.rows.values();
+
+    // Step 2: a similar candidate triggers a MERGE against the row created above.
+    // Reuse the same store so the merge acts on a row with real smart-metadata.
+    const mergeLlm = {
+      async completeJson(_prompt, mode) {
+        if (mode === "extract-candidates") {
+          return {
+            memories: [
+              makeCandidate({
+                abstract: "Tea preference: oolong tea, prefers it strong",
+                content: "The user likes strong oolong tea.",
+              }),
+            ],
+          };
+        }
+        if (mode === "dedup-decision") {
+          return { decision: "merge", match_index: 1, reason: "same preference" };
+        }
+        if (mode === "merge-memory") {
+          return {
+            abstract: "Tea preference: oolong tea, prefers it strong",
+            overview: "## Preference\n- Likes strong oolong tea",
+            content: "The user likes strong oolong tea.",
+          };
+        }
+        throw new Error(`unexpected mode: ${mode}`);
+      },
+    };
+    const mergeExtractor = new SmartExtractor(createStore, embedder, mergeLlm, {
+      user: "User",
+      extractMinMessages: 1,
+      extractMaxChars: 8000,
+      defaultScope: "global",
+      log() {},
+      debugLog() {},
+      onPersisted(entry, meta) {
+        persisted.push({ entry, meta });
+      },
+    });
+    // makeFakeStore's vectorSearch closed over the constructor-time value, so
+    // patch it directly for this second phase of the test.
+    createStore.vectorSearch = async () => [{ entry: existingRow, score: 0.95 }];
+
+    const stats = await mergeExtractor.extractAndPersist(
+      "The user likes strong oolong tea.",
+      "session-2",
+      { scope: "global", agentId: "agent-two" },
+    );
+
+    assert.equal(stats.merged, 1);
+    assert.equal(persisted.length, 2, "onPersisted should now have fired for the create and the merge");
+
+    const [, { entry, meta }] = persisted;
+    assert.equal(entry.text, "Tea preference: oolong tea, prefers it strong");
+    assert.equal(entry.category, "preference");
+    assert.equal(entry.scope, "global");
+    assert.equal(typeof entry.timestamp, "number");
+    assert.equal(meta.source, "smart-extraction");
+    assert.equal(meta.agentId, "agent-two");
+  });
+
+  it("does not invoke onPersisted when it is not configured", async () => {
+    const store = makeFakeStore({ vectorSearchResult: [] });
+    const embedder = makeFakeEmbedder();
+
+    const llm = {
+      async completeJson(_prompt, mode) {
+        if (mode === "extract-candidates") {
+          return { memories: [makeCandidate()] };
+        }
+        throw new Error(`unexpected mode: ${mode}`);
+      },
+    };
+
+    const extractor = new SmartExtractor(store, embedder, llm, {
+      user: "User",
+      extractMinMessages: 1,
+      extractMaxChars: 8000,
+      defaultScope: "global",
+      log() {},
+      debugLog() {},
+    });
+
+    const stats = await extractor.extractAndPersist("The user likes oolong tea.", "session-none", {
+      scope: "global",
+    });
+
+    assert.equal(stats.created, 1, "extraction still persists normally without onPersisted configured");
+  });
+
+  it("swallows onPersisted failures without failing the underlying store operation", async () => {
+    const store = makeFakeStore({ vectorSearchResult: [] });
+    const embedder = makeFakeEmbedder();
+    const logs = [];
+
+    const llm = {
+      async completeJson(_prompt, mode) {
+        if (mode === "extract-candidates") {
+          return { memories: [makeCandidate()] };
+        }
+        throw new Error(`unexpected mode: ${mode}`);
+      },
+    };
+
+    const extractor = new SmartExtractor(store, embedder, llm, {
+      user: "User",
+      extractMinMessages: 1,
+      extractMaxChars: 8000,
+      defaultScope: "global",
+      log(msg) {
+        logs.push(msg);
+      },
+      debugLog() {},
+      onPersisted() {
+        throw new Error("simulated mirror failure");
+      },
+    });
+
+    const stats = await extractor.extractAndPersist("The user likes oolong tea.", "session-fail", {
+      scope: "global",
+    });
+
+    assert.equal(stats.created, 1, "store operation succeeds even though onPersisted threw");
+    assert.ok(
+      logs.some((msg) => msg.includes("onPersisted callback failed")),
+      "failure should be logged, not thrown",
+    );
+  });
+});


### PR DESCRIPTION
### What this fixes

With `mdMirror.enabled: true` and Smart Extraction active (the default capture path), created and merged memories are never mirrored to markdown. The extractor persists directly through `store.bulkStore()` / `store.store()` / `store.update()` and has no mirror hook, and the auto-capture handler returns early on smart-extraction success, before the code block that performs mirror writes for the regex-fallback path.

### How

Adds an optional `onPersisted` callback to `SmartExtractorConfig`, following the same constructor-injection pattern already used by `onAdmissionRejected` for admission-control audit logging. The callback fires after each successful create and merge, is awaited with failures swallowed and logged (a mirror error can never fail the store), and is wired in `index.ts` to the same `mdMirror` writer instance the other capture paths use. The writer is now created once alongside the extractor singleton instead of per `register()` call.

### Tests

New `test/smart-extractor-md-mirror.test.mjs` (4 tests): callback fires on create with the mirror entry shape, fires on merge with post-merge text, is skipped when unconfigured, and callback failures do not fail the store. Full existing smart-extractor, mdmirror-fallback-dir, regex-fallback, and plugin-bootstrap suites pass.

Fixes #910 (previously reported as #524, which was closed without a linked fix and still reproduces on current master).
