### PR TITLE
fix: completely disable auto-recall for reasoning models

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2206,7 +2206,7 @@ const memoryLanceDBProPlugin = {
 
           // Model-aware injection limits: reasoning models (mimo, deepseek-reasoning, etc.)
           // are more sensitive to injected context and may enter repetition loops.
-          // Apply conservative limits for these models to prevent output degradation.
+          // For these models, completely disable auto-recall to prevent output degradation.
           const REASONING_MODEL_PATTERNS = [
             /^mimo-/i,
             /^deepseek.*reasoning/i,
@@ -2222,26 +2222,17 @@ const memoryLanceDBProPlugin = {
           const modelId = ctx?.modelId || "";
           const isReasoning = isReasoningModel(modelId);
 
-          // Apply model-specific budget adjustments
-          const baseMaxItems = config.autoRecallMaxItems ?? 3;
-          const baseMaxChars = config.autoRecallMaxChars ?? 600;
-          const basePerItemMaxChars = config.autoRecallPerItemMaxChars ?? 180;
-
-          // For reasoning models, use more conservative defaults (50% reduction)
-          const REASONING_MODEL_REDUCTION = 0.5;
-          const adjustedMaxItems = isReasoning ? Math.max(1, Math.floor(baseMaxItems * REASONING_MODEL_REDUCTION)) : baseMaxItems;
-          const adjustedMaxChars = isReasoning ? Math.max(64, Math.floor(baseMaxChars * REASONING_MODEL_REDUCTION)) : baseMaxChars;
-          const adjustedPerItemMaxChars = isReasoning ? Math.max(32, Math.floor(basePerItemMaxChars * REASONING_MODEL_REDUCTION)) : basePerItemMaxChars;
-
+          // For reasoning models, completely skip auto-recall to prevent repetition loops
           if (isReasoning) {
             api.logger.info(
-              `memory-lancedb-pro: reasoning model detected (${modelId}), applying conservative injection limits: items=${adjustedMaxItems}, chars=${adjustedMaxChars}, perItem=${adjustedPerItemMaxChars}`
+              `memory-lancedb-pro: reasoning model detected (${modelId}), skipping auto-recall entirely to prevent repetition loops`
             );
+            return;
           }
 
-          const autoRecallMaxItems = clampInt(adjustedMaxItems, 1, 20);
-          const autoRecallMaxChars = clampInt(adjustedMaxChars, 64, 8000);
-          const autoRecallPerItemMaxChars = clampInt(adjustedPerItemMaxChars, 32, 1000);
+          const autoRecallMaxItems = clampInt(config.autoRecallMaxItems ?? 3, 1, 20);
+          const autoRecallMaxChars = clampInt(config.autoRecallMaxChars ?? 600, 64, 8000);
+          const autoRecallPerItemMaxChars = clampInt(config.autoRecallPerItemMaxChars ?? 180, 32, 1000);
           const retrieveLimit = clampInt(Math.max(autoRecallMaxItems * 2, autoRecallMaxItems), 1, 20);
 
           const results = filterUserMdExclusiveRecallResults(await retrieveWithRetry({

--- a/index.ts
+++ b/index.ts
@@ -2204,9 +2204,44 @@ const memoryLanceDBProPlugin = {
             );
           }
 
-          const autoRecallMaxItems = clampInt(config.autoRecallMaxItems ?? 3, 1, 20);
-          const autoRecallMaxChars = clampInt(config.autoRecallMaxChars ?? 600, 64, 8000);
-          const autoRecallPerItemMaxChars = clampInt(config.autoRecallPerItemMaxChars ?? 180, 32, 1000);
+          // Model-aware injection limits: reasoning models (mimo, deepseek-reasoning, etc.)
+          // are more sensitive to injected context and may enter repetition loops.
+          // Apply conservative limits for these models to prevent output degradation.
+          const REASONING_MODEL_PATTERNS = [
+            /^mimo-/i,
+            /^deepseek.*reasoning/i,
+            /^o[13]-/i,
+            /^claude.*thinking/i,
+          ];
+
+          function isReasoningModel(modelId: string | undefined): boolean {
+            if (!modelId) return false;
+            return REASONING_MODEL_PATTERNS.some(pattern => pattern.test(modelId));
+          }
+
+          const modelId = ctx?.modelId || "";
+          const isReasoning = isReasoningModel(modelId);
+
+          // Apply model-specific budget adjustments
+          const baseMaxItems = config.autoRecallMaxItems ?? 3;
+          const baseMaxChars = config.autoRecallMaxChars ?? 600;
+          const basePerItemMaxChars = config.autoRecallPerItemMaxChars ?? 180;
+
+          // For reasoning models, use more conservative defaults (50% reduction)
+          const REASONING_MODEL_REDUCTION = 0.5;
+          const adjustedMaxItems = isReasoning ? Math.max(1, Math.floor(baseMaxItems * REASONING_MODEL_REDUCTION)) : baseMaxItems;
+          const adjustedMaxChars = isReasoning ? Math.max(64, Math.floor(baseMaxChars * REASONING_MODEL_REDUCTION)) : baseMaxChars;
+          const adjustedPerItemMaxChars = isReasoning ? Math.max(32, Math.floor(basePerItemMaxChars * REASONING_MODEL_REDUCTION)) : basePerItemMaxChars;
+
+          if (isReasoning) {
+            api.logger.info(
+              `memory-lancedb-pro: reasoning model detected (${modelId}), applying conservative injection limits: items=${adjustedMaxItems}, chars=${adjustedMaxChars}, perItem=${adjustedPerItemMaxChars}`
+            );
+          }
+
+          const autoRecallMaxItems = clampInt(adjustedMaxItems, 1, 20);
+          const autoRecallMaxChars = clampInt(adjustedMaxChars, 64, 8000);
+          const autoRecallPerItemMaxChars = clampInt(adjustedPerItemMaxChars, 32, 1000);
           const retrieveLimit = clampInt(Math.max(autoRecallMaxItems * 2, autoRecallMaxItems), 1, 20);
 
           const results = filterUserMdExclusiveRecallResults(await retrieveWithRetry({


### PR DESCRIPTION
## Summary

Reasoning models (mimo-v2.5, deepseek-reasoning, o1/o3, claude-thinking) are more sensitive to injected context and enter repetition loops when memory-lancedb-pro injects memories via auto-recall.

**Previous approach (50% reduction) was insufficient** - even with items=1, chars=300, perItem=90, mimo-v2.5 still produced `repetition_truncation` errors.

This fix **completely skips auto-recall** for reasoning models to prevent output degradation while still allowing manual memory recall via explicit commands.

## Problem

When using mimo-v2.5 with memory-lancedb-pro, the model enters repetition loops and generates `repetition_truncation` errors. This occurs because:

1. memory-lancedb-pro injects memories into context via `before_prompt_build` hook
2. Reasoning models are more sensitive to injected XML context
3. The model's reasoning chain gets confused by the untrusted-data block and enters repetitive output

**Logs show:**
```
memory-lancedb-pro: reasoning model detected (mimo-v2.5), applying conservative injection limits: items=1, chars=300, perItem=90
// Still: The model stopped because the provider returned an unhandled stop reason: repetition_truncation
```

## Solution

**Completely disable auto-recall for reasoning models** instead of just reducing limits:

1. **Detection**: Add `REASONING_MODEL_PATTERNS` to identify reasoning models by ID
2. **Skip entirely**: Return early from auto-recall hook for reasoning models
3. **Logging**: Log when auto-recall is skipped for debugging
4. **Preserve manual recall**: Users can still manually recall memories via explicit commands

## Changes

- Add `isReasoningModel()` function with patterns for mimo, deepseek-reasoning, o1/o3, claude-thinking
- Skip auto-recall entirely for reasoning models (return early)
- Add info log when auto-recall is skipped
- No breaking changes: standard models unaffected, reasoning models get no auto-injection

## Testing

- Verified with mimo-v2.5 in OpenClaw: repetition loops eliminated
- Standard models (deepseek-v4-flash, gpt-4o) continue working normally
- Manual memory recall still works for reasoning models

## Related Issues

- Fixes mimo-v2.5 repetition loops with memory injection
- See: https://github.com/openclaw/openclaw/issues/101570

## Breaking Changes

None. This is a backwards-compatible improvement that only affects reasoning models.
