### PR TITLE
fix: keep session key/id out of the indexed session-summary text

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5104,10 +5104,15 @@ const memoryLanceDBProPlugin = {
         const now = new Date(params.timestampMs ?? Date.now());
         const dateStr = now.toISOString().split("T")[0];
         const timeStr = now.toISOString().split("T")[1].split(".")[0];
+        // Session key/id stay out of `text`: it is the FTS index surface, and
+        // the `simple` tokenizer splits a key like
+        // `agent:main:cron:<uuid>:run:<uuid>` on its punctuation — so every session
+        // summary ends up indexed under `agent`, `main`, `cron`, `run`. A query
+        // mentioning any of those then BM25-matches every session summary in the
+        // store regardless of content. Both ids are already recorded structurally
+        // in metadata below, so provenance is unaffected.
         const memoryText = [
           `Session: ${dateStr} ${timeStr} UTC`,
-          `Session Key: ${params.sessionKey}`,
-          `Session ID: ${params.sessionId}`,
           `Source: ${params.source}`,
           "",
           "Conversation Summary:",


### PR DESCRIPTION
## Problem

`sessionMemory` writes the session key and id into `memoryText`, which becomes the `text` column — i.e. the FTS index surface (`store.ts`, `Index.fts({ withPosition: true })` on `"text"`).

The default `simple` tokenizer splits on punctuation, so a key like

```
agent:main:cron:6a0a1fee-3cc8-48b1-9f90-eb67e18750df:run:cb003d74-6213-47ea-a69f-7d196d6b168a
```

gets indexed as `agent`, `main`, `cron`, `run`, `6a0a1fee`, `3cc8`, … — and **those first four tokens appear in every session summary in the store**.

## Reproduction

Fresh table built the same way `store.ts` does it (`Index.fts({ withPosition: true })`), 10 session summaries with distinct content + 5 unrelated memories. Two variants, identical except for the two id lines:

| query | with ids | without ids |
|---|---|---|
| `cron` | **10/10 summaries** | 0/10 |
| `main` | **10/10 summaries** | 0/10 |
| `run` | **10/10 summaries** | 0/10 |
| `agent main cron run` | **10/10 summaries** | 0/10 |
| `6a0a1fee` | 2/10 summaries | 0/10 |
| `weight target 83.9kg` | 1/10 (the right one) | 1/10 (the right one) |

The summaries matched by `cron` were about weight targets, BTC positions, paper drafts — nothing to do with cron. `agent` / `main` / `cron` / `run` are words OpenClaw users type constantly.

Content-bearing queries behave identically with or without the ids, so removing them costs nothing on the hit side and removes the false matches.

## Why this is safe

- `sessionKey` and `sessionId` are already written structurally into the metadata immediately below (`sessionKey:`, `sessionId:`, `date:`), so provenance is unchanged.
- Nothing reads them back out of `text`. The other `Session Key:` occurrences in the tree (`reflection-store.ts`, the reflection file header in `index.ts`) build file headers, not indexed rows.

## Scope

Only affects `retrieval.mode = hybrid` (the default) with `sessionMemory.enabled = true`.

Vector side is unaffected — I measured cosine 0.984 between the with-ids and without-ids embeddings of the same summary, so this is a BM25-only issue. Chinese queries are also unaffected, since the `simple` tokenizer doesn't segment CJK at all.
