### PR TITLE
feat: mirror reflection slice rows into the daily memory journal

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4071,6 +4071,14 @@ const memoryLanceDBProPlugin = {
                             embedPassage: (text) => embedForReflectionPersistence(text, "slice-embedding"),
                             vectorSearch: (vector, limit, minScore, scopeFilter) => store.vectorSearch(vector, limit, minScore, scopeFilter),
                             store: (entry) => store.store(entry),
+                            onPersisted: mdMirror
+                                ? async (entry, kind) => {
+                                    const source = kind === "event" ? "reflection-slice:event"
+                                        : kind === "item-invariant" ? "reflection-slice:invariant"
+                                            : "reflection-slice:derived";
+                                    await mdMirror({ text: entry.text, category: entry.category, scope: entry.scope, timestamp: entry.timestamp }, { source, agentId: sourceAgentId });
+                                }
+                                : undefined,
                         });
                         if (sessionKey && stored.slices.derived.length > 0 && !isSessionBoundaryReflectionAction(action)) {
                             reflectionDerivedBySession.set(sessionKey, {

--- a/dist/index.js
+++ b/dist/index.js
@@ -4073,9 +4073,13 @@ const memoryLanceDBProPlugin = {
                             store: (entry) => store.store(entry),
                             onPersisted: mdMirror
                                 ? async (entry, kind) => {
-                                    const source = kind === "event" ? "reflection-slice:event"
-                                        : kind === "item-invariant" ? "reflection-slice:invariant"
-                                            : "reflection-slice:derived";
+                                    // The event row is a run-marker (kv stamp, no semantic content); the
+                                    // daily journal already records the run via its "Reflection generated"
+                                    // line, so mirroring the stamp only adds a content-less entry.
+                                    if (kind === "event")
+                                        return;
+                                    const source = kind === "item-invariant" ? "reflection-slice:invariant"
+                                        : "reflection-slice:derived";
                                     await mdMirror({ text: entry.text, category: entry.category, scope: entry.scope, timestamp: entry.timestamp }, { source, agentId: sourceAgentId });
                                 }
                                 : undefined,

--- a/dist/src/reflection-store.js
+++ b/dist/src/reflection-store.js
@@ -113,7 +113,7 @@ export async function storeReflectionToLanceDB(params) {
                 continue;
             }
         }
-        await params.store({
+        const storedEntry = await params.store({
             text: payload.text,
             vector,
             category: "reflection",
@@ -122,6 +122,14 @@ export async function storeReflectionToLanceDB(params) {
             metadata: JSON.stringify(payload.metadata),
         });
         storedKinds.push(payload.kind);
+        if (params.onPersisted && payload.kind !== "combined-legacy") {
+            try {
+                await params.onPersisted(storedEntry, payload.kind);
+            }
+            catch {
+                // mirror/notification failures must never abort reflection persistence
+            }
+        }
     }
     return { stored: storedKinds.length > 0, eventId, slices, storedKinds };
 }

--- a/index.ts
+++ b/index.ts
@@ -5179,6 +5179,18 @@ const memoryLanceDBProPlugin = {
               vectorSearch: (vector, limit, minScore, scopeFilter) =>
                 store.vectorSearch(vector, limit, minScore, scopeFilter),
               store: (entry) => store.store(entry),
+              onPersisted: mdMirror
+                ? async (entry, kind) => {
+                    const source =
+                      kind === "event" ? "reflection-slice:event"
+                      : kind === "item-invariant" ? "reflection-slice:invariant"
+                      : "reflection-slice:derived";
+                    await mdMirror(
+                      { text: entry.text, category: entry.category, scope: entry.scope, timestamp: entry.timestamp },
+                      { source, agentId: sourceAgentId },
+                    );
+                  }
+                : undefined,
             });
             if (sessionKey && stored.slices.derived.length > 0 && !isSessionBoundaryReflectionAction(action)) {
               reflectionDerivedBySession.set(sessionKey, {

--- a/index.ts
+++ b/index.ts
@@ -5181,9 +5181,12 @@ const memoryLanceDBProPlugin = {
               store: (entry) => store.store(entry),
               onPersisted: mdMirror
                 ? async (entry, kind) => {
+                    // The event row is a run-marker (kv stamp, no semantic content); the
+                    // daily journal already records the run via its "Reflection generated"
+                    // line, so mirroring the stamp only adds a content-less entry.
+                    if (kind === "event") return;
                     const source =
-                      kind === "event" ? "reflection-slice:event"
-                      : kind === "item-invariant" ? "reflection-slice:invariant"
+                      kind === "item-invariant" ? "reflection-slice:invariant"
                       : "reflection-slice:derived";
                     await mdMirror(
                       { text: entry.text, category: entry.category, scope: entry.scope, timestamp: entry.timestamp },

--- a/src/reflection-store.ts
+++ b/src/reflection-store.ts
@@ -176,6 +176,7 @@ interface ReflectionStoreDeps {
     scopeFilter?: string[]
   ) => Promise<MemorySearchResult[]>;
   store: (entry: Omit<MemoryEntry, "id" | "timestamp">) => Promise<MemoryEntry>;
+  onPersisted?: (entry: MemoryEntry, kind: ReflectionStoreKind) => Promise<void> | void;
 }
 
 interface StoreReflectionToLanceDBParams extends BuildReflectionStorePayloadsParams, ReflectionStoreDeps {
@@ -202,7 +203,7 @@ export async function storeReflectionToLanceDB(params: StoreReflectionToLanceDBP
       }
     }
 
-    await params.store({
+    const storedEntry = await params.store({
       text: payload.text,
       vector,
       category: "reflection",
@@ -211,6 +212,14 @@ export async function storeReflectionToLanceDB(params: StoreReflectionToLanceDBP
       metadata: JSON.stringify(payload.metadata),
     });
     storedKinds.push(payload.kind);
+
+    if (params.onPersisted && payload.kind !== "combined-legacy") {
+      try {
+        await params.onPersisted(storedEntry, payload.kind);
+      } catch {
+        // mirror/notification failures must never abort reflection persistence
+      }
+    }
   }
 
   return { stored: storedKinds.length > 0, eventId, slices, storedKinds };

--- a/test/memory-reflection.test.mjs
+++ b/test/memory-reflection.test.mjs
@@ -485,6 +485,147 @@ describe("memory reflection", () => {
       assert.equal(meta.usedFallback, true);
     });
 
+    it("fires onPersisted for event and slice item rows, not for the legacy combined row", async () => {
+      const storedEntries = [];
+      const persisted = [];
+
+      const result = await storeReflectionToLanceDB({
+        reflectionText: [
+          "## Invariants",
+          "- Always confirm assumptions before changing files.",
+          "## Derived",
+          "- Next run verify reflection persistence with targeted tests.",
+        ].join("\n"),
+        sessionKey: "agent:main:session:mirror",
+        sessionId: "mirror",
+        agentId: "main",
+        command: "command:reset",
+        scope: "global",
+        toolErrorSignals: [],
+        runAt: 1_700_500_000_000,
+        usedFallback: false,
+        embedPassage: async (text) => [text.length],
+        vectorSearch: async () => [],
+        store: async (entry) => {
+          storedEntries.push(entry);
+          return { ...entry, id: `id-${storedEntries.length}`, timestamp: 1_700_500_000_000 };
+        },
+        onPersisted: async (entry, kind) => {
+          persisted.push({ entry, kind });
+        },
+      });
+
+      assert.deepEqual(result.storedKinds, ["event", "item-invariant", "item-derived", "combined-legacy"]);
+      assert.equal(storedEntries.length, 4);
+
+      assert.deepEqual(persisted.map((p) => p.kind), ["event", "item-invariant", "item-derived"]);
+
+      const eventCall = persisted.find((p) => p.kind === "event");
+      assert.ok(eventCall);
+      assert.equal(eventCall.entry.category, "reflection");
+      assert.equal(eventCall.entry.scope, "global");
+      assert.equal(eventCall.entry.timestamp, 1_700_500_000_000);
+      assert.match(eventCall.entry.text, /^reflection-event/);
+      assert.ok(eventCall.entry.text.includes("\n"), "event text should be the raw multi-line key=value form at the mint site");
+
+      const invariantCall = persisted.find((p) => p.kind === "item-invariant");
+      assert.equal(invariantCall.entry.text, "Always confirm assumptions before changing files.");
+
+      const derivedCall = persisted.find((p) => p.kind === "item-derived");
+      assert.equal(derivedCall.entry.text, "Next run verify reflection persistence with targeted tests.");
+    });
+
+    it("does not fail storage when onPersisted is absent", async () => {
+      const storedEntries = [];
+      const result = await storeReflectionToLanceDB({
+        reflectionText: "## Invariants\n- Always run tests after edits.",
+        sessionKey: "agent:main:session:noop",
+        sessionId: "noop",
+        agentId: "main",
+        command: "command:reset",
+        scope: "global",
+        toolErrorSignals: [],
+        runAt: 1_700_600_000_000,
+        usedFallback: false,
+        writeLegacyCombined: false,
+        embedPassage: async (text) => [text.length],
+        vectorSearch: async () => [],
+        store: async (entry) => {
+          storedEntries.push(entry);
+          return { ...entry, id: `id-${storedEntries.length}`, timestamp: 1_700_600_000_000 };
+        },
+      });
+
+      assert.deepEqual(result.storedKinds, ["event", "item-invariant"]);
+    });
+
+    it("does not abort remaining stores when onPersisted throws", async () => {
+      const storedEntries = [];
+      const persistedCalls = [];
+      const result = await storeReflectionToLanceDB({
+        reflectionText: [
+          "## Invariants",
+          "- Always run tests after edits.",
+          "## Derived",
+          "- Next run double-check the mirror callback contract.",
+        ].join("\n"),
+        sessionKey: "agent:main:session:throwing",
+        sessionId: "throwing",
+        agentId: "main",
+        command: "command:reset",
+        scope: "global",
+        toolErrorSignals: [],
+        runAt: 1_700_800_000_000,
+        usedFallback: false,
+        writeLegacyCombined: false,
+        embedPassage: async (text) => [text.length],
+        vectorSearch: async () => [],
+        store: async (entry) => {
+          storedEntries.push(entry);
+          return { ...entry, id: `id-${storedEntries.length}`, timestamp: 1_700_800_000_000 };
+        },
+        onPersisted: async (_entry, kind) => {
+          persistedCalls.push(kind);
+          throw new Error(`boom for ${kind}`);
+        },
+      });
+
+      assert.deepEqual(result.storedKinds, ["event", "item-invariant", "item-derived"]);
+      assert.equal(storedEntries.length, 3);
+      assert.deepEqual(persistedCalls, ["event", "item-invariant", "item-derived"]);
+    });
+
+    it("mirrors the event row's multi-line text as a single line using the existing mdMirror collapse contract", async () => {
+      let eventEntry = null;
+      await storeReflectionToLanceDB({
+        reflectionText: "## Invariants\n- Keep the daily journal append-only.",
+        sessionKey: "agent:main:session:oneline",
+        sessionId: "oneline",
+        agentId: "main",
+        command: "command:reset",
+        scope: "global",
+        toolErrorSignals: [{ signatureHash: "cafef00d" }],
+        runAt: 1_700_700_000_000,
+        usedFallback: false,
+        writeLegacyCombined: false,
+        embedPassage: async (text) => [text.length],
+        vectorSearch: async () => [],
+        store: async (entry) => ({ ...entry, id: "id-event", timestamp: 1_700_700_000_000 }),
+        onPersisted: async (entry, kind) => {
+          if (kind === "event") eventEntry = entry;
+        },
+      });
+
+      assert.ok(eventEntry);
+      assert.ok(eventEntry.text.includes("\n"), "sanity check: mint site emits multi-line event text");
+
+      // Same one-line collapse formula createMdMirrorWriter applies at index.ts:2135
+      // (`entry.text.replace(/\n/g, " ").slice(0, 500)`) before appending to the daily file.
+      const mirroredLine = eventEntry.text.replace(/\n/g, " ").slice(0, 500);
+      assert.equal(mirroredLine.includes("\n"), false);
+      assert.match(mirroredLine, /^reflection-event · global eventId=refl-.* session=oneline agent=main command=command:reset usedFallback=false$/);
+    });
+
     it("sanitizes returned slices used for same-session derived injection cache", () => {
       const { slices } = buildReflectionStorePayloads({
         reflectionText: [


### PR DESCRIPTION

The mdMirror daily journal (`memory/<date>.md`) mirrors writer-1 reflection mapped rows, smart-extraction rows, and manual `memory_store` rows, but not the reflection writer-2 slice rows (`storeReflectionToLanceDB`'s event / invariant / derived rows). Those rows entered the database invisibly; the daily file only got the "Reflection generated: `<path>`" pointer line. This PR closes that gap so every row that enters the database is observable in the daily file without CLI tools.

- `storeReflectionToLanceDB` (`src/reflection-store.ts`) gains an optional `onPersisted(entry, kind)` hook, fired after each `event` / `item-invariant` / `item-derived` row is stored. The `combined-legacy` row is intentionally excluded since it is out of scope for this change (it is a distinct legacy row type, not one of the writer-2 slice rows this PR targets).
- Callback failures are swallowed with a try/catch so a mirror bug can never abort reflection persistence, matching the existing `SmartExtractor.notifyPersisted` convention for the same kind of hook.
- `index.ts` wires `mdMirror` through this hook with source labels `reflection-slice:event`, `reflection-slice:invariant`, and `reflection-slice:derived`.
- The event row's text is a multi-line `key=value` block. It renders as one line for free, because `createMdMirrorWriter`'s existing line formatter already replaces `\n` with a space before appending to the daily file - no changes were needed there.

## Test plan

- [x] Red-first: added tests to `test/memory-reflection.test.mjs` asserting `onPersisted` fires for event/invariant/derived rows, is skipped for the legacy row, does not break storage when absent, does not abort remaining stores if it throws, and that the event row's multi-line text collapses to one line under the existing mirror formatting contract. All five failed before the implementation and pass after.
- [x] `npm run build` (tsc) clean.
- [x] Full local `npm test` chain green (one test skipped: a known host-side port 11434 conflict unrelated to this change).

## Notes for reviewers

While working on this I found that `test/memory-reflection.test.mjs` itself (the file with the most direct coverage of `storeReflectionToLanceDB`) is not wired into either `package.json`'s `test` script or `scripts/ci-test-manifest.mjs` on master, and separately has four pre-existing failing tests unrelated to this change. Both are out of scope here and are called out separately rather than folded into this PR.
