### PR TITLE
docs: use a whole-store filesystem backup before upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ Done! Your agent now has long-term memory.
 
 ```bash
 # 1) Backup
-openclaw memory-pro export --scope global --output memories-backup.json
+cp -r <your dbPath> <your dbPath>.bak
+#    whole-store copy; `export` caps at --limit 1000 and one --scope,
+#    so it silently drops rows past 1000 and every non-global scope
 # 2) Dry run
 openclaw memory-pro upgrade --dry-run
 # 3) Run upgrade

--- a/README_CN.md
+++ b/README_CN.md
@@ -149,7 +149,9 @@ openclaw logs --follow --plain | grep "memory-lancedb-pro"
 
 ```bash
 # 1) 备份
-openclaw memory-pro export --scope global --output memories-backup.json
+cp -r <your dbPath> <your dbPath>.bak
+#    whole-store copy; `export` caps at --limit 1000 and one --scope,
+#    so it silently drops rows past 1000 and every non-global scope
 # 2) 试运行
 openclaw memory-pro upgrade --dry-run
 # 3) 执行升级

--- a/README_DE.md
+++ b/README_DE.md
@@ -149,7 +149,9 @@ Fertig! Ihr Agent verfügt jetzt über Langzeitgedächtnis.
 
 ```bash
 # 1) Backup
-openclaw memory-pro export --scope global --output memories-backup.json
+cp -r <your dbPath> <your dbPath>.bak
+#    whole-store copy; `export` caps at --limit 1000 and one --scope,
+#    so it silently drops rows past 1000 and every non-global scope
 # 2) Testlauf
 openclaw memory-pro upgrade --dry-run
 # 3) Upgrade ausführen

--- a/README_ES.md
+++ b/README_ES.md
@@ -149,7 +149,9 @@ Deberías ver:
 
 ```bash
 # 1) Respaldo
-openclaw memory-pro export --scope global --output memories-backup.json
+cp -r <your dbPath> <your dbPath>.bak
+#    whole-store copy; `export` caps at --limit 1000 and one --scope,
+#    so it silently drops rows past 1000 and every non-global scope
 # 2) Ejecución de prueba
 openclaw memory-pro upgrade --dry-run
 # 3) Ejecutar actualización

--- a/README_FR.md
+++ b/README_FR.md
@@ -149,7 +149,9 @@ Terminé ! Votre agent dispose maintenant d'une mémoire long terme.
 
 ```bash
 # 1) Sauvegarde
-openclaw memory-pro export --scope global --output memories-backup.json
+cp -r <your dbPath> <your dbPath>.bak
+#    whole-store copy; `export` caps at --limit 1000 and one --scope,
+#    so it silently drops rows past 1000 and every non-global scope
 # 2) Simulation
 openclaw memory-pro upgrade --dry-run
 # 3) Exécution de la mise à niveau

--- a/README_IT.md
+++ b/README_IT.md
@@ -149,7 +149,9 @@ Fatto! Il tuo agente ora ha una memoria a lungo termine.
 
 ```bash
 # 1) Backup
-openclaw memory-pro export --scope global --output memories-backup.json
+cp -r <your dbPath> <your dbPath>.bak
+#    whole-store copy; `export` caps at --limit 1000 and one --scope,
+#    so it silently drops rows past 1000 and every non-global scope
 # 2) Dry run
 openclaw memory-pro upgrade --dry-run
 # 3) Run upgrade

--- a/README_JA.md
+++ b/README_JA.md
@@ -149,7 +149,9 @@ openclaw logs --follow --plain | grep "memory-lancedb-pro"
 
 ```bash
 # 1) バックアップ
-openclaw memory-pro export --scope global --output memories-backup.json
+cp -r <your dbPath> <your dbPath>.bak
+#    whole-store copy; `export` caps at --limit 1000 and one --scope,
+#    so it silently drops rows past 1000 and every non-global scope
 # 2) ドライラン
 openclaw memory-pro upgrade --dry-run
 # 3) アップグレード実行

--- a/README_KO.md
+++ b/README_KO.md
@@ -149,7 +149,9 @@ openclaw logs --follow --plain | grep "memory-lancedb-pro"
 
 ```bash
 # 1) 백업
-openclaw memory-pro export --scope global --output memories-backup.json
+cp -r <your dbPath> <your dbPath>.bak
+#    whole-store copy; `export` caps at --limit 1000 and one --scope,
+#    so it silently drops rows past 1000 and every non-global scope
 # 2) 시뮬레이션 실행
 openclaw memory-pro upgrade --dry-run
 # 3) 업그레이드 실행

--- a/README_PT-BR.md
+++ b/README_PT-BR.md
@@ -149,7 +149,9 @@ Pronto! Seu agente agora tem memória de longo prazo.
 
 ```bash
 # 1) Backup
-openclaw memory-pro export --scope global --output memories-backup.json
+cp -r <your dbPath> <your dbPath>.bak
+#    whole-store copy; `export` caps at --limit 1000 and one --scope,
+#    so it silently drops rows past 1000 and every non-global scope
 # 2) Dry run
 openclaw memory-pro upgrade --dry-run
 # 3) Run upgrade

--- a/README_RU.md
+++ b/README_RU.md
@@ -149,7 +149,9 @@ openclaw logs --follow --plain | grep "memory-lancedb-pro"
 
 ```bash
 # 1) Резервная копия
-openclaw memory-pro export --scope global --output memories-backup.json
+cp -r <your dbPath> <your dbPath>.bak
+#    whole-store copy; `export` caps at --limit 1000 and one --scope,
+#    so it silently drops rows past 1000 and every non-global scope
 # 2) Пробный запуск
 openclaw memory-pro upgrade --dry-run
 # 3) Выполнить апгрейд

--- a/README_TW.md
+++ b/README_TW.md
@@ -149,7 +149,9 @@ openclaw logs --follow --plain | grep "memory-lancedb-pro"
 
 ```bash
 # 1) 備份
-openclaw memory-pro export --scope global --output memories-backup.json
+cp -r <your dbPath> <your dbPath>.bak
+#    whole-store copy; `export` caps at --limit 1000 and one --scope,
+#    so it silently drops rows past 1000 and every non-global scope
 # 2) 試執行
 openclaw memory-pro upgrade --dry-run
 # 3) 執行升級


### PR DESCRIPTION
The pre-v1.1.0 upgrade steps back up with `memory-pro export --scope global`. But `export` defaults to `--limit 1000` and a single `--scope` (`cli.ts`), so a store with more than 1000 rows — or any memories outside `global` (e.g. `agent:*` scopes) — gets a **silently incomplete backup**: exactly the safety net an in-place `upgrade` is supposed to provide.

This replaces the backup command with a filesystem copy of the LanceDB directory (`cp -r`), which captures the whole store regardless of row count or scope, across all 11 language READMEs. Docs-only; no code change.

Noticed while addressing review feedback on #953, which fixes the same `export`-as-backup pattern in the Jina task-hint migration section.