### PR TITLE
fix(repair): confirm rollback absence before reporting unrecovered rows, and move the full-row dump off stderr

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -2285,12 +2285,42 @@ export function registerMemoryCLI(program: Command, context: CLIContext): void {
         const { repaired, failed, skipped, unrecovered } = await context.store.repairLegacyScopes(targetScope);
         console.log(`\nRepair complete: ${repaired} reassigned to "${targetScope}", ${skipped} skipped (changed or removed since discovery), ${failed} failed.`);
         if (unrecovered.length > 0) {
-          console.error(
-            `\n${unrecovered.length} row(s) could not be restored after a failed replacement write. ` +
-            "Full row content follows (JSON, one per line) so the data is not lost:",
-          );
-          for (const entry of unrecovered) {
-            console.error(JSON.stringify(entry));
+          // Full rows (text, metadata, vectors) go to a recovery file next to
+          // the db, not to stderr; stderr gets a bounded summary. The full
+          // stderr dump remains only as the fallback when the file cannot be
+          // written, so the data is never lost either way.
+          const dbPathForRecovery = typeof context.store.dbPath === "string" && context.store.dbPath.trim() !== ""
+            ? context.store.dbPath
+            : null;
+          let savedTo: string | null = null;
+          if (dbPathForRecovery) {
+            const recoveryPath = `${dbPathForRecovery.replace(/[\\/]+$/, "")}-unrecovered-${Date.now()}.json`;
+            try {
+              await writeFile(recoveryPath, JSON.stringify(unrecovered, null, 2), "utf8");
+              savedTo = recoveryPath;
+            } catch {
+              savedTo = null;
+            }
+          }
+          if (savedTo) {
+            console.error(
+              `\n${unrecovered.length} row(s) could not be restored after a failed replacement write. ` +
+              `Full row content saved to ${savedTo}; summary:`,
+            );
+            for (const entry of unrecovered.slice(0, 20)) {
+              console.error(`  ${String(entry.id).slice(0, 8)}  scope=${entry.scope ?? "NULL"}  ${String(entry.text).replace(/\s+/g, " ").slice(0, 60)}`);
+            }
+            if (unrecovered.length > 20) {
+              console.error(`  ... and ${unrecovered.length - 20} more (all in the recovery file)`);
+            }
+          } else {
+            console.error(
+              `\n${unrecovered.length} row(s) could not be restored after a failed replacement write, ` +
+              "and the recovery file could not be written. Full row content follows (JSON, one per line) so the data is not lost:",
+            );
+            for (const entry of unrecovered) {
+              console.error(JSON.stringify(entry));
+            }
           }
         }
         if (failed > 0 || unrecovered.length > 0) {

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -1910,10 +1910,40 @@ export function registerMemoryCLI(program, context) {
             const { repaired, failed, skipped, unrecovered } = await context.store.repairLegacyScopes(targetScope);
             console.log(`\nRepair complete: ${repaired} reassigned to "${targetScope}", ${skipped} skipped (changed or removed since discovery), ${failed} failed.`);
             if (unrecovered.length > 0) {
-                console.error(`\n${unrecovered.length} row(s) could not be restored after a failed replacement write. ` +
-                    "Full row content follows (JSON, one per line) so the data is not lost:");
-                for (const entry of unrecovered) {
-                    console.error(JSON.stringify(entry));
+                // Full rows (text, metadata, vectors) go to a recovery file next to
+                // the db, not to stderr; stderr gets a bounded summary. The full
+                // stderr dump remains only as the fallback when the file cannot be
+                // written, so the data is never lost either way.
+                const dbPathForRecovery = typeof context.store.dbPath === "string" && context.store.dbPath.trim() !== ""
+                    ? context.store.dbPath
+                    : null;
+                let savedTo = null;
+                if (dbPathForRecovery) {
+                    const recoveryPath = `${dbPathForRecovery.replace(/[\\/]+$/, "")}-unrecovered-${Date.now()}.json`;
+                    try {
+                        await writeFile(recoveryPath, JSON.stringify(unrecovered, null, 2), "utf8");
+                        savedTo = recoveryPath;
+                    }
+                    catch {
+                        savedTo = null;
+                    }
+                }
+                if (savedTo) {
+                    console.error(`\n${unrecovered.length} row(s) could not be restored after a failed replacement write. ` +
+                        `Full row content saved to ${savedTo}; summary:`);
+                    for (const entry of unrecovered.slice(0, 20)) {
+                        console.error(`  ${String(entry.id).slice(0, 8)}  scope=${entry.scope ?? "NULL"}  ${String(entry.text).replace(/\s+/g, " ").slice(0, 60)}`);
+                    }
+                    if (unrecovered.length > 20) {
+                        console.error(`  ... and ${unrecovered.length - 20} more (all in the recovery file)`);
+                    }
+                }
+                else {
+                    console.error(`\n${unrecovered.length} row(s) could not be restored after a failed replacement write, ` +
+                        "and the recovery file could not be written. Full row content follows (JSON, one per line) so the data is not lost:");
+                    for (const entry of unrecovered) {
+                        console.error(JSON.stringify(entry));
+                    }
                 }
             }
             if (failed > 0 || unrecovered.length > 0) {

--- a/dist/src/store.js
+++ b/dist/src/store.js
@@ -2567,10 +2567,24 @@ export class MemoryStore {
                                 await this.table.add([{ ...row }]);
                             }
                             catch {
-                                // Both the replacement and the rollback write failed after the
-                                // delete, so the row is no longer in the table. Surface its full
-                                // content to the caller instead of silently losing the data.
-                                unrecovered.push({ ...row });
+                                // The rollback write shares the replacement add's
+                                // commit-then-reject hazard: it can persist and still error.
+                                // Confirm absence before declaring the row lost; a failed
+                                // confirmation read stays fail-closed and still reports it.
+                                let rolledBack = false;
+                                try {
+                                    const rollbackRows = await this.table.query().where(`id = '${safeId}'`).limit(1).toArray();
+                                    rolledBack = rollbackRows.length > 0;
+                                }
+                                catch {
+                                    rolledBack = false;
+                                }
+                                if (!rolledBack) {
+                                    // Both writes genuinely failed after the delete, so the row
+                                    // is no longer in the table. Surface its full content to the
+                                    // caller instead of silently losing the data.
+                                    unrecovered.push({ ...row });
+                                }
                             }
                         }
                         throw addError;

--- a/src/store.ts
+++ b/src/store.ts
@@ -3063,10 +3063,23 @@ export class MemoryStore {
               try {
                 await this.table!.add([{ ...row }]);
               } catch {
-                // Both the replacement and the rollback write failed after the
-                // delete, so the row is no longer in the table. Surface its full
-                // content to the caller instead of silently losing the data.
-                unrecovered.push({ ...row });
+                // The rollback write shares the replacement add's
+                // commit-then-reject hazard: it can persist and still error.
+                // Confirm absence before declaring the row lost; a failed
+                // confirmation read stays fail-closed and still reports it.
+                let rolledBack = false;
+                try {
+                  const rollbackRows = await this.table!.query().where(`id = '${safeId}'`).limit(1).toArray();
+                  rolledBack = rollbackRows.length > 0;
+                } catch {
+                  rolledBack = false;
+                }
+                if (!rolledBack) {
+                  // Both writes genuinely failed after the delete, so the row
+                  // is no longer in the table. Surface its full content to the
+                  // caller instead of silently losing the data.
+                  unrecovered.push({ ...row });
+                }
               }
             }
             throw addError;

--- a/test/scope-owner-leak-hardening.test.mjs
+++ b/test/scope-owner-leak-hardening.test.mjs
@@ -1145,3 +1145,142 @@ describe("(i) repair-scopes command wiring", () => {
     assert.notEqual(result.exitCode, 1, "global is always a defined destination");
   });
 });
+
+describe("(j) repair-scopes unrecovered reporting follow-ups", () => {
+  function buildRecoveryCliProgram(storeStubs) {
+    const { createMemoryCLI } = jiti("../cli.ts");
+    const { createScopeManager } = jiti("../src/scopes.ts");
+    const program = new Command();
+    program.exitOverride();
+    createMemoryCLI({ store: storeStubs, retriever: {}, scopeManager: createScopeManager(), migrator: {} })({ program });
+    return program;
+  }
+
+  async function runRepairScopes(storeStubs, extraArgs = []) {
+    const program = buildRecoveryCliProgram(storeStubs);
+    const logs = [];
+    const errors = [];
+    const originalLog = console.log;
+    const originalError = console.error;
+    const priorExitCode = process.exitCode;
+    console.log = (...parts) => logs.push(parts.join(" "));
+    console.error = (...parts) => errors.push(parts.join(" "));
+    let exitCode;
+    try {
+      await program.parseAsync(["node", "cli", "memory-pro", "repair-scopes", ...extraArgs]);
+    } finally {
+      exitCode = process.exitCode;
+      process.exitCode = priorExitCode;
+      console.log = originalLog;
+      console.error = originalError;
+    }
+    return { logs: logs.join("\n"), errors: errors.join("\n"), exitCode };
+  }
+
+  it("a rollback write that persists but still errors is not reported unrecovered", async () => {
+    const { store, dir } = makeStore();
+    try {
+      await seedLegacyRow(store, {
+        id: "55555555-5555-4555-8555-555555555555",
+        text: "legacy row whose rollback commits and still errors",
+        vector: [0.1, 0.2, 0.3],
+        category: "fact",
+        scope: null,
+      });
+
+      const originalAdd = store.table.add.bind(store.table);
+      let call = 0;
+      store.table.add = async (rows) => {
+        call += 1;
+        if (call === 1) {
+          // Replacement write: fail without landing anything.
+          throw new Error("synthetic replacement add failure");
+        }
+        // Rollback write: commit-then-reject — persist the rows, then error.
+        await originalAdd(rows);
+        throw new Error("synthetic rollback commit-then-reject");
+      };
+
+      const result = await store.repairLegacyScopes("global");
+      assert.equal(result.repaired, 0);
+      assert.equal(result.failed, 1, "the repair itself still counts as failed");
+      assert.equal(
+        result.unrecovered.length,
+        0,
+        "a rollback that actually persisted must not be reported as unrecovered",
+      );
+
+      const legacy = await store.findLegacyScopeRows();
+      assert.ok(
+        legacy.some((row) => row.id === "55555555-5555-4555-8555-555555555555"),
+        "the rolled-back row must still exist as a legacy NULL-scope row",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes unrecovered rows to a recovery file and keeps full row content off stderr", async () => {
+    const { mkdtempSync, readFileSync, existsSync, readdirSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const workDir = mkdtempSync(join(tmpdir(), "repair-recovery-"));
+    try {
+      const dbPath = join(workDir, "db");
+      const lostRow = {
+        id: "66666666-6666-4666-8666-666666666666",
+        text: "sensitive memory text that must stay out of shared logs",
+        vector: [0.11, 0.22, 0.33, 0.44],
+        category: "fact",
+        scope: "global",
+        metadata: JSON.stringify({ agentId: "agent-one" }),
+      };
+      const { errors, exitCode } = await runRepairScopes({
+        dbPath,
+        async findLegacyScopeRows() { return [{ id: lostRow.id, text: lostRow.text }]; },
+        async repairLegacyScopes() { return { repaired: 0, failed: 1, skipped: 0, unrecovered: [lostRow] }; },
+      }, ["--apply"]);
+
+      assert.equal(exitCode, 1);
+      assert.match(errors, /Full row content saved to /);
+      assert.match(errors, /66666666\s+scope=global\s+sensitive memory text/);
+      assert.ok(!errors.includes('"vector"'), "stderr must not carry the raw JSON row dump when the recovery file was written");
+
+      const recoveryFile = readdirSync(workDir).find((name) => name.startsWith("db-unrecovered-") && name.endsWith(".json"));
+      assert.ok(recoveryFile, `expected a recovery file next to the db path, saw: ${readdirSync(workDir).join(", ")}`);
+      assert.ok(existsSync(join(workDir, recoveryFile)));
+      const saved = JSON.parse(readFileSync(join(workDir, recoveryFile), "utf8"));
+      assert.equal(saved.length, 1);
+      assert.deepEqual(saved[0], lostRow, "the recovery file must preserve the complete row, vector included");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the full stderr dump when the recovery file cannot be written", async () => {
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const workDir = mkdtempSync(join(tmpdir(), "repair-recovery-fallback-"));
+    try {
+      const dbPath = join(workDir, "missing-parent", "nested", "db");
+      const lostRow = {
+        id: "77777777-7777-4777-8777-777777777777",
+        text: "row preserved via the stderr fallback",
+        vector: [0.5, 0.6],
+        category: "fact",
+        scope: "global",
+        metadata: "{}",
+      };
+      const { errors, exitCode } = await runRepairScopes({
+        dbPath,
+        async findLegacyScopeRows() { return [{ id: lostRow.id, text: lostRow.text }]; },
+        async repairLegacyScopes() { return { repaired: 0, failed: 1, skipped: 0, unrecovered: [lostRow] }; },
+      }, ["--apply"]);
+
+      assert.equal(exitCode, 1);
+      assert.match(errors, /recovery file could not be written/);
+      assert.ok(errors.includes(JSON.stringify(lostRow)), "the fallback must dump the complete row so the data is not lost");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Two follow-ups the reviewer named explicitly on [#923](https://github.com/CortexReach/memory-lancedb-pro/pull/923) round 4 ("the rollback commit-then-reject false `unrecovered` report and full-row stderr output are useful follow-ups, but they are not the blocker"):

1. The repair rollback write shares the replacement add's commit-then-reject hazard, which the replacement path already documents and handles: the write can persist and still surface an error. `repairLegacyScopes` treated any rollback error as data loss and pushed the row into `unrecovered`, falsely reporting a row that was actually restored to the table.
2. The `repair-scopes` CLI dumped every unrecovered row as full JSON (memory text, metadata, embedding vectors) to stderr, flooding terminals and shared logs with row content.

## Change

- `src/store.ts`: the rollback catch now re-reads the row by id and reports `unrecovered` only when the table confirms the row is truly absent. A failed confirmation read stays fail-closed and still reports, so genuine loss is never hidden.
- `cli.ts`: full unrecovered rows are written to a recovery file next to the db path (`<dbPath>-unrecovered-<timestamp>.json`), and stderr carries a bounded id/scope/preview summary plus the file path. When the recovery file cannot be written (or no db path is available), the original full stderr dump remains as the fallback, so the data-preservation guarantee is unchanged.
- `test/scope-owner-leak-hardening.test.mjs`, three new cells in the file that owns this subsystem: a rollback commit-then-reject regression (rollback persists then errors, must not be reported unrecovered, row must remain discoverable as legacy), the recovery-file path (full row with vector preserved in the file, no raw JSON on stderr), and the fallback path (unwritable recovery file keeps the complete stderr dump).

## Validation

- Red before, green after: with the source changes reverted the three new cells fail (49 pass, 3 fail); with them in place, 52 of 52 pass.
- `npm run build` clean, `tsc --noEmit` clean, full `npm test` chain green, `cli-smoke` CI group green (the CLI output change gate), `core-regression` group green, dist rebuilt in the same commit. No registration changes needed (the test file was already registered).
- Deployed to a live gateway: plugin initialized clean, and a real `memory-pro repair-scopes` report-only run executed the changed command against the live store without issues.
