### PR TITLE
fix(reflection): recognize MiniMax regional endpoint and align provider id

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1178,14 +1178,17 @@ function splitProviderModel(modelRef: string): { provider?: string; model?: stri
 
 /**
  * When modelRef is a bare name (no / prefix), infer provider from baseURL.
- * Use "." + suffix to prevent fake-minimax.io subdomain spoofing.
+ * Use "." + suffix to prevent host spoofing (e.g. fake-minimax.io). Both
+ * MiniMax regional endpoints (minimax.io / minimaxi.com) map to the same
+ * "minimax" provider id used by the explicit modelRef path (e.g.
+ * "minimax/MiniMax-M3"), so a bare model name resolves consistently.
  */
 export function inferProviderFromBaseURL(baseURL: string | undefined): string | undefined {
   if (!baseURL) return undefined;
   try {
     const url = new URL(baseURL);
     const hostname = url.hostname.toLowerCase();
-    if (hostname.endsWith(".minimax.io")) return "minimax-portal";
+    if (hostname.endsWith(".minimax.io") || hostname.endsWith(".minimaxi.com")) return "minimax";
     if (hostname.endsWith(".openai.com")) return "openai";
     if (hostname.endsWith(".anthropic.com")) return "anthropic";
     return undefined;

--- a/test/infer-provider-from-baseurl.test.mjs
+++ b/test/infer-provider-from-baseurl.test.mjs
@@ -19,9 +19,24 @@ const { inferProviderFromBaseURL } = indexModule;
 describe("inferProviderFromBaseURL - PR #713 regression", () => {
 
   describe("URL hostname inference", () => {
-    it("baseURL with minimax.io returns minimax-portal", () => {
+    it("baseURL with minimax.io returns minimax", () => {
       const result = inferProviderFromBaseURL("https://api.minimax.io/v1");
-      assert.strictEqual(result, "minimax-portal");
+      assert.strictEqual(result, "minimax");
+    });
+
+    it("baseURL with minimax.io anthropic endpoint returns minimax", () => {
+      const result = inferProviderFromBaseURL("https://api.minimax.io/anthropic");
+      assert.strictEqual(result, "minimax");
+    });
+
+    it("baseURL with minimaxi.com (regional endpoint) returns minimax", () => {
+      const result = inferProviderFromBaseURL("https://api.minimaxi.com/v1");
+      assert.strictEqual(result, "minimax");
+    });
+
+    it("baseURL with minimaxi.com anthropic endpoint returns minimax", () => {
+      const result = inferProviderFromBaseURL("https://api.minimaxi.com/anthropic");
+      assert.strictEqual(result, "minimax");
     });
 
     it("baseURL with openai.com returns openai", () => {
@@ -41,6 +56,11 @@ describe("inferProviderFromBaseURL - PR #713 regression", () => {
       assert.strictEqual(result, undefined);
     });
 
+    it("fake-minimaxi.com should NOT match (subdomain spoofing protection)", () => {
+      const result = inferProviderFromBaseURL("https://fake-minimaxi.com");
+      assert.strictEqual(result, undefined);
+    });
+
     it("null returns undefined", () => {
       assert.strictEqual(inferProviderFromBaseURL(null), undefined);
     });
@@ -57,7 +77,7 @@ describe("inferProviderFromBaseURL - PR #713 regression", () => {
   describe("URL path variations", () => {
     it("handles baseURL with deep path", () => {
       const result = inferProviderFromBaseURL("https://api.minimax.io/v1/chat/completions");
-      assert.strictEqual(result, "minimax-portal");
+      assert.strictEqual(result, "minimax");
     });
 
     it("handles baseURL without path", () => {


### PR DESCRIPTION
Reason: MiniMax reflection provider inference ignored the regional api.minimaxi.com endpoint and returned a provider id inconsistent with the explicit model-reference path, making bare-name configuration region-dependent.

## What changed
- `inferProviderFromBaseURL` now recognizes both MiniMax base URLs — `api.minimax.io` (global) and `api.minimaxi.com` (regional) — using the existing `"." + suffix` `endsWith` guard that blocks host spoofing (e.g. `fake-minimax.io`, `fake-minimaxi.com`).
- It now returns the `minimax` provider id, matching the id parsed from an explicit `minimax/<model>` reference in `splitProviderModel`, so a bare model name such as `MiniMax-M3` or `MiniMax-M2.7` resolves to the same provider regardless of the configured region.

## Why
The global host previously mapped to `minimax-portal` while the explicit model-reference path used `minimax`, and the regional host was not matched at all. Bare-name reflection configuration was therefore region-dependent and inconsistent between the two resolution branches (`split.provider ?? inferProviderFromBaseURL(...)`).

## Tests
- Extended `test/infer-provider-from-baseurl.test.mjs` with the updated provider id, both regional hosts (`/v1` and `/anthropic` base URLs), and `fake-minimaxi.com` spoofing protection.
- `node --test test/infer-provider-from-baseurl.test.mjs` — 13/13 pass.
- `npx tsc -p tsconfig.json --noEmit` — passes.
