### PR TITLE
fix: apply fusion weighting uniformly and recalibrate the exact-keyword floor

### DIFF
--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -1347,20 +1347,25 @@ export class MemoryRetriever {
       // BM25 hit acts as a bonus (keyword match confirms relevance).
       const vectorScore = vectorResult ? vectorResult.score : 0;
       const bm25Score = bm25Result ? bm25Result.score : 0;
-      // Weighted fusion: vectorWeight/bm25Weight directly control score blending.
-      // BM25 high-score floor (>= 0.75) preserves exact keyword matches
-      // (e.g. API keys, ticket numbers) that may have low vector similarity.
+      // Weighted fusion: vectorWeight/bm25Weight directly control score blending,
+      // applied identically to every candidate. Previously the BM25-only branch
+      // used the normalised BM25 score directly, bypassing bm25Weight — so a
+      // keyword-only candidate kept its full sigmoid-normalised score (floor 0.5
+      // by construction) while a semantic-only candidate was capped at
+      // vectorWeight, and keyword noise systematically outranked strong semantic
+      // matches regardless of configured weights (#978).
+      //
+      // The exact-keyword floor preserves identifier-like matches (API keys,
+      // ticket numbers) above minScore even with weak vector similarity. Its
+      // threshold is calibrated to the sigmoid normalisation in
+      // store.bm25Search (1/(1+e^(-raw/5))): the old 0.75 threshold maps to a
+      // raw BM25 of ~5.5, which almost every FTS hit clears — making the floor
+      // re-create the bypass it was meant to bound. 0.95 maps to raw ~14.7,
+      // i.e. genuinely exceptional keyword matches.
       const weightedFusion = (vectorScore * this.config.vectorWeight)
                            + (bm25Score * this.config.bm25Weight);
-      const fusedScore = vectorResult
-        ? clamp01(
-          Math.max(
-            weightedFusion,
-            bm25Score >= 0.75 ? bm25Score * 0.92 : 0,
-          ),
-          0.1,
-        )
-        : clamp01(bm25Result!.score, 0.1);
+      const keywordFloor = bm25Score >= 0.95 ? bm25Score * 0.92 : 0;
+      const fusedScore = clamp01(Math.max(weightedFusion, keywordFloor), 0.1);
 
       fusedResults.push({
         entry: baseResult.entry,


### PR DESCRIPTION
Addresses the confirmed remainder of #978 (post-correction).

As the reporter's follow-up established, BM25 scores **are** sigmoid-normalised before fusion — but the structural asymmetry stands: the BM25-only branch used the normalised score directly, bypassing `bm25Weight`, so keyword-only candidates (sigmoid floor 0.5) outranked semantic candidates capped at `vectorWeight` no matter how the weights were configured.

Two changes:

1. **Uniform scoring** — every candidate gets `clamp01(max(v·vectorWeight + b·bm25Weight, keywordFloor), 0.1)`.
2. **Floor recalibration** — the exact-keyword floor's 0.75 threshold predates the sigmoid: `1/(1+e^(-raw/5))` reaches 0.75 at raw ≈ 5.5, which almost every FTS hit clears, so the floor (b·0.92 ≥ 0.69) quietly re-created the bypass on both branches. 0.95 corresponds to raw ≈ 14.7 — genuinely exceptional matches (identifiers, exact strings), preserving the floor's documented purpose of keeping those above `minScore`.

Observed effect on a 7,253-row store: queries with no relevant corpus content used to return unrelated keyword-only hits at floored confidence 0.85; they now score ~b·bm25Weight (≈0.28, below default `minScore`) and are suppressed, while on-topic queries are unaffected (verified before/after on the same store).

If you'd prefer the floor threshold configurable rather than a constant, happy to add a `retrieval.keywordFloorThreshold` option instead. An alternative worth considering longer-term is rank-based fusion (RRF) — which the comment above this code already names — as it sidesteps score-scale calibration entirely. `tsc --noEmit` clean.