### PR TITLE
fix(reflection): keep caller-requested aborts out of the transient retry class

### DIFF
--- a/dist/src/reflection-retry.js
+++ b/dist/src/reflection-retry.js
@@ -8,6 +8,7 @@ const REFLECTION_TRANSIENT_PATTERNS = [
     /socket hang up/i,
     /socket (?:closed|disconnected)/i,
     /connection (?:closed|aborted|dropped)/i,
+    /\bconnection error\b/i,
     /early close/i,
     /stream (?:ended|closed) unexpectedly/i,
     /temporar(?:y|ily).*unavailable/i,
@@ -86,6 +87,9 @@ export function classifyReflectionRetry(input) {
     if (!input.inReflectionScope) {
         return { retryable: false, reason: "not_reflection_scope", normalizedError };
     }
+    if (input.callerAborted) {
+        return { retryable: false, reason: "caller_aborted", normalizedError };
+    }
     if (input.retryCount > 0) {
         return { retryable: false, reason: "retry_already_used", normalizedError };
     }
@@ -115,6 +119,7 @@ export async function runWithReflectionTransientRetryOnce(params) {
             retryCount: params.retryState.count,
             usefulOutputChars: 0,
             error,
+            callerAborted: params.signal?.aborted === true,
         });
         if (!decision.retryable)
             throw error;
@@ -123,6 +128,10 @@ export async function runWithReflectionTransientRetryOnce(params) {
         params.onLog?.("warn", `memory-${params.scope}: transient upstream failure detected (${params.runner}); ` +
             `retrying once in ${delayMs}ms (${decision.reason}). error=${decision.normalizedError}`);
         await (params.sleep ?? DEFAULT_SLEEP)(delayMs);
+        if (params.signal?.aborted) {
+            params.onLog?.("warn", `memory-${params.scope}: caller aborted during retry backoff (${params.runner}); not retrying`);
+            throw error;
+        }
         try {
             const result = await params.execute();
             params.onLog?.("info", `memory-${params.scope}: retry succeeded (${params.runner})`);
@@ -142,14 +151,17 @@ export async function runWithReflectionTransientRetryOnce(params) {
  * slices failed the whole hook after the reflection md was already written,
  * losing the cycle's rows. Each embed call carries its own single-retry
  * budget, so one healed abort does not spend the budget of later rows.
+ * A caller-provided abort signal suppresses the retry entirely: cancellation
+ * the caller requested is not a transient failure, whatever the error text.
  */
-export async function embedWithReflectionTransientRetry(embed, text, runner, onLog, sleep) {
+export async function embedWithReflectionTransientRetry(embed, text, runner, onLog, sleep, signal) {
     return runWithReflectionTransientRetryOnce({
         scope: "reflection",
         runner,
         retryState: { count: 0 },
         onLog,
         sleep,
+        signal,
         execute: () => embed(text),
     });
 }

--- a/src/reflection-retry.ts
+++ b/src/reflection-retry.ts
@@ -3,12 +3,14 @@ type RetryClassifierInput = {
   retryCount: number;
   usefulOutputChars: number;
   error: unknown;
+  callerAborted?: boolean;
 };
 
 type RetryClassifierResult = {
   retryable: boolean;
   reason:
   | "not_reflection_scope"
+  | "caller_aborted"
   | "retry_already_used"
   | "useful_output_present"
   | "non_retry_error"
@@ -27,6 +29,10 @@ type RetryRunnerParams<T> = {
   onLog?: (level: "info" | "warn", message: string) => void;
   random?: () => number;
   sleep?: (ms: number) => Promise<void>;
+  // Caller-side cancellation (an AbortSignal works structurally). An abort the
+  // CALLER requested must never be retried, even when the surfaced error text
+  // matches the transient request-abort patterns below.
+  signal?: { aborted: boolean };
 };
 
 const REFLECTION_TRANSIENT_PATTERNS: RegExp[] = [
@@ -39,6 +45,7 @@ const REFLECTION_TRANSIENT_PATTERNS: RegExp[] = [
   /socket hang up/i,
   /socket (?:closed|disconnected)/i,
   /connection (?:closed|aborted|dropped)/i,
+  /\bconnection error\b/i,
   /early close/i,
   /stream (?:ended|closed) unexpectedly/i,
   /temporar(?:y|ily).*unavailable/i,
@@ -122,6 +129,9 @@ export function classifyReflectionRetry(input: RetryClassifierInput): RetryClass
   if (!input.inReflectionScope) {
     return { retryable: false, reason: "not_reflection_scope", normalizedError };
   }
+  if (input.callerAborted) {
+    return { retryable: false, reason: "caller_aborted", normalizedError };
+  }
   if (input.retryCount > 0) {
     return { retryable: false, reason: "retry_already_used", normalizedError };
   }
@@ -154,6 +164,7 @@ export async function runWithReflectionTransientRetryOnce<T>(
       retryCount: params.retryState.count,
       usefulOutputChars: 0,
       error,
+      callerAborted: params.signal?.aborted === true,
     });
     if (!decision.retryable) throw error;
 
@@ -165,6 +176,13 @@ export async function runWithReflectionTransientRetryOnce<T>(
       `retrying once in ${delayMs}ms (${decision.reason}). error=${decision.normalizedError}`
     );
     await (params.sleep ?? DEFAULT_SLEEP)(delayMs);
+    if (params.signal?.aborted) {
+      params.onLog?.(
+        "warn",
+        `memory-${params.scope}: caller aborted during retry backoff (${params.runner}); not retrying`
+      );
+      throw error;
+    }
 
     try {
       const result = await params.execute();
@@ -188,6 +206,8 @@ export async function runWithReflectionTransientRetryOnce<T>(
  * slices failed the whole hook after the reflection md was already written,
  * losing the cycle's rows. Each embed call carries its own single-retry
  * budget, so one healed abort does not spend the budget of later rows.
+ * A caller-provided abort signal suppresses the retry entirely: cancellation
+ * the caller requested is not a transient failure, whatever the error text.
  */
 export async function embedWithReflectionTransientRetry(
   embed: (text: string) => Promise<number[]>,
@@ -195,6 +215,7 @@ export async function embedWithReflectionTransientRetry(
   runner: string,
   onLog?: (level: "info" | "warn", message: string) => void,
   sleep?: (ms: number) => Promise<void>,
+  signal?: { aborted: boolean },
 ): Promise<number[]> {
   return runWithReflectionTransientRetryOnce({
     scope: "reflection",
@@ -202,6 +223,7 @@ export async function embedWithReflectionTransientRetry(
     retryState: { count: 0 },
     onLog,
     sleep,
+    signal,
     execute: () => embed(text),
   });
 }

--- a/test/reflection-embed-transient-retry.test.mjs
+++ b/test/reflection-embed-transient-retry.test.mjs
@@ -111,3 +111,288 @@ describe("embedWithReflectionTransientRetry", () => {
     assert.equal(secondCalls, 2);
   });
 });
+
+const { classifyReflectionRetry } = jiti("../src/reflection-retry.ts");
+
+describe("caller-abort awareness", () => {
+  it("classifies a caller-aborted failure as non-retryable even when the message looks transient", () => {
+    const decision = classifyReflectionRetry({
+      inReflectionScope: true,
+      retryCount: 0,
+      usefulOutputChars: 0,
+      error: ABORT_ERROR,
+      callerAborted: true,
+    });
+    assert.equal(decision.retryable, false);
+    assert.equal(decision.reason, "caller_aborted");
+  });
+
+  it("does not retry when the caller's signal is already aborted", async () => {
+    let calls = 0;
+    const embed = async () => {
+      calls += 1;
+      throw ABORT_ERROR;
+    };
+    await assert.rejects(
+      embedWithReflectionTransientRetry(embed, "text", "unit", undefined, instantSleep, { aborted: true }),
+      /Request was aborted/,
+    );
+    assert.equal(calls, 1, "a caller-requested abort must not spend the retry");
+  });
+
+  it("skips the second attempt when the caller aborts during the retry backoff", async () => {
+    let calls = 0;
+    const embed = async () => {
+      calls += 1;
+      throw ABORT_ERROR;
+    };
+    const signal = { aborted: false };
+    const abortDuringSleep = async () => {
+      signal.aborted = true;
+    };
+    await assert.rejects(
+      embedWithReflectionTransientRetry(embed, "text", "unit", undefined, abortDuringSleep, signal),
+      /Request was aborted/,
+    );
+    assert.equal(calls, 1, "an abort during the backoff must cancel the pending retry");
+  });
+
+  it("still retries a transient failure when the provided signal is not aborted", async () => {
+    let calls = 0;
+    const embed = async () => {
+      calls += 1;
+      if (calls === 1) throw ABORT_ERROR;
+      return [1, 2, 3, 4];
+    };
+    const result = await embedWithReflectionTransientRetry(
+      embed, "text", "unit", undefined, instantSleep, { aborted: false },
+    );
+    assert.deepEqual(result, [1, 2, 3, 4]);
+    assert.equal(calls, 2);
+  });
+});
+
+// ===== Caller-level integration coverage (mapped-row, slice, session-summary) =====
+// Each path runs against a real embedder pointed at a local mock server that
+// kills the socket on the FIRST request carrying a poisoned marker text. The
+// OpenAI client is constructed with maxRetries: 0, so the transport failure
+// surfaces to embedWithReflectionTransientRetry, which must heal it once.
+
+const { describe: describeIntegration } = await import("node:test");
+const { beforeEach, afterEach } = await import("node:test");
+const http = (await import("node:http")).default;
+const { mkdtempSync, rmSync, writeFileSync } = await import("node:fs");
+const { tmpdir } = await import("node:os");
+const path = (await import("node:path")).default;
+
+const pluginModule = jiti("../index.ts");
+const memoryLanceDBProPlugin = pluginModule.default || pluginModule;
+const resetRegistration = pluginModule.resetRegistration ?? (() => {});
+const { MemoryStore } = jiti("../src/store.ts");
+
+const EMBEDDING_DIMENSIONS = 4;
+const FIXED_VECTOR = [0.5, 0.5, 0.5, 0.5];
+
+function createPoisoningEmbeddingServer(markers) {
+  const spent = new Set();
+  const requestCounts = new Map(markers.map((m) => [m, 0]));
+  const server = http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    let inputs = [];
+    try {
+      const payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      inputs = Array.isArray(payload.input) ? payload.input : [payload.input];
+    } catch {
+      inputs = [];
+    }
+    const hitMarkers = markers.filter((m) => inputs.some((t) => typeof t === "string" && t.includes(m)));
+    for (const m of hitMarkers) requestCounts.set(m, (requestCounts.get(m) ?? 0) + 1);
+    const freshPoison = hitMarkers.find((m) => !spent.has(m));
+    if (freshPoison) {
+      spent.add(freshPoison);
+      req.socket.destroy();
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      object: "list",
+      data: inputs.map((_, index) => ({ object: "embedding", index, embedding: FIXED_VECTOR })),
+      model: "mock-embedding-model",
+      usage: { prompt_tokens: 0, total_tokens: 0 },
+    }));
+  });
+  return { server, requestCounts };
+}
+
+function createListedApiHarness({ pluginConfig, resolveRoot }) {
+  const eventHandlers = new Map();
+  const logs = [];
+  const api = {
+    pluginConfig,
+    resolvePath(target) {
+      if (typeof target !== "string") return target;
+      if (path.isAbsolute(target)) return target;
+      return path.join(resolveRoot, target);
+    },
+    logger: {
+      info(m) { logs.push(["info", String(m)]); },
+      warn(m) { logs.push(["warn", String(m)]); },
+      debug(m) { logs.push(["debug", String(m)]); },
+      error(m) { logs.push(["error", String(m)]); },
+    },
+    registerTool() {},
+    registerCli() {},
+    registerService() {},
+    on(eventName, handler, meta) {
+      const list = eventHandlers.get(eventName) || [];
+      list.push({ handler, meta });
+      eventHandlers.set(eventName, list);
+    },
+    registerHook(eventName, handler, opts) {
+      const list = eventHandlers.get(eventName) || [];
+      list.push({ handler, meta: opts });
+      eventHandlers.set(eventName, list);
+    },
+  };
+  return { api, eventHandlers, logs };
+}
+
+function retryWarnCount(logs) {
+  return logs.filter(([level, message]) =>
+    level === "warn" && /transient upstream failure detected .*retrying once/.test(message)).length;
+}
+
+describeIntegration("persistence paths heal one transient embed abort through the retry wrapper", () => {
+  let workDir;
+  let poison;
+  let baseURL;
+
+  beforeEach(async () => {
+    resetRegistration();
+    workDir = mkdtempSync(path.join(tmpdir(), "embed-retry-integration-"));
+  });
+  afterEach(async () => {
+    if (poison) await new Promise((resolve) => poison.server.close(resolve));
+    poison = null;
+    resetRegistration();
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  async function startServer(markers) {
+    poison = createPoisoningEmbeddingServer(markers);
+    await new Promise((resolve) => poison.server.listen(0, "127.0.0.1", resolve));
+    baseURL = `http://127.0.0.1:${poison.server.address().port}/v1`;
+  }
+
+  it("slice and mapped-row persistence complete after one transient abort each", async () => {
+    const SLICE_MARKER = "poisoned-derived-slice";
+    const MAPPED_MARKER = "poisoned-decision-row";
+    await startServer([SLICE_MARKER, MAPPED_MARKER]);
+
+    const pluginConfig = {
+      dbPath: path.join(workDir, "db"),
+      embedding: {
+        provider: "openai-compatible",
+        apiKey: "dummy",
+        model: "text-embedding-3-small",
+        baseURL,
+        dimensions: EMBEDDING_DIMENSIONS,
+      },
+      sessionStrategy: "memoryReflection",
+      memoryReflection: { timeoutMs: 5000 },
+      smartExtraction: false,
+      autoCapture: false,
+      autoRecall: false,
+      selfImprovement: { enabled: false, beforeResetNote: false, ensureLearningFiles: false },
+    };
+    const { api, eventHandlers, logs } = createListedApiHarness({ pluginConfig, resolveRoot: workDir });
+    api.runtime = {
+      agent: {
+        async runEmbeddedPiAgent() {
+          return { payloads: [{ text: [
+            "## Invariants",
+            "- Always run the persistence retry integration checks before merging changes.",
+            "## Derived",
+            `- Next run exercise the ${SLICE_MARKER} retry path for agent-one end to end.`,
+            "## Decisions (durable)",
+            `- Adopt the ${MAPPED_MARKER} persistence retry policy for agent-one going forward.`,
+          ].join("\n") }] };
+        },
+      },
+    };
+    memoryLanceDBProPlugin.register(api);
+
+    const sessionFile = path.join(workDir, "session.jsonl");
+    writeFileSync(sessionFile, [
+      JSON.stringify({ type: "message", message: { role: "user", content: "Please remember this retry integration scenario." } }),
+      JSON.stringify({ type: "message", message: { role: "assistant", content: "I will reflect on it." } }),
+    ].join("\n"), "utf-8");
+
+    const commandHooks = eventHandlers.get("command:new") || [];
+    const hook = commandHooks.find((h) => h.meta?.name === "memory-lancedb-pro.memory-reflection.command-new");
+    assert.ok(hook, "expected the command:new reflection hook");
+    await hook.handler({
+      sessionKey: "agent:agent-one:retry-integration",
+      timestamp: 1_800_000_000_000,
+      action: "tick",
+      context: { cfg: pluginConfig, workspaceDir: workDir,
+        sessionEntry: { sessionId: "retry-integration-session", sessionFile } },
+    }, { sessionKey: "agent:agent-one:retry-integration", agentId: "agent-one" });
+
+    assert.ok(retryWarnCount(logs) >= 2,
+      `expected at least two heal-retry warns (slice + mapped), saw ${retryWarnCount(logs)}: ${JSON.stringify(logs.filter(([l]) => l === "warn"))}`);
+    assert.ok((poison.requestCounts.get(SLICE_MARKER) ?? 0) >= 2, "poisoned slice text must be re-requested after the abort");
+    assert.ok((poison.requestCounts.get(MAPPED_MARKER) ?? 0) >= 2, "poisoned mapped text must be re-requested after the abort");
+
+    const rows = await new MemoryStore({ dbPath: pluginConfig.dbPath, vectorDim: EMBEDDING_DIMENSIONS })
+      .list(undefined, undefined, 100, 0);
+    assert.ok(rows.some((r) => r.text.includes(SLICE_MARKER)), "derived slice row must be stored despite the transient abort");
+    assert.ok(rows.some((r) => r.text.includes(MAPPED_MARKER)), "mapped decision row must be stored despite the transient abort");
+  });
+
+  it("session-summary persistence completes after one transient abort", async () => {
+    const SUMMARY_MARKER = "poisoned-session-summary";
+    await startServer([SUMMARY_MARKER]);
+
+    const pluginConfig = {
+      dbPath: path.join(workDir, "db-summary"),
+      embedding: {
+        provider: "openai-compatible",
+        apiKey: "dummy",
+        model: "text-embedding-3-small",
+        baseURL,
+        dimensions: EMBEDDING_DIMENSIONS,
+      },
+      sessionStrategy: "systemSessionMemory",
+      autoCapture: false,
+      autoRecall: false,
+    };
+    const { api, eventHandlers, logs } = createListedApiHarness({ pluginConfig, resolveRoot: workDir });
+    memoryLanceDBProPlugin.register(api);
+
+    const resetHooks = eventHandlers.get("before_reset") || [];
+    assert.ok(resetHooks.length > 0, "expected a before_reset hook");
+    await resetHooks[0].handler({
+      reason: "new",
+      messages: [
+        { role: "user", content: `Wrap up the ${SUMMARY_MARKER} scenario and store the summary.` },
+        { role: "assistant", content: "Summarizing and storing now." },
+      ],
+    }, {
+      agentId: "agent-one",
+      sessionKey: "agent:agent-one:webchat:summary-retry",
+      sessionId: "session-summary-retry",
+      workspaceDir: workDir,
+    });
+
+    assert.ok(retryWarnCount(logs) >= 1,
+      `expected a heal-retry warn for the summary embed, warns: ${JSON.stringify(logs.filter(([l]) => l === "warn"))}`);
+    assert.ok((poison.requestCounts.get(SUMMARY_MARKER) ?? 0) >= 2, "poisoned summary text must be re-requested after the abort");
+
+    const rows = await new MemoryStore({ dbPath: pluginConfig.dbPath, vectorDim: EMBEDDING_DIMENSIONS })
+      .list(undefined, undefined, 10, 0);
+    assert.equal(rows.length, 1, "the session summary must be stored despite the transient abort");
+    assert.match(rows[0].text, /Conversation Summary:/);
+  });
+});


### PR DESCRIPTION
## Problem

The transient-retry layer added in [#970](https://github.com/CortexReach/memory-lancedb-pro/pull/970) classifies request aborts by error message alone. Two consequences, one promised as a follow-up on that PR's approval and one found by the new coverage:

1. A cancellation the caller itself requested (an aborted signal) matches the transient patterns and earns a pointless retry after the caller has already given up. Intentional cancellation is not a transient failure, whatever the surfaced error text says.
2. The embedding client is constructed with `maxRetries: 0`, and it surfaces a killed connection as "Connection error.", which the transient patterns did not match. Persistence-path retries therefore never fired for the most common transient shape on the api-key path. The new caller-level integration tests exposed this immediately.

## Change

- `src/reflection-retry.ts`: the retry runner and `embedWithReflectionTransientRetry` accept an optional caller signal (an `AbortSignal` works structurally). An aborted signal classifies as the new `caller_aborted` reason and is never retried, and the signal is checked again after the backoff sleep so an abort arriving during the wait also cancels the pending second attempt. Existing call sites are unchanged and keep their behavior; the parameter gives deadline-owning callers a correct path. Also added `connection error` to the transient patterns.
- `test/reflection-embed-transient-retry.test.mjs`: four caller-abort unit cells, plus the caller-level integration coverage promised on [#970](https://github.com/CortexReach/memory-lancedb-pro/pull/970): the mapped-row, slice, and session-summary persistence paths each run against a real embedder client and a local mock server that kills the socket on the first request carrying a poisoned text, asserting the wrapper heals the failure once and the rows still land.

## Validation

- Red before, green after: with the source change reverted, 5 of 13 cells fail (the caller-abort cells and both integration cells); with it in place, 13 of 13 pass.
- `npm run build` clean, `tsc --noEmit` clean, full `npm test` chain green, `core-regression` CI group green, dist rebuilt in the same commit. No registration changes needed (the test file was already in the chain and manifest).
- Deployed to a live gateway: a real `/new` reflection cycle ran generation and every persistence embed through the changed module end to end with zero warnings or errors.
