### PR TITLE
feat(reflection): add memoryReflection.includeGroupChats toggle for group-chat reflection generation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -778,6 +778,29 @@ function asNonEmptyString(value) {
 function isInternalReflectionSessionKey(sessionKey) {
     return typeof sessionKey === "string" && sessionKey.trim().startsWith("temp:memory-reflection");
 }
+// Multi-party vs direct peer kinds at the session key's STRUCTURAL kind
+// position, mirroring core's parseSessionDeliveryRoute shape
+// (src/sessions/session-key-utils.ts): agent:<agentId>:<channel>:<peerKind>:
+// <opaque peer id...>, with an optional ":thread:<id>" suffix. The peer id
+// tail is opaque and may itself contain segments like ":channel:" (e.g.
+// "agent:main:discord:direct:user:channel:1" is a DIRECT route), so only the
+// kind position may decide -- never a full-key search. Unrecognized shapes
+// (main sessions, subagents, account-scoped forms, cron) fail toward
+// generating reflections, matching the toggle's enabled default.
+const GROUP_SESSION_PEER_KINDS = new Set(["group", "channel", "room"]);
+function isGroupChatSessionKey(sessionKey) {
+    if (typeof sessionKey !== "string" || sessionKey.length === 0) {
+        return false;
+    }
+    const lower = sessionKey.toLowerCase();
+    const threadAt = lower.lastIndexOf(":thread:");
+    const base = threadAt === -1 ? lower : lower.slice(0, threadAt);
+    const parts = base.split(":");
+    if (parts[0] !== "agent" || parts.length < 5) {
+        return false;
+    }
+    return GROUP_SESSION_PEER_KINDS.has(parts[3]);
+}
 // Any :subagent:/:active-memory: sub-build (delegated subagents in general, not only
 // memory-internal ones) is treated as "its context comes from the parent" across every
 // memory-adjacent hook in this file: auto-recall injection, reflection injection, and
@@ -4406,6 +4429,21 @@ const memoryLanceDBProPlugin = {
                     api.logger.debug?.(`memory-reflection: command hook skipped (excluded agent=${sourceAgentId}, sessionKey=${sessionKey ?? "(none)"})`);
                     return;
                 }
+                // Group-chat opt-out (memoryReflection.includeGroupChats=false): the
+                // distiller input for multi-party sessions misattributes speakers, so
+                // operators can skip reflection generation on group channels entirely.
+                if (config.memoryReflection?.includeGroupChats === false && isGroupChatSessionKey(sessionKey)) {
+                    // A boundary command still rotates the session even though
+                    // generation is skipped: drop its per-session error state here
+                    // (normally the generation path's finally does this), or a
+                    // pre-boundary tool error leaks an <error-detected> reminder into
+                    // the next session's prompts until session_end cleanup wins the race.
+                    if (sessionKey && isSessionBoundaryReflectionAction(action)) {
+                        reflectionErrorStateBySession.delete(sessionKey);
+                    }
+                    api.logger.info(`memory-reflection: command:${action} skipped (group-chat reflection disabled, sessionKey=${sessionKey ?? "(none)"})`);
+                    return;
+                }
                 let emptyEventGuardKey;
                 const isBoundaryAction = isSessionBoundaryReflectionAction(action);
                 if (isBoundaryAction) {
@@ -5566,6 +5604,7 @@ export function parsePluginConfig(value) {
                 excludeAgents: Array.isArray(memoryReflectionRaw.excludeAgents)
                     ? memoryReflectionRaw.excludeAgents.filter((id) => typeof id === "string" && id.trim() !== "")
                     : undefined,
+                includeGroupChats: memoryReflectionRaw.includeGroupChats !== false,
             }
             : {
                 enabled: sessionStrategy === "memoryReflection",
@@ -5582,6 +5621,7 @@ export function parsePluginConfig(value) {
                 serialCooldownMs: DEFAULT_SERIAL_GUARD_COOLDOWN_MS,
                 maxConcurrentRuns: DEFAULT_REFLECTION_MAX_CONCURRENT_RUNS,
                 excludeAgents: undefined,
+                includeGroupChats: true,
             },
         sessionMemory: typeof cfg.sessionMemory === "object" && cfg.sessionMemory !== null
             ? {

--- a/index.ts
+++ b/index.ts
@@ -314,6 +314,8 @@ interface PluginConfig {
     maxConcurrentRuns?: number;
     /** Agent/session patterns excluded from reflection injection. Supports exact match, wildcard prefix (e.g. "pi-"), and "temp:*". */
     excludeAgents?: string[];
+    /** Run the reflection distiller for group-chat sessions (session keys carrying a ":group:" or ":channel:" segment). Default: true. Set false to skip reflection generation on group channels. */
+    includeGroupChats?: boolean;
   };
   mdMirror?: { enabled?: boolean; dir?: string };
   workspaceBoundary?: WorkspaceBoundaryConfig;
@@ -1216,6 +1218,31 @@ function asNonEmptyString(value: unknown): string | undefined {
 
 function isInternalReflectionSessionKey(sessionKey: unknown): boolean {
   return typeof sessionKey === "string" && sessionKey.trim().startsWith("temp:memory-reflection");
+}
+
+// Multi-party vs direct peer kinds at the session key's STRUCTURAL kind
+// position, mirroring core's parseSessionDeliveryRoute shape
+// (src/sessions/session-key-utils.ts): agent:<agentId>:<channel>:<peerKind>:
+// <opaque peer id...>, with an optional ":thread:<id>" suffix. The peer id
+// tail is opaque and may itself contain segments like ":channel:" (e.g.
+// "agent:main:discord:direct:user:channel:1" is a DIRECT route), so only the
+// kind position may decide -- never a full-key search. Unrecognized shapes
+// (main sessions, subagents, account-scoped forms, cron) fail toward
+// generating reflections, matching the toggle's enabled default.
+const GROUP_SESSION_PEER_KINDS = new Set(["group", "channel", "room"]);
+
+function isGroupChatSessionKey(sessionKey: string | undefined): boolean {
+  if (typeof sessionKey !== "string" || sessionKey.length === 0) {
+    return false;
+  }
+  const lower = sessionKey.toLowerCase();
+  const threadAt = lower.lastIndexOf(":thread:");
+  const base = threadAt === -1 ? lower : lower.slice(0, threadAt);
+  const parts = base.split(":");
+  if (parts[0] !== "agent" || parts.length < 5) {
+    return false;
+  }
+  return GROUP_SESSION_PEER_KINDS.has(parts[3]);
 }
 
 // Any :subagent:/:active-memory: sub-build (delegated subagents in general, not only
@@ -5595,6 +5622,23 @@ const memoryLanceDBProPlugin = {
           );
           return;
         }
+        // Group-chat opt-out (memoryReflection.includeGroupChats=false): the
+        // distiller input for multi-party sessions misattributes speakers, so
+        // operators can skip reflection generation on group channels entirely.
+        if (config.memoryReflection?.includeGroupChats === false && isGroupChatSessionKey(sessionKey)) {
+          // A boundary command still rotates the session even though
+          // generation is skipped: drop its per-session error state here
+          // (normally the generation path's finally does this), or a
+          // pre-boundary tool error leaks an <error-detected> reminder into
+          // the next session's prompts until session_end cleanup wins the race.
+          if (sessionKey && isSessionBoundaryReflectionAction(action)) {
+            reflectionErrorStateBySession.delete(sessionKey);
+          }
+          api.logger.info(
+            `memory-reflection: command:${action} skipped (group-chat reflection disabled, sessionKey=${sessionKey ?? "(none)"})`,
+          );
+          return;
+        }
 
         let emptyEventGuardKey: string | undefined;
         const isBoundaryAction = isSessionBoundaryReflectionAction(action);
@@ -6952,6 +6996,7 @@ export function parsePluginConfig(value: unknown): PluginConfig {
         excludeAgents: Array.isArray(memoryReflectionRaw.excludeAgents)
           ? memoryReflectionRaw.excludeAgents.filter((id: unknown): id is string => typeof id === "string" && id.trim() !== "")
           : undefined,
+        includeGroupChats: memoryReflectionRaw.includeGroupChats !== false,
       }
       : {
         enabled: sessionStrategy === "memoryReflection",
@@ -6968,6 +7013,7 @@ export function parsePluginConfig(value: unknown): PluginConfig {
         serialCooldownMs: DEFAULT_SERIAL_GUARD_COOLDOWN_MS,
         maxConcurrentRuns: DEFAULT_REFLECTION_MAX_CONCURRENT_RUNS,
         excludeAgents: undefined,
+        includeGroupChats: true,
       },
     sessionMemory:
       typeof cfg.sessionMemory === "object" && cfg.sessionMemory !== null

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1506,6 +1506,11 @@
               "type": "string"
             },
             "description": "Agent/session patterns excluded from reflection injection. Supports exact match, wildcard prefix (e.g. pi-), and temp:*."
+          },
+          "includeGroupChats": {
+            "type": "boolean",
+            "default": true,
+            "description": "Run the reflection distiller for group-chat sessions (session keys carrying a :group: or :channel: segment). Default true; set false to skip reflection generation on group channels."
           }
         }
       },
@@ -2260,6 +2265,11 @@
     "memoryReflection.maxConcurrentRuns": {
       "label": "Reflection Max Concurrent Runs",
       "help": "Max concurrent reflection runs across all agents (reflections queue in per-agent lanes). Default 1 keeps reflections serialized; raise to allow parallel reflections.",
+      "advanced": true
+    },
+    "memoryReflection.includeGroupChats": {
+      "label": "Reflect Group Chats",
+      "help": "Run the reflection distiller for group-chat sessions (:group:/:channel: session keys). Default true; set false to skip reflection generation on group channels.",
       "advanced": true
     },
     "memoryReflection.messageCount": {

--- a/test/command-reflection-guard.test.mjs
+++ b/test/command-reflection-guard.test.mjs
@@ -365,3 +365,137 @@ describe("Unattributable sessionKey — no main masquerade, no mirroring", () =>
     );
   });
 });
+
+describe("Group-chat reflection toggle (memoryReflection.includeGroupChats)", () => {
+  let workDir;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(path.join(tmpdir(), "cmd-reflect-group-"));
+    resetRegistration();
+  });
+
+  afterEach(() => {
+    resetRegistration();
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function setupHarness(includeGroupChats) {
+    const pluginConfig = makePluginConfig(workDir);
+    if (includeGroupChats !== undefined) {
+      pluginConfig.memoryReflection.includeGroupChats = includeGroupChats;
+    }
+    const harness = createPluginApiHarness({ resolveRoot: workDir, pluginConfig });
+    memoryLanceDBProPlugin.register(harness.api);
+    return harness;
+  }
+
+  async function fireCommandNew(harness, sessionKey) {
+    const hooks = harness.eventHandlers.get("command:new") || [];
+    assert.ok(hooks.length > 0, "expected a command:new hook");
+    const event = {
+      sessionKey,
+      action: "command:new",
+      context: {
+        cfg: harness.api.pluginConfig,
+        sessionEntry: { sessionId: "test-session", sessionFile: undefined },
+      },
+    };
+    Object.defineProperty(event.context, "agentId", {
+      value: "main",
+      writable: true,
+      enumerable: true,
+    });
+    for (const hook of hooks) {
+      await hook.handler(event, { sessionKey, agentId: "main" });
+    }
+  }
+
+  async function invokeWithConfig(sessionKey, includeGroupChats) {
+    const harness = setupHarness(includeGroupChats);
+    await fireCommandNew(harness, sessionKey);
+    return harness.logs;
+  }
+
+  // The generation pipeline logs "hook start" only after every skip gate has
+  // passed -- its presence/absence is the downstream signal that reflection
+  // work actually began (or provably never did).
+  const startedGeneration = (logs) => logs.some(([, msg]) => msg.includes("command:command:new hook start") || msg.includes("command:new hook start"));
+  const loggedToggleSkip = (logs) => logs.some(([, msg]) => msg.includes("group-chat reflection disabled"));
+
+  it("skips reflection generation for a :group: session when disabled", async () => {
+    const logs = await invokeWithConfig("agent:main:slack:group:g0example1", false);
+    assert.ok(loggedToggleSkip(logs), "the hook must log the group-chat toggle skip");
+    assert.ok(!startedGeneration(logs), "no generation work may start for a disabled group session");
+  });
+
+  it("skips reflection generation for a :channel: session when disabled", async () => {
+    const logs = await invokeWithConfig("agent:main:slack:channel:c0example2", false);
+    assert.ok(loggedToggleSkip(logs), "the hook must log the group-chat toggle skip for channel keys");
+    assert.ok(!startedGeneration(logs), "no generation work may start for a disabled channel session");
+  });
+
+  it("skips a room-kind session when disabled (docs list ...:room:<id> forms)", async () => {
+    const logs = await invokeWithConfig("agent:main:matrix:room:!r0example3:homeserver.example", false);
+    assert.ok(loggedToggleSkip(logs), "room keys are multi-party and must honor the toggle");
+    assert.ok(!startedGeneration(logs), "no generation work may start for a disabled room session");
+  });
+
+  it("skips a thread under a channel when disabled (thread suffix stripped)", async () => {
+    const logs = await invokeWithConfig("agent:main:slack:channel:c0example4:thread:171200:9", false);
+    assert.ok(loggedToggleSkip(logs), "a thread within a channel is that channel's context");
+    assert.ok(!startedGeneration(logs), "no generation work may start for a disabled channel thread");
+  });
+
+  it("still reflects non-group sessions when the toggle is disabled", async () => {
+    const logs = await invokeWithConfig("agent:main:main", false);
+    assert.ok(!loggedToggleSkip(logs), "a non-group session must not trip the group-chat toggle");
+    assert.ok(startedGeneration(logs), "the generation pipeline must actually start for an allowed session");
+  });
+
+  it("never misreads an opaque direct-route peer id as a group marker", async () => {
+    // Structural kind position is "direct"; the ":channel:" segment belongs
+    // to the opaque peer id tail (core's parseSessionDeliveryRoute contract).
+    const logs = await invokeWithConfig("agent:main:discord:direct:user:channel:1", false);
+    assert.ok(!loggedToggleSkip(logs), "a direct route must never be suppressed by the group toggle");
+    assert.ok(startedGeneration(logs), "the generation pipeline must actually start for a direct session");
+  });
+
+  it("keeps group-chat reflection enabled by default", async () => {
+    const logs = await invokeWithConfig("agent:main:slack:group:g0example5", undefined);
+    assert.ok(!loggedToggleSkip(logs), "the default (toggle absent) must not skip group sessions");
+    assert.ok(startedGeneration(logs), "the generation pipeline must actually start under the default");
+  });
+
+  it("clears pre-boundary tool-error state when a boundary command skips a disabled group session", async () => {
+    const sessionKey = "agent:main:slack:group:g0example6";
+    const harness = setupHarness(false);
+
+    const toolHooks = harness.eventHandlers.get("after_tool_call") || [];
+    assert.ok(toolHooks.length > 0, "expected an after_tool_call hook");
+    for (const hook of toolHooks) {
+      await hook.handler(
+        { toolName: "probe-tool", error: "synthetic failure: fixture probe for boundary cleanup" },
+        { sessionKey, agentId: "main" },
+      );
+    }
+
+    await fireCommandNew(harness, sessionKey);
+
+    const promptHooks = harness.eventHandlers.get("before_prompt_build") || [];
+    assert.ok(promptHooks.length > 0, "expected before_prompt_build hooks");
+    const injected = [];
+    for (const hook of promptHooks) {
+      try {
+        const out = await hook.handler({}, { sessionKey, agentId: "main" });
+        if (out && typeof out.prependContext === "string") injected.push(out.prependContext);
+      } catch {
+        // Handlers needing richer fixtures may bail; only the injection
+        // content matters here.
+      }
+    }
+    assert.ok(
+      !injected.join("\n").includes("<error-detected>"),
+      "a pre-boundary tool error must not leak an error reminder across a skipped boundary",
+    );
+  });
+});


### PR DESCRIPTION
## What

New knob `memoryReflection.includeGroupChats` (boolean, default `true`, so existing configs are a no-op). When set to `false`, the command:new / command:reset reflection hook skips reflection GENERATION for group-chat sessions, meaning session keys carrying a `:group:` or `:channel:` segment, and logs an info line naming the skip. Direct/DM/main sessions are unaffected either way.

## Why

The reflection distiller's transcript input renders every non-self participant as a plain user turn, so on multi-agent group channels the distilled lessons and rules misattribute peer agents' messages (and can ingest a parallel session's status lines that ride the shared channel window). Observed live on a multi-agent fleet: a group-channel reset distilled peer-agent coaching and cross-session chatter into the standing rule set.

A structural fix for the distiller input (speaker-tagged transcript, matching the extraction pipeline's format) is the durable direction, but until that lands operators running multi-agent group channels need a supported way to keep reflections scoped to direct sessions. This knob gives them that choice without losing reflections wholesale.

## Implementation

- Config surface: `memoryReflection.includeGroupChats` added to the config type, to BOTH arms of the `parsePluginConfig` memoryReflection rebuild (normalized to boolean, default `true`), and to the manifest schema (nested property plus the config-docs entry).
- `isGroupChatSessionKey(sessionKey)`: single bounded regex (`/:(group|channel):/i`), no unbounded quantifiers.
- Gate sits in the shared command-hook body directly after the existing `excludeAgents` guard, before any session-file recovery work, and returns early with an info log:
  `memory-reflection: command:<action> skipped (group-chat reflection disabled, sessionKey=...)`.

## Tests

Four cells added to `test/command-reflection-guard.test.mjs` (the existing full-register harness):

- skips reflection generation for a `:group:` session when disabled (red-proofed: fails without the gate)
- skips reflection generation for a `:channel:` session when disabled (red-proofed)
- still reflects non-group sessions when the toggle is disabled (pin)
- keeps group-chat reflection enabled by default (pin)

Full suite green, typecheck clean, dist rebuilt and committed, CI test manifest untouched (no new test files).
