### PR TITLE
chore: send the internal call label as a request header on the openai-compatible path

### DIFF
--- a/dist/src/llm-client.js
+++ b/dist/src/llm-client.js
@@ -74,6 +74,11 @@ function recoverJsonFromReasoning(reasoningText) {
 function shouldDisableReasoningForJson(model) {
     return /qwen3|deepseek.*r1|qwq/i.test(model);
 }
+/** Restrict a call label to header-safe characters (labels are internal literals). */
+function sanitizeLabelHeader(label) {
+    const cleaned = label.replace(/[^A-Za-z0-9._-]/g, "-").slice(0, 64);
+    return cleaned || "generic";
+}
 function previewText(value, maxLen = 200) {
     const normalized = value.replace(/\s+/g, " ").trim();
     if (normalized.length <= maxLen)
@@ -197,7 +202,14 @@ function createApiKeyClient(config, log, warnLog) {
                         ? { chat_template_kwargs: { enable_thinking: false } }
                         : {}),
                 };
-                const response = await client.chat.completions.create(request);
+                // Transmit the internal call label as a request header so gateway-side
+                // observability (tracing UIs, proxy logs) can distinguish call sites
+                // without any change to the prompt or sampling parameters. Applied on
+                // the openai-compatible path only; the OAuth path posts to a foreign
+                // endpoint with a fixed request shape and is left untouched.
+                const response = await client.chat.completions.create(request, {
+                    headers: { "x-memory-call-label": sanitizeLabelHeader(label) },
+                });
                 const message = response.choices?.[0]?.message;
                 const raw = message?.content;
                 if (!raw) {

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -103,6 +103,12 @@ function shouldDisableReasoningForJson(model: string): boolean {
   return /qwen3|deepseek.*r1|qwq/i.test(model);
 }
 
+/** Restrict a call label to header-safe characters (labels are internal literals). */
+function sanitizeLabelHeader(label: string): string {
+  const cleaned = label.replace(/[^A-Za-z0-9._-]/g, "-").slice(0, 64);
+  return cleaned || "generic";
+}
+
 function previewText(value: string, maxLen = 200): string {
   const normalized = value.replace(/\s+/g, " ").trim();
   if (normalized.length <= maxLen) return normalized;
@@ -245,7 +251,14 @@ function createApiKeyClient(config: LlmClientConfig, log: (msg: string) => void,
             : {}),
         };
 
-        const response = await client.chat.completions.create(request as any);
+        // Transmit the internal call label as a request header so gateway-side
+        // observability (tracing UIs, proxy logs) can distinguish call sites
+        // without any change to the prompt or sampling parameters. Applied on
+        // the openai-compatible path only; the OAuth path posts to a foreign
+        // endpoint with a fixed request shape and is left untouched.
+        const response = await client.chat.completions.create(request as any, {
+          headers: { "x-memory-call-label": sanitizeLabelHeader(label) },
+        });
 
         const message = response.choices?.[0]?.message;
         const raw = message?.content;

--- a/test/llm-api-key-client.test.mjs
+++ b/test/llm-api-key-client.test.mjs
@@ -52,6 +52,11 @@ describe("LLM api-key client", () => {
     const result = await llm.completeJson("hello", "api-key-probe");
     assert.deepEqual(result, { memories: [] });
     assert.equal(requestHeaders.authorization, "Bearer test-api-key");
+    assert.equal(
+      requestHeaders["x-memory-call-label"],
+      "api-key-probe",
+      "the internal call label must reach the gateway as a request header",
+    );
     assert.equal(requestBody.model, "gpt-4o-mini");
     assert.deepEqual(requestBody.messages, [
       {

--- a/test/llm-api-key-client.test.mjs
+++ b/test/llm-api-key-client.test.mjs
@@ -72,6 +72,86 @@ describe("LLM api-key client", () => {
     assert.equal(requestBody.chat_template_kwargs, undefined);
   });
 
+  it("sanitizes control/invalid characters out of the call label header", async () => {
+    let requestHeaders;
+
+    server = http.createServer(async (req, res) => {
+      requestHeaders = req.headers;
+      for await (const _chunk of req) { /* drain */ }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ choices: [{ message: { content: "{\"memories\":[]}" } }] }));
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = server.address().port;
+
+    const llm = createLlmClient({
+      auth: "api-key",
+      apiKey: "test-api-key",
+      model: "gpt-4o-mini",
+      baseURL: `http://127.0.0.1:${port}/v1`,
+    });
+
+    await llm.completeJson("hello", "weird label!!\r\ninjected: true");
+    assert.equal(
+      requestHeaders["x-memory-call-label"],
+      "weird-label----injected--true",
+      "non [A-Za-z0-9._-] characters (including CR/LF, which could otherwise inject a header) must be replaced with -",
+    );
+  });
+
+  it("truncates a call label header at 64 characters", async () => {
+    let requestHeaders;
+
+    server = http.createServer(async (req, res) => {
+      requestHeaders = req.headers;
+      for await (const _chunk of req) { /* drain */ }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ choices: [{ message: { content: "{\"memories\":[]}" } }] }));
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = server.address().port;
+
+    const llm = createLlmClient({
+      auth: "api-key",
+      apiKey: "test-api-key",
+      model: "gpt-4o-mini",
+      baseURL: `http://127.0.0.1:${port}/v1`,
+    });
+
+    const longLabel = "a".repeat(100);
+    await llm.completeJson("hello", longLabel);
+    assert.equal(requestHeaders["x-memory-call-label"], "a".repeat(64));
+  });
+
+  it("falls back to \"generic\" for a label that sanitizes to empty", async () => {
+    let requestHeaders;
+
+    server = http.createServer(async (req, res) => {
+      requestHeaders = req.headers;
+      for await (const _chunk of req) { /* drain */ }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ choices: [{ message: { content: "{\"memories\":[]}" } }] }));
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = server.address().port;
+
+    const llm = createLlmClient({
+      auth: "api-key",
+      apiKey: "test-api-key",
+      model: "gpt-4o-mini",
+      baseURL: `http://127.0.0.1:${port}/v1`,
+    });
+
+    // Every character the sanitizer regex rejects gets replaced with "-" (itself a
+    // valid, non-empty character), so a label full of invalid characters (e.g.
+    // "!!!###") sanitizes to "------", not "". The only input that actually reaches
+    // the sanitizer's `cleaned || "generic"` fallback is a genuinely empty label —
+    // and completeJson's own `label = "generic"` default only applies to `undefined`,
+    // not "", so an explicit empty string is the one way to exercise this branch.
+    await llm.completeJson("hello", "");
+    assert.equal(requestHeaders["x-memory-call-label"], "generic");
+  });
+
   it("disables thinking for reasoning models and strips reasoning traces before JSON parse", async () => {
     let requestBody;
 


### PR DESCRIPTION
## Problem

`completeJson` receives an internal `label` for every memory-pipeline call (extraction, admission-utility, dedup, merge), but the label is never transmitted. In observability tooling, every call appears as an indistinguishable generic LLM generation, and pipeline stages can only be told apart by reading prompt text.

## Fix

Send the label as a sanitized `x-memory-call-label` request header on the openai-compatible path. Prompt content, parameters, and the OAuth path (foreign fixed-shape endpoint) are untouched.

## Tests

Header presence and sanitization asserted in the existing mock-server test.
