### PR TITLE
fix: insert blank line before numbered items in injected reflection blocks

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3453,6 +3453,7 @@ const memoryLanceDBProPlugin = {
                         prependContext: [
                             "<inherited-rules>",
                             "Stable rules inherited from memory-lancedb-pro reflections. Treat as long-term behavioral constraints unless user overrides.",
+                            "",
                             body,
                             "</inherited-rules>",
                         ].join("\n"),
@@ -3495,6 +3496,7 @@ const memoryLanceDBProPlugin = {
                                 blocks.push([
                                     "<derived-focus>",
                                     "Weighted recent derived execution deltas from reflection memory:",
+                                    "",
                                     ...derivedLines.slice(0, 6).map((line, i) => `${i + 1}. ${line}`),
                                     "</derived-focus>",
                                 ].join("\n"));

--- a/index.ts
+++ b/index.ts
@@ -4482,6 +4482,7 @@ const memoryLanceDBProPlugin = {
             prependContext: [
               "<inherited-rules>",
               "Stable rules inherited from memory-lancedb-pro reflections. Treat as long-term behavioral constraints unless user overrides.",
+              "",
               body,
               "</inherited-rules>",
             ].join("\n"),
@@ -4527,6 +4528,7 @@ const memoryLanceDBProPlugin = {
                   [
                     "<derived-focus>",
                     "Weighted recent derived execution deltas from reflection memory:",
+                    "",
                     ...derivedLines.slice(0, 6).map((line, i) => `${i + 1}. ${line}`),
                     "</derived-focus>",
                   ].join("\n")

--- a/test/reflection-bypass-hook.test.mjs
+++ b/test/reflection-bypass-hook.test.mjs
@@ -176,6 +176,16 @@ describe("reflection hooks tolerate bypass scope filters", () => {
     assert.match(startResult?.prependContext || "", /Always verify reflection hook coverage for main\./);
     assert.match(promptResult?.prependContext || "", /<derived-focus>/);
     assert.match(promptResult?.prependContext || "", /Next run exercise the reflection injection path for main\./);
+    assert.match(
+      startResult?.prependContext || "",
+      /Treat as long-term behavioral constraints unless user overrides\.\n\n1\./,
+      "inherited-rules block should have a blank line between the header and the first numbered item",
+    );
+    assert.match(
+      promptResult?.prependContext || "",
+      /Weighted recent derived execution deltas from reflection memory:\n\n1\./,
+      "derived-focus block should have a blank line between the header and the first numbered item",
+    );
     assert.deepStrictEqual(
       harness.logs.filter(([level]) => level === "warn"),
       [],


### PR DESCRIPTION
## What Problem This Solves

The reflection prompt injection builder emits two blocks, `<inherited-rules>` and `<derived-focus>`, each of which pairs a header sentence with a numbered list of items. Both blocks joined the header and the first numbered item with a single newline. Plain text renders this fine, but some markdown viewers (for example trace UIs that render prompt context as markdown) require a blank line before a list for it to be recognized as a list at all. Without that blank line, the numbered items can collapse into a single run-on paragraph instead of a numbered list, and whether that happens is inconsistent across renderers.

## Why This Change Was Made

This is a formatting fix only. It inserts one blank line between the header sentence and the first numbered item in both blocks, so the numbered list renders as a list consistently everywhere it is viewed. No wording, tags, or item content changed, and the join between items themselves is untouched.

## User Impact

This is a cosmetic fix for anyone viewing these injected blocks in a markdown-rendering trace or debug UI. It has no effect on model comprehension: the underlying model reads the raw text either way, and a blank line between a header and a list does not change the meaning of the content. There is no behavior change for the plugin itself, only how the injected context looks when rendered as markdown.

## Evidence

- Added a regression assertion to the existing reflection hook test suite (`test/reflection-bypass-hook.test.mjs`) checking that both blocks contain a blank line between the header sentence and the first numbered item.
- Verified the new assertion fails against the pre-fix code and passes after the fix (stash-verified red before, green after).
- Ran the full local test suite; all tests pass (one unrelated test that binds to a fixed local port was skipped due to a pre-existing environment conflict with an already-running local service, unrelated to this change).
- `tsc` build completes with no errors, and the compiled `dist/index.js` reflects the same two-line change.
