### PR TITLE
fix: activate the canonical corpus indexer (agents.entries + startup sync)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6128,6 +6128,28 @@ const memoryLanceDBProPlugin = {
         // Fire-and-forget: allow gateway to start serving immediately.
         setTimeout(() => void runStartupChecks(), 0);
 
+        // Canonical corpus: nothing else invokes canonicalCorpusIndexer.sync().
+        // Its only call sites are inside the memory capability (search()/sync()),
+        // which the host reaches via getActiveMemorySearchManager — but agent
+        // searches resolve to this plugin's own memory_search/memory_get tools
+        // and bypass the capability, so with canonicalCorpus.enabled the index
+        // silently stayed empty. Kick one sync at service start; sync() checks
+        // canonicalCorpus.enabled itself, rate-limits via syncIntervalMs, and
+        // de-duplicates concurrent runs, so this is safe and cheap when current.
+        setTimeout(() => void (async () => {
+          try {
+            const corpusStats = await canonicalCorpusIndexer.sync({ reason: "startup" });
+            api.logger.info(
+              `memory-lancedb-pro: canonical corpus startup sync — indexed ${corpusStats.indexed}/${corpusStats.chunks} chunk(s) ` +
+              `from ${corpusStats.documents} document(s); ${corpusStats.staleDeleted} stale removed`,
+            );
+          } catch (err) {
+            api.logger.warn(
+              `memory-lancedb-pro: canonical corpus startup sync failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        })(), 0);
+
         // Check for legacy memories that could be upgraded
         setTimeout(async () => {
           try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,9 +86,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/@lancedb/lancedb-darwin-x64": {
-      "optional": true
-    },
     "node_modules/@lancedb/lancedb-linux-arm64-gnu": {
       "version": "0.26.2",
       "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.26.2.tgz",

--- a/src/corpus-indexer.ts
+++ b/src/corpus-indexer.ts
@@ -217,6 +217,18 @@ export function resolveCanonicalCorpusWorkspaces(cfg: unknown, homeDir = homedir
     add(entry.workspace ?? entry.workspaceDir ?? entry.cwd, entry.id);
   }
 
+  // OpenClaw stores agents as an object keyed by agent id under `agents.entries`
+  // (not an array under `agents.list`). Without this, the loop above matches
+  // nothing on current OpenClaw configs and the function silently falls back to
+  // the single default workspace, so per-agent workspaces are never indexed.
+  const entries = isRecord(agents?.entries) ? agents.entries : undefined;
+  if (entries) {
+    for (const [entryAgentId, entry] of Object.entries(entries)) {
+      if (!isRecord(entry)) continue;
+      add(entry.workspace ?? entry.workspaceDir ?? entry.cwd, entryAgentId);
+    }
+  }
+
   const defaults = isRecord(agents?.defaults) ? agents.defaults : undefined;
   add(defaults?.workspace ?? defaults?.workspaceDir ?? defaults?.cwd, "main");
 


### PR DESCRIPTION
Fixes #980.

Two independent faults left the canonical corpus permanently empty when `canonicalCorpus.enabled` was set — details and reproduction in the issue.

1. **`canonicalCorpusIndexer.sync()` was never invoked.** Its only call sites are inside the memory capability, which agent searches bypass because the plugin registers its own `memory_search`/`memory_get` tools. This adds a fire-and-forget sync at service start, mirroring the existing `runStartupChecks` pattern so gateway startup is never blocked. `sync()` already checks `enabled`, rate-limits via `syncIntervalMs`, and de-duplicates concurrent runs.
2. **`resolveCanonicalCorpusWorkspaces` read `agents.list`**, but OpenClaw stores agents keyed by id under `agents.entries` — the loop matched nothing and fell back to the single default workspace. Both shapes are now supported; `agents.list` handling is untouched.

Verified on a 6-agent install (OpenClaw 2026.7.2-beta.6): workspaces resolved went 1 → 6, and the startup sync indexed **2505/2505 chunks from 796 documents**.

Note: the startup log line intentionally omits the `unchanged` counter so this branch stands alone; #981's PR adds that counter. `tsc --noEmit` clean.