### PR TITLE
fix: exempt canonical corpus chunks from length normalization and decay

### DIFF
--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -1634,7 +1634,11 @@ export class MemoryRetriever {
 
     const reranked = results.map((result, index) => ({
       ...result,
-      score: clamp01(scored[index].score, result.score * 0.3),
+      // Corpus rows carry the source file's mtime as their timestamp;
+      // reference material must not decay like conversation memory.
+      score: (result.entry.id ?? "").startsWith("corpus:")
+        ? result.score
+        : clamp01(scored[index].score, result.score * 0.3),
     }));
 
     return reranked.sort((a, b) => b.score - a.score);
@@ -1654,6 +1658,11 @@ export class MemoryRetriever {
     if (!anchor || anchor <= 0) return results;
 
     const normalized = results.map((r) => {
+      // Canonical corpus chunks are line-span document chunks: their length is
+      // a property of the chunker, not of entry quality. Normalising them by
+      // length double-penalises reference material (chunk size is already
+      // bounded by the indexer).
+      if ((r.entry.id ?? "").startsWith("corpus:")) return r;
       const charLen = r.entry.text.length;
       const ratio = charLen / anchor;
       // No penalty for entries at or below anchor length.
@@ -1688,6 +1697,8 @@ export class MemoryRetriever {
 
     const now = Date.now();
     const decayed = results.map((r) => {
+      // Reference chunks keep file mtimes — do not age them.
+      if ((r.entry.id ?? "").startsWith("corpus:")) return r;
       const ts =
         r.entry.timestamp && r.entry.timestamp > 0 ? r.entry.timestamp : now;
       const ageDays = (now - ts) / 86_400_000;


### PR DESCRIPTION
Fixes #985.

Corpus chunks are line-span document chunks whose length is set by the indexer, and whose timestamps are source-file mtimes — so conversation-memory length normalisation and decay compound to ~0.15 on a chunk that fused at 0.917, dropping the store's #1 match below `minScore`. Details and measurements in the issue.

The guard is `id.startsWith("corpus:")` (always true for `buildCorpusId` output), applied in `applyLengthNormalization`, `applyDecayBoost`, and `applyTimeDecay`. Conversation-memory scoring is untouched. `tsc --noEmit` clean; verified before/after on a live 2,505-chunk store.

Complements #982/#983 — with all three, a canonical-corpus-only store (no import-markdown copies) has working recall.