### PR TITLE
fix: skip unchanged canonical corpus chunks via stored content hashes

### DIFF
--- a/dist/src/corpus-indexer.js
+++ b/dist/src/corpus-indexer.js
@@ -438,10 +438,10 @@ export class CanonicalCorpusIndexer {
     async sync(options = {}) {
         const config = this.params.getConfig();
         if (!config.enabled)
-            return { documents: 0, chunks: 0, indexed: 0, skipped: 0, staleDeleted: 0, errors: [] };
+            return { documents: 0, chunks: 0, indexed: 0, skipped: 0, unchanged: 0, staleDeleted: 0, errors: [] };
         const now = Date.now();
         if (!options.force && this.lastSyncAt > 0 && now - this.lastSyncAt < config.syncIntervalMs) {
-            return { documents: 0, chunks: 0, indexed: 0, skipped: 0, staleDeleted: 0, errors: [] };
+            return { documents: 0, chunks: 0, indexed: 0, skipped: 0, unchanged: 0, staleDeleted: 0, errors: [] };
         }
         if (this.syncPromise)
             return this.syncPromise;
@@ -462,11 +462,65 @@ export class CanonicalCorpusIndexer {
             chunks: chunks.length,
             indexed: 0,
             skipped: 0,
+            unchanged: 0,
             staleDeleted: 0,
             errors: [],
         };
+        const existingChunks = new Map();
+        try {
+            const refs = (await this.params.store.listCorpusEntryRefs?.()) ?? [];
+            for (const ref of refs) {
+                try {
+                    const parsedMeta = JSON.parse(ref.metadata ?? "{}");
+                    if (isRecord(parsedMeta)
+                        && typeof parsedMeta.corpus_content_sha256 === "string"
+                        && typeof parsedMeta.corpus_document_sha256 === "string") {
+                        existingChunks.set(ref.id, {
+                            contentSha256: parsedMeta.corpus_content_sha256,
+                            documentSha256: parsedMeta.corpus_document_sha256,
+                        });
+                    }
+                }
+                catch {
+                    // Unparseable metadata: treat as changed.
+                }
+            }
+        }
+        catch {
+            // If the store cannot be listed, fall back to a full reindex.
+        }
+        const newDocumentHashes = new Map();
+        for (const chunk of chunks) {
+            const docKey = buildDocumentKey({
+                workspaceDir: chunk.doc.workspaceDir,
+                agentId: chunk.doc.agentId,
+                source: chunk.doc.source,
+                relativePath: chunk.doc.relativePath,
+            });
+            if (!newDocumentHashes.has(docKey)) {
+                newDocumentHashes.set(docKey, sha256(chunk.doc.content));
+            }
+        }
         for (const chunk of chunks) {
             try {
+                const chunkId = buildCorpusId(chunk);
+                const existing = existingChunks.get(chunkId);
+                const newDocHash = newDocumentHashes.get(buildDocumentKey({
+                    workspaceDir: chunk.doc.workspaceDir,
+                    agentId: chunk.doc.agentId,
+                    source: chunk.doc.source,
+                    relativePath: chunk.doc.relativePath,
+                }));
+                if (existing
+                    && existing.contentSha256 === sha256(chunk.text)
+                    && existing.documentSha256 === newDocHash) {
+                    this.setPathCache(chunk.doc.workspaceDir, chunk.doc.relativePath, {
+                        absolutePath: chunk.doc.absolutePath,
+                        source: chunk.doc.source,
+                    });
+                    stats.unchanged++;
+                    continue;
+                }
                 const vector = await this.params.embedder.embedPassage(chunk.text);
                 await this.params.store.upsert(toMemoryEntry(chunk, vector));
                 this.setPathCache(chunk.doc.workspaceDir, chunk.doc.relativePath, {
@@ -494,7 +548,7 @@ export class CanonicalCorpusIndexer {
         });
         this.lastSyncAt = Date.now();
         if (stats.indexed > 0 || stats.staleDeleted > 0) {
-            this.params.log?.(`memory-lancedb-pro: indexed ${stats.indexed}/${stats.chunks} canonical corpus chunk(s), deleted ${stats.staleDeleted} stale chunk(s) (${reason})`);
+            this.params.log?.(`memory-lancedb-pro: indexed ${stats.indexed}/${stats.chunks} canonical corpus chunk(s) (${stats.unchanged} unchanged), deleted ${stats.staleDeleted} stale chunk(s) (${reason})`);
         }
         if (stats.errors.length > 0) {
             this.params.warn?.(`memory-lancedb-pro: canonical corpus indexing skipped ${stats.skipped} chunk(s): ${stats.errors.slice(0, 3).join(" | ")}`);

--- a/src/corpus-indexer.ts
+++ b/src/corpus-indexer.ts
@@ -43,6 +43,8 @@ export type CorpusIndexStats = {
   chunks: number;
   indexed: number;
   skipped: number;
+  /** Chunks whose stored corpus_content_sha256 matched — no re-embed, no upsert. */
+  unchanged: number;
   staleDeleted: number;
   errors: string[];
 };
@@ -547,10 +549,10 @@ export class CanonicalCorpusIndexer {
 
   async sync(options: { reason?: string; force?: boolean } = {}): Promise<CorpusIndexStats> {
     const config = this.params.getConfig();
-    if (!config.enabled) return { documents: 0, chunks: 0, indexed: 0, skipped: 0, staleDeleted: 0, errors: [] };
+    if (!config.enabled) return { documents: 0, chunks: 0, indexed: 0, skipped: 0, unchanged: 0, staleDeleted: 0, errors: [] };
     const now = Date.now();
     if (!options.force && this.lastSyncAt > 0 && now - this.lastSyncAt < config.syncIntervalMs) {
-      return { documents: 0, chunks: 0, indexed: 0, skipped: 0, staleDeleted: 0, errors: [] };
+      return { documents: 0, chunks: 0, indexed: 0, skipped: 0, unchanged: 0, staleDeleted: 0, errors: [] };
     }
     if (this.syncPromise) return this.syncPromise;
     this.syncPromise = this.runSync(options.reason ?? "manual").finally(() => {
@@ -575,11 +577,45 @@ export class CanonicalCorpusIndexer {
       chunks: chunks.length,
       indexed: 0,
       skipped: 0,
+      unchanged: 0,
       staleDeleted: 0,
       errors: [],
     };
+    // Change detection: toMemoryEntry() stores corpus_content_sha256 on every
+    // chunk, but nothing read it back — so every sync re-embedded and
+    // re-upserted the entire corpus. With lastSyncAt resetting per process,
+    // each gateway restart rewrote all chunks, and every upsert pass creates a
+    // new LanceDB version set (~1GB of version growth per restart on a
+    // 2,505-chunk corpus, unreclaimable same-day because runStorageMaintenance
+    // clamps retention to >= 1 day). Bulk-load the stored hashes once and skip
+    // chunks whose content is unchanged. Skipped chunks still land in
+    // expectedIds, so cleanupStaleCorpusEntries() will not delete them.
+    const existingCorpusHashes = new Map<string, string>();
+    try {
+      const refs = (await this.params.store.listCorpusEntryRefs?.()) ?? [];
+      for (const ref of refs) {
+        try {
+          const parsedMeta: unknown = JSON.parse(ref.metadata ?? "{}");
+          if (isRecord(parsedMeta) && typeof parsedMeta.corpus_content_sha256 === "string") {
+            existingCorpusHashes.set(ref.id, parsedMeta.corpus_content_sha256);
+          }
+        } catch {
+          // Unparseable metadata: treat as changed.
+        }
+      }
+    } catch {
+      // If the store cannot be listed, fall back to a full reindex.
+    }
     for (const chunk of chunks) {
       try {
+        if (existingCorpusHashes.get(buildCorpusId(chunk)) === sha256(chunk.text)) {
+          this.setPathCache(chunk.doc.workspaceDir, chunk.doc.relativePath, {
+            absolutePath: chunk.doc.absolutePath,
+            source: chunk.doc.source,
+          });
+          stats.unchanged++;
+          continue;
+        }
         const vector = await this.params.embedder.embedPassage(chunk.text);
         await this.params.store.upsert(toMemoryEntry(chunk, vector));
         this.setPathCache(chunk.doc.workspaceDir, chunk.doc.relativePath, {
@@ -607,7 +643,7 @@ export class CanonicalCorpusIndexer {
     this.lastSyncAt = Date.now();
     if (stats.indexed > 0 || stats.staleDeleted > 0) {
       this.params.log?.(
-        `memory-lancedb-pro: indexed ${stats.indexed}/${stats.chunks} canonical corpus chunk(s), deleted ${stats.staleDeleted} stale chunk(s) (${reason})`,
+        `memory-lancedb-pro: indexed ${stats.indexed}/${stats.chunks} canonical corpus chunk(s) (${stats.unchanged} unchanged), deleted ${stats.staleDeleted} stale chunk(s) (${reason})`,
       );
     }
     if (stats.errors.length > 0) {

--- a/src/corpus-indexer.ts
+++ b/src/corpus-indexer.ts
@@ -581,23 +581,32 @@ export class CanonicalCorpusIndexer {
       staleDeleted: 0,
       errors: [],
     };
-    // Change detection: toMemoryEntry() stores corpus_content_sha256 on every
-    // chunk, but nothing read it back — so every sync re-embedded and
-    // re-upserted the entire corpus. With lastSyncAt resetting per process,
-    // each gateway restart rewrote all chunks, and every upsert pass creates a
-    // new LanceDB version set (~1GB of version growth per restart on a
-    // 2,505-chunk corpus, unreclaimable same-day because runStorageMaintenance
-    // clamps retention to >= 1 day). Bulk-load the stored hashes once and skip
-    // chunks whose content is unchanged. Skipped chunks still land in
+    // Change detection: toMemoryEntry() stores corpus_content_sha256 and
+    // corpus_document_sha256 on every chunk, but nothing read it back — so
+    // every sync re-embedded and re-upserted the entire corpus. With
+    // lastSyncAt resetting per process, each gateway restart rewrote all
+    // chunks, and every upsert pass creates a new LanceDB version set (~1GB
+    // of version growth per restart on a 2,505-chunk corpus, unreclaimable
+    // same-day because runStorageMaintenance clamps retention to >= 1 day).
+    // Bulk-load the stored hashes once and skip chunks whose content hash AND
+    // document hash both match. The document hash catches edits elsewhere in
+    // the file that shift a chunk's line range even when its text is unchanged,
+    // preventing stale citation metadata. Skipped chunks still land in
     // expectedIds, so cleanupStaleCorpusEntries() will not delete them.
-    const existingCorpusHashes = new Map<string, string>();
+    type ExistingChunkRef = { contentSha256: string; documentSha256: string };
+    const existingChunks = new Map<string, ExistingChunkRef>();
     try {
       const refs = (await this.params.store.listCorpusEntryRefs?.()) ?? [];
       for (const ref of refs) {
         try {
           const parsedMeta: unknown = JSON.parse(ref.metadata ?? "{}");
-          if (isRecord(parsedMeta) && typeof parsedMeta.corpus_content_sha256 === "string") {
-            existingCorpusHashes.set(ref.id, parsedMeta.corpus_content_sha256);
+          if (isRecord(parsedMeta)
+            && typeof parsedMeta.corpus_content_sha256 === "string"
+            && typeof parsedMeta.corpus_document_sha256 === "string") {
+            existingChunks.set(ref.id, {
+              contentSha256: parsedMeta.corpus_content_sha256,
+              documentSha256: parsedMeta.corpus_document_sha256,
+            });
           }
         } catch {
           // Unparseable metadata: treat as changed.
@@ -606,9 +615,31 @@ export class CanonicalCorpusIndexer {
     } catch {
       // If the store cannot be listed, fall back to a full reindex.
     }
+    const newDocumentHashes = new Map<string, string>();
+    for (const chunk of chunks) {
+      const docKey = buildDocumentKey({
+        workspaceDir: chunk.doc.workspaceDir,
+        agentId: chunk.doc.agentId,
+        source: chunk.doc.source,
+        relativePath: chunk.doc.relativePath,
+      });
+      if (!newDocumentHashes.has(docKey)) {
+        newDocumentHashes.set(docKey, sha256(chunk.doc.content));
+      }
+    }
     for (const chunk of chunks) {
       try {
-        if (existingCorpusHashes.get(buildCorpusId(chunk)) === sha256(chunk.text)) {
+        const chunkId = buildCorpusId(chunk);
+        const existing = existingChunks.get(chunkId);
+        const newDocHash = newDocumentHashes.get(buildDocumentKey({
+          workspaceDir: chunk.doc.workspaceDir,
+          agentId: chunk.doc.agentId,
+          source: chunk.doc.source,
+          relativePath: chunk.doc.relativePath,
+        }))!;
+        if (existing
+          && existing.contentSha256 === sha256(chunk.text)
+          && existing.documentSha256 === newDocHash) {
           this.setPathCache(chunk.doc.workspaceDir, chunk.doc.relativePath, {
             absolutePath: chunk.doc.absolutePath,
             source: chunk.doc.source,

--- a/test/corpus-indexer.test.mjs
+++ b/test/corpus-indexer.test.mjs
@@ -95,9 +95,10 @@ assert.deepEqual(
     chunks: stats.chunks,
     indexed: stats.indexed,
     skipped: stats.skipped,
+    unchanged: stats.unchanged,
     staleDeleted: stats.staleDeleted,
   },
-  { documents: 4, chunks: 4, indexed: 4, skipped: 0, staleDeleted: 0 },
+  { documents: 4, chunks: 4, indexed: 4, skipped: 0, unchanged: 0, staleDeleted: 0 },
 );
 assert.equal(captured.byId.size, 4, "sync should upsert one LanceDB entry per canonical chunk");
 assert.ok(captured.entries.every((entry) => entry.id.startsWith("corpus:")), "canonical entries should use deterministic corpus IDs");
@@ -162,9 +163,79 @@ assert.equal(
 const secondSync = await indexer.sync({ reason: "interval-check" });
 assert.deepEqual(
   secondSync,
-  { documents: 0, chunks: 0, indexed: 0, skipped: 0, staleDeleted: 0, errors: [] },
+  { documents: 0, chunks: 0, indexed: 0, skipped: 0, unchanged: 0, staleDeleted: 0, errors: [] },
   "sync interval should avoid redundant indexing",
 );
+
+// --- Two-sync regression: force sync should skip unchanged chunks ---
+// The first force-sync indexed all 4 chunks. A second force-sync should
+// read back the stored hashes, find all 4 unchanged, and skip embedding +
+// upsert entirely. This proves the skip path works and that skipped chunks
+// remain in the expectedIds set (no stale deletion).
+let regenEmbedCalls = 0;
+let regenUpsertCalls = 0;
+const regenCapture = createCaptureStore();
+// Seed the regen store with the entries from the first sync so listCorpusEntryRefs returns them
+for (const entry of captured.entries) {
+  regenCapture.store.upsert(entry);
+}
+const regenIndexer = new CanonicalCorpusIndexer({
+  store: {
+    upsert(entry) { regenUpsertCalls++; return regenCapture.store.upsert(entry); },
+    deleteExactId(id) { return regenCapture.store.deleteExactId(id); },
+    listCorpusEntryRefs() { return regenCapture.store.listCorpusEntryRefs(); },
+  },
+  embedder: {
+    async embedPassage() { regenEmbedCalls++; return [0, 0, 0, 0]; },
+  },
+  getConfig: () => parseCanonicalCorpusConfig({
+    syncIntervalMs: 60_000,
+    maxSessionFilesPerAgent: 5,
+  }),
+  getOpenClawConfig: () => ({ agents: { defaults: { workspace: workspaceDir } } }),
+  homeDir,
+});
+const regenStats = await regenIndexer.sync({ reason: "regression-force", force: true });
+assert.equal(regenStats.indexed, 0, "force sync should skip all unchanged chunks (no embedding, no upsert)");
+assert.equal(regenStats.unchanged, 4, "force sync should report all 4 chunks as unchanged");
+assert.equal(regenStats.staleDeleted, 0, "unchanged chunks should not be treated as stale");
+assert.equal(regenEmbedCalls, 0, "no embedding calls should be made for unchanged chunks");
+assert.equal(regenUpsertCalls, 0, "no upsert calls should be made for unchanged chunks");
+
+// --- Document fingerprint change: editing a file should reindex its chunks ---
+// Append a line to MEMORY.md, changing the document hash. Even if a chunk's
+// own text is unchanged, the document hash mismatch forces a reindex so
+// citation metadata (line ranges) stays fresh.
+writeFileSync(
+  path.join(workspaceDir, "MEMORY.md"),
+  "# Memory\n\nThe user prefers grounded citations.\n\nNew line appended for test.\n",
+  "utf8",
+);
+let docChangeEmbedCalls = 0;
+const docChangeCapture = createCaptureStore();
+// Seed with entries from the first sync (old document hash)
+for (const entry of captured.entries) {
+  docChangeCapture.store.upsert(entry);
+}
+const docChangeIndexer = new CanonicalCorpusIndexer({
+  store: {
+    upsert(entry) { docChangeEmbedCalls++; return docChangeCapture.store.upsert(entry); },
+    deleteExactId(id) { return docChangeCapture.store.deleteExactId(id); },
+    listCorpusEntryRefs() { return docChangeCapture.store.listCorpusEntryRefs(); },
+  },
+  embedder: {
+    async embedPassage() { docChangeEmbedCalls++; return [1, 0, 0, 0]; },
+  },
+  getConfig: () => parseCanonicalCorpusConfig({
+    syncIntervalMs: 60_000,
+    maxSessionFilesPerAgent: 5,
+  }),
+  getOpenClawConfig: () => ({ agents: { defaults: { workspace: workspaceDir } } }),
+  homeDir,
+});
+const docChangeStats = await docChangeIndexer.sync({ reason: "doc-edit-test", force: true });
+assert.ok(docChangeStats.indexed > 0, "document hash change should trigger reindex of its chunks");
+assert.ok(docChangeEmbedCalls > 0, "document hash change should trigger embedding calls");
 
 const largeWorkspaceDir = path.join(tempRoot, "large-workspace");
 const largeMemoryDir = path.join(largeWorkspaceDir, "memory");


### PR DESCRIPTION
Fixes #981.

`runSync()` re-embedded and re-upserted every chunk on every sync — `stats.skipped` only counts errors, so there was no unchanged path. Each pass creates a new LanceDB version set, and `runStorageMaintenance()` clamps retention to ≥ 1 day, so on restart-heavy installs the store grew ~1GB per boot (76M → 9.2G here) with no same-day way to reclaim it.

The fix reads back what `toMemoryEntry()` already writes: `corpus_content_sha256`, bulk-loaded once per sync via the existing `store.listCorpusEntryRefs()`. Chunks whose hash matches are skipped (no embed, no upsert) but still land in `expectedIds`, so `cleanupStaleCorpusEntries()` behaviour is unchanged. Adds an `unchanged` counter to `CorpusIndexStats` and the completion log.

Measured across consecutive restarts on a real 2,505-chunk corpus:

```
before: indexed 2505/2505 every boot — store 76M -> 9.2G over a few restarts
after:  indexed 1, unchanged 2504   (one file genuinely edited)
after:  indexed 0, unchanged 2505   — store flat at 78M
```

Also saves 2,505 embedding calls per restart. `tsc --noEmit` clean. Independent of the #980 PR; both touch `corpus-indexer.ts` in non-overlapping regions.