### PR TITLE
docs: surface Jina task hints (and the re-embed they require)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,62 @@ openclaw memory-pro stats
 
 See `CHANGELOG-v1.1.0.md` for behavior changes and upgrade rationale.
 
+**Turning on Jina task hints on an existing database?**
+
+Task hints are two config keys under the plugin's `embedding` block:
+
+```jsonc
+"memory-lancedb-pro": {
+  "config": {
+    "embedding": {
+      "model": "jina-embeddings-v5-text-small",
+      "taskQuery": "retrieval.query",
+      "taskPassage": "retrieval.passage"
+    }
+  }
+}
+```
+
+They only affect vectors written *after* you set them. Rows already in your store
+were embedded without a task hint, so a query embedded with `retrieval.query` is
+compared against passages that live in a different vector space — you get roughly
+half the benefit, silently.
+
+To fix existing rows, re-embed into a **fresh database and cut over to it**. Do
+**not** re-embed in place: `reembed` writes each row with `table.add()` (append by
+id, not replace), so an in-place run — which is exactly what `--force` unlocks —
+leaves the old vector beside the new one and **doubles every row**; retries pile on
+more. `reembed` refuses same-path runs unless you force it, for this reason.
+
+```bash
+# 0) Stop the gateway so nothing writes mid-migration.
+
+# 1) Back up the whole store — a real filesystem copy of the LanceDB directory.
+#    (Do NOT rely on `memory-pro export`: it defaults to --limit 1000 and a single
+#    --scope, so it silently drops rows past 1000 and every non-global scope.)
+cp -r <your dbPath> <your dbPath>.bak
+
+# 2) In the plugin config, set the task hints AND point `dbPath` at a new, empty
+#    target (e.g. "<your dbPath>-v2"). A fresh target is also what lets you change
+#    `embedding.dimensions`: a new vector width can only go into a new table.
+
+# 3) Dry run — reads the source, prints the row count, writes nothing.
+openclaw memory-pro reembed --source-db <old dbPath> --dry-run
+
+# 4) Re-embed old -> new with the now-current task hints. Source != target, so each
+#    id lands exactly once. Safe to re-run with --skip-existing if interrupted.
+openclaw memory-pro reembed --source-db <old dbPath>
+
+# 5) Verify before trusting the cutover: the "imported" count and
+#    `memory-pro stats` on the new dbPath must equal the dry-run row count.
+openclaw memory-pro stats
+
+# 6) Start the gateway; it now opens the new dbPath.
+```
+
+The same cutover applies whenever you change `embedding.model` or
+`embedding.dimensions` — always re-embed into a fresh `dbPath`, never in place.
+
 </details>
 
 <details>
@@ -220,7 +276,7 @@ Help me connect this memory plugin with the most user-friendly configuration: ht
 
 Requirements:
 1. Set it as the only active memory plugin
-2. Use Jina for embedding
+2. Use Jina for embedding, and set embedding.taskQuery=retrieval.query and embedding.taskPassage=retrieval.passage
 3. Use Jina for reranker
 4. Use gpt-4o-mini for the smart-extraction LLM
 5. Enable autoCapture, autoRecall, smartExtraction

--- a/README_CN.md
+++ b/README_CN.md
@@ -160,6 +160,60 @@ openclaw memory-pro stats
 
 详见 `CHANGELOG-v1.1.0.md` 了解行为变更和升级说明。
 
+**在已有数据库上启用 Jina task hints？**
+
+Task hints 是插件 `embedding` 配置块下的两个键：
+
+```jsonc
+"memory-lancedb-pro": {
+  "config": {
+    "embedding": {
+      "model": "jina-embeddings-v5-text-small",
+      "taskQuery": "retrieval.query",
+      "taskPassage": "retrieval.passage"
+    }
+  }
+}
+```
+
+它们只影响设置**之后**写入的向量。库里已有的记录是在没有 task hint 的情况下嵌入的，
+因此用 `retrieval.query` 嵌入的查询，会去和另一个向量空间里的 passage 做比较——
+收益大约只剩一半，而且没有任何提示。
+
+要修复已有记录，请**重嵌到一个全新的库并切换过去**。**切勿原地重嵌**：`reembed`
+用 `table.add()` 写入（按 id 追加，而非替换），所以原地运行——也正是 `--force`
+所解锁的——会让旧向量和新向量并存，**每条记录翻倍**，重试还会继续叠加。正因如此，
+`reembed` 默认拒绝源库=目标库，除非你强行 `--force`。
+
+```bash
+# 0) 先停网关，避免迁移过程中有写入。
+
+# 1) 备份整个库——直接对 LanceDB 目录做文件系统级拷贝。
+#    （不要用 `memory-pro export`：它默认 --limit 1000、单一 --scope，
+#      会静默丢掉第 1000 行之后的记录以及所有非 global scope。）
+cp -r <你的 dbPath> <你的 dbPath>.bak
+
+# 2) 在插件配置里设好 task hints，并把 `dbPath` 指向一个新的空目标
+#    （例如 "<你的 dbPath>-v2"）。换新目标也是修改 `embedding.dimensions`
+#      的前提：新的向量维度只能写进新表。
+
+# 3) Dry run——读源库、打印行数、不写入。
+openclaw memory-pro reembed --source-db <旧 dbPath> --dry-run
+
+# 4) 用现在生效的 task hints 把旧库重嵌到新库。源≠目标，每个 id 只落一次。
+#    中断了可加 --skip-existing 安全重跑。
+openclaw memory-pro reembed --source-db <旧 dbPath>
+
+# 5) 切换前先核对：imported 数量、以及新 dbPath 上 `memory-pro stats` 的总数，
+#    都要等于 dry-run 报告的行数。
+openclaw memory-pro stats
+
+# 6) 启动网关，此时它打开的是新 dbPath。
+```
+
+修改 `embedding.model` 或 `embedding.dimensions` 时用同样的切换流程——
+始终重嵌到新的 `dbPath`，绝不原地重嵌。
+
 </details>
 
 <details>
@@ -174,7 +228,7 @@ Help me connect this memory plugin with the most user-friendly configuration: ht
 
 Requirements:
 1. Set it as the only active memory plugin
-2. Use Jina for embedding
+2. Use Jina for embedding, and set embedding.taskQuery=retrieval.query and embedding.taskPassage=retrieval.passage
 3. Use Jina for reranker
 4. Use gpt-4o-mini for the smart-extraction LLM
 5. Enable autoCapture, autoRecall, smartExtraction

--- a/README_DE.md
+++ b/README_DE.md
@@ -174,7 +174,7 @@ Help me connect this memory plugin with the most user-friendly configuration: ht
 
 Requirements:
 1. Set it as the only active memory plugin
-2. Use Jina for embedding
+2. Use Jina for embedding, and set embedding.taskQuery=retrieval.query and embedding.taskPassage=retrieval.passage
 3. Use Jina for reranker
 4. Use gpt-4o-mini for the smart-extraction LLM
 5. Enable autoCapture, autoRecall, smartExtraction

--- a/README_ES.md
+++ b/README_ES.md
@@ -174,7 +174,7 @@ Help me connect this memory plugin with the most user-friendly configuration: ht
 
 Requirements:
 1. Set it as the only active memory plugin
-2. Use Jina for embedding
+2. Use Jina for embedding, and set embedding.taskQuery=retrieval.query and embedding.taskPassage=retrieval.passage
 3. Use Jina for reranker
 4. Use gpt-4o-mini for the smart-extraction LLM
 5. Enable autoCapture, autoRecall, smartExtraction

--- a/README_FR.md
+++ b/README_FR.md
@@ -174,7 +174,7 @@ Help me connect this memory plugin with the most user-friendly configuration: ht
 
 Requirements:
 1. Set it as the only active memory plugin
-2. Use Jina for embedding
+2. Use Jina for embedding, and set embedding.taskQuery=retrieval.query and embedding.taskPassage=retrieval.passage
 3. Use Jina for reranker
 4. Use gpt-4o-mini for the smart-extraction LLM
 5. Enable autoCapture, autoRecall, smartExtraction

--- a/README_IT.md
+++ b/README_IT.md
@@ -174,7 +174,7 @@ Help me connect this memory plugin with the most user-friendly configuration: ht
 
 Requirements:
 1. Set it as the only active memory plugin
-2. Use Jina for embedding
+2. Use Jina for embedding, and set embedding.taskQuery=retrieval.query and embedding.taskPassage=retrieval.passage
 3. Use Jina for reranker
 4. Use gpt-4o-mini for the smart-extraction LLM
 5. Enable autoCapture, autoRecall, smartExtraction

--- a/README_JA.md
+++ b/README_JA.md
@@ -174,7 +174,7 @@ Help me connect this memory plugin with the most user-friendly configuration: ht
 
 Requirements:
 1. Set it as the only active memory plugin
-2. Use Jina for embedding
+2. Use Jina for embedding, and set embedding.taskQuery=retrieval.query and embedding.taskPassage=retrieval.passage
 3. Use Jina for reranker
 4. Use gpt-4o-mini for the smart-extraction LLM
 5. Enable autoCapture, autoRecall, smartExtraction

--- a/README_KO.md
+++ b/README_KO.md
@@ -174,7 +174,7 @@ Help me connect this memory plugin with the most user-friendly configuration: ht
 
 Requirements:
 1. Set it as the only active memory plugin
-2. Use Jina for embedding
+2. Use Jina for embedding, and set embedding.taskQuery=retrieval.query and embedding.taskPassage=retrieval.passage
 3. Use Jina for reranker
 4. Use gpt-4o-mini for the smart-extraction LLM
 5. Enable autoCapture, autoRecall, smartExtraction

--- a/README_PT-BR.md
+++ b/README_PT-BR.md
@@ -174,7 +174,7 @@ Help me connect this memory plugin with the most user-friendly configuration: ht
 
 Requirements:
 1. Set it as the only active memory plugin
-2. Use Jina for embedding
+2. Use Jina for embedding, and set embedding.taskQuery=retrieval.query and embedding.taskPassage=retrieval.passage
 3. Use Jina for reranker
 4. Use gpt-4o-mini for the smart-extraction LLM
 5. Enable autoCapture, autoRecall, smartExtraction

--- a/README_RU.md
+++ b/README_RU.md
@@ -174,7 +174,7 @@ Help me connect this memory plugin with the most user-friendly configuration: ht
 
 Requirements:
 1. Set it as the only active memory plugin
-2. Use Jina for embedding
+2. Use Jina for embedding, and set embedding.taskQuery=retrieval.query and embedding.taskPassage=retrieval.passage
 3. Use Jina for reranker
 4. Use gpt-4o-mini for the smart-extraction LLM
 5. Enable autoCapture, autoRecall, smartExtraction

--- a/README_TW.md
+++ b/README_TW.md
@@ -174,7 +174,7 @@ Help me connect this memory plugin with the most user-friendly configuration: ht
 
 Requirements:
 1. Set it as the only active memory plugin
-2. Use Jina for embedding
+2. Use Jina for embedding, and set embedding.taskQuery=retrieval.query and embedding.taskPassage=retrieval.passage
 3. Use Jina for reranker
 4. Use gpt-4o-mini for the smart-extraction LLM
 5. Enable autoCapture, autoRecall, smartExtraction


### PR DESCRIPTION
## Problem

The recommended-config prompt says **"Use Jina for embedding"** but never mentions task hints. `jina-embeddings-v5` is an asymmetric retrieval model — without `task`, the retrieval adapter is never activated. Since that prompt is what generates the user's `openclaw.json`, **every user who follows this README silently runs at degraded recall**.

The knob already exists (`embedding.taskQuery` / `embedding.taskPassage`, documented in `configSchema`) — it's just not surfaced anywhere a new user would look.

## Evidence

Real production store (~4k Chinese memories, ~6 months of use). Retrieval set: **208 docs** (12 with a known gold answer + 196 distractors from the same store) × **12 real user queries**.

| | MRR | Top-1 | mean margin |
|---|---|---|---|
| without task | 0.690 | 7/12 (58%) | +0.049 |
| with task | **0.854** | **9/12 (75%)** | **+0.143** |

`mean margin = cos(gold) − cos(best distractor)`. **Without task hints the gold answer loses the top slot 42% of the time.**

## Why the second commit

Task hints only affect vectors written *after* they are set. Turning them on over an existing store leaves queries in one space and passages in another — and nothing warns about it.

Measured on the same store: re-embedding identical text with vs without a task hint gives **cosine 0.53–0.70 (mean 0.63)** between the two vectors. Same model, same text. Enabling the config without re-embedding captures only about half the gain.

`reembed` already does the right thing (`cli.ts:1900` → `embedBatchPassage`), it just isn't mentioned near the task-hint config.

## A note on "asymmetric"

The gain comes from **having a task tag at all**, not from pairing query/passage correctly. On a 6-doc probe, tagging both sides with `retrieval.query` scored about the same as the official pairing (+0.314 vs +0.321 — noise-level). Tagging only one side captures roughly half. So the README line matters more than getting the pairing exactly right.

## Changes

- **1/2**: one line in the Requirements list → applied to all 11 README translations (that block is English everywhere, keeping it in sync)
- **2/2**: a re-embed note in the existing-users/upgrade section → `README.md` + `README_CN.md` only; other translations are localized and belong to your translation flow

Docs only, no code changes.
